### PR TITLE
docs: fix duplicated word in README license note

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,4 +15,4 @@ For compiling, see [engine/README.md](engine/README.md).
 ## License
 The source code (engine directory) is licensed under the GPLv2 or later unless specified otherwise.
 
-The data files (baseq3r directory) do not have have a known license and should be treated as non-commericial / non-free.
+The data files (baseq3r directory) do not have a known license and should be treated as non-commericial / non-free.


### PR DESCRIPTION
## Summary
- fix doubled "have" in README data files license note

## Testing
- `make test` *(fails: No rule to make target 'test')*
- `make -C engine test` *(fails: No rule to make target 'test')*

------
https://chatgpt.com/codex/tasks/task_e_68ab0853e72483249428bd8796660c6b