### PR TITLE
Add tests for hazard friction calculation

### DIFF
--- a/engine/Makefile
+++ b/engine/Makefile
@@ -3343,6 +3343,9 @@ endif
 dist:
 	git archive --format zip --output $(CLIENTBIN)-$(VERSION).zip HEAD
 
+test:
+	$(MAKE) -C code/game/tests run
+
 #############################################################################
 # DEPENDENCIES
 #############################################################################
@@ -3359,10 +3362,10 @@ ifneq ($(B),)
 endif
 
 .PHONY: all clean clean2 clean-debug clean-release copyfiles \
-	debug default dist distclean installer makedirs \
-	release targets \
-	toolsclean toolsclean2 toolsclean-debug toolsclean-release \
-	$(OBJ_D_FILES) $(TOOLSOBJ_D_FILES)
+        debug default dist distclean installer makedirs \
+        release targets test \
+        toolsclean toolsclean2 toolsclean-debug toolsclean-release \
+        $(OBJ_D_FILES) $(TOOLSOBJ_D_FILES)
 
 # If the target name contains "clean", don't do a parallel build
 ifneq ($(findstring clean, $(MAKECMDGOALS)),)

--- a/engine/code/game/tests/Makefile
+++ b/engine/code/game/tests/Makefile
@@ -1,0 +1,18 @@
+CC ?= gcc
+CFLAGS ?= -I.. -I../.. -DARCH_STRING="x86_64" -Wall -Wextra -std=c99
+
+TEST_BINARY := test_g_frictioncalc
+SRCS := test_g_frictioncalc.c ../g_rally_hazard.c
+
+all: $(TEST_BINARY)
+
+$(TEST_BINARY): $(SRCS)
+	$(CC) $(CFLAGS) $(SRCS) -lm -o $@
+
+run: $(TEST_BINARY)
+	./$(TEST_BINARY)
+
+clean:
+	rm -f $(TEST_BINARY) *.o
+
+.PHONY: all run clean

--- a/engine/code/game/tests/test_g_frictioncalc.c
+++ b/engine/code/game/tests/test_g_frictioncalc.c
@@ -1,0 +1,70 @@
+#include "g_local.h"
+#include <assert.h>
+#include <string.h>
+
+static int stubEntityList[MAX_GENTITIES];
+static int stubEntityCount;
+
+gentity_t g_entities[MAX_GENTITIES];
+
+level_locals_t level;
+
+void G_FreeEntity(gentity_t *e) {}
+qboolean G_RadiusDamage_NoKnockBack(vec3_t origin, gentity_t *attacker, float damage, float radius, gentity_t *ignore, int mod) { return qfalse; }
+gentity_t *G_Find(gentity_t *from, int fieldofs, const char *match) { return NULL; }
+gentity_t *G_TempRallyEntity(vec3_t origin, int event) { return NULL; }
+gentity_t *G_TempEntity(vec3_t origin, int event) { return NULL; }
+
+int trap_EntitiesInBox(const vec3_t mins, const vec3_t maxs, int *entityList, int maxcount) {
+    int count = stubEntityCount < maxcount ? stubEntityCount : maxcount;
+    for (int i = 0; i < count; ++i) {
+        entityList[i] = stubEntityList[i];
+    }
+    return count;
+}
+
+static void test_no_hazard(void) {
+    carPoint_t point;
+    memset(&point, 0, sizeof(point));
+    point.radius = 1.0f;
+    point.r[0] = point.r[1] = point.r[2] = 0.0f;
+
+    float sCOF = 0.5f;
+    float kCOF = 0.4f;
+
+    stubEntityCount = 0;
+    qboolean result = G_FrictionCalc(&point, &sCOF, &kCOF);
+    assert(result == qfalse);
+    assert(sCOF == 0.5f);
+    assert(kCOF == 0.4f);
+}
+
+static void test_oil_hazard(void) {
+    carPoint_t point;
+    memset(&point, 0, sizeof(point));
+    point.radius = 1.0f;
+    point.r[0] = point.r[1] = point.r[2] = 0.0f;
+
+    float sCOF = 0.5f;
+    float kCOF = 0.4f;
+
+    memset(&g_entities[0], 0, sizeof(g_entities[0]));
+    g_entities[0].s.eType = ET_EVENTS + EV_HAZARD;
+    g_entities[0].s.weapon = HT_OIL;
+    g_entities[0].splashRadius = 1;
+    g_entities[0].r.currentOrigin[0] = g_entities[0].r.currentOrigin[1] = g_entities[0].r.currentOrigin[2] = 0.0f;
+
+    stubEntityList[0] = 0;
+    stubEntityCount = 1;
+
+    qboolean result = G_FrictionCalc(&point, &sCOF, &kCOF);
+    assert(result == qtrue);
+    assert(sCOF == CP_OIL_SCOF);
+    assert(kCOF == CP_OIL_KCOF);
+}
+
+int main(void) {
+    test_no_hazard();
+    test_oil_hazard();
+    return 0;
+}


### PR DESCRIPTION
## Summary
- add unit tests covering G_FrictionCalc behavior with and without nearby hazards
- hook the new tests into the build system via `make test`

## Testing
- `cd engine && make test`


------
https://chatgpt.com/codex/tasks/task_e_68ab30018c5c83249e038e5d2f05274a