### PR TITLE
fix session comment spelling

### DIFF
--- a/engine/code/game/g_session.c
+++ b/engine/code/game/g_session.c
@@ -29,7 +29,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 
   SESSION DATA
 
-Session data is the only data that stays persistant across level loads
+Session data is the only data that stays persistent across level loads
 and tournament restarts.
 =======================================================================
 */


### PR DESCRIPTION
## Summary
- correct spelling of session data comment to say persistent across level loads

## Testing
- `make -n` (dry-run build)


------
https://chatgpt.com/codex/tasks/task_e_68ab2edda8448324ba8a877aa7efcedb