### PR TITLE
Broadcast lap updates for all clients

### DIFF
--- a/engine/code/cgame/cg_local.h
+++ b/engine/code/cgame/cg_local.h
@@ -1859,7 +1859,7 @@ qboolean CG_InsideBox( vec3_t mins, vec3_t maxs, vec3_t pos );
 //
 // cg_rally_race_tools.c
 //
-void CG_NewLapTime( int lap, int time );
+void CG_NewLapTime( int client, int lap, int time );
 void CG_FinishedRace( int client, int time );
 void CG_StartRace( int time );
 void CG_DrawRaceCountDown( void );

--- a/engine/code/cgame/cg_rally_racetools.c
+++ b/engine/code/cgame/cg_rally_racetools.c
@@ -24,11 +24,11 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #include "cg_local.h"
 
 
-void CG_NewLapTime( int lap, int time ) {
+void CG_NewLapTime( int client, int lap, int time ) {
 	centity_t	*cent;
 	char		*t;
 
-	cent = &cg_entities[cg.snap->ps.clientNum];
+	cent = &cg_entities[client];
 
 	if ((time - cent->startLapTime) < cent->bestLapTime || cent->bestLapTime == 0){
 		// New bestlap
@@ -37,7 +37,9 @@ void CG_NewLapTime( int lap, int time ) {
 
 		t = getStringForTime( cent->bestLapTime );
 
-		Com_Printf("You got a personal record lap time of %s!\n", t);
+		if ( client == cg.snap->ps.clientNum ) {
+                        Com_Printf("You got a personal record lap time of %s!\n", t);
+		}
 	}
 
 	cent->currentLap = lap;
@@ -51,15 +53,16 @@ void CG_FinishedRace( int client, int time ) {
 
 	cent = &cg_entities[client];
 
-	if ( client == cg.snap->ps.clientNum
-		&& ((time - cent->startLapTime) < cent->bestLapTime || cent->bestLapTime == 0) ){
+	if ((time - cent->startLapTime) < cent->bestLapTime || cent->bestLapTime == 0){
 		// New bestlap
 		cent->bestLapTime = (time - cent->startLapTime);
 		cent->bestLap = cent->currentLap;
 
 		t = getStringForTime( cent->bestLapTime );
 
-		Com_Printf("You got a personal record lap time of %s!\n", t);
+		if ( client == cg.snap->ps.clientNum ) {
+                        Com_Printf("You got a personal record lap time of %s!\n", t);
+		}
 	}
 
 	cent->finishRaceTime = time;

--- a/engine/code/cgame/cg_servercmds.c
+++ b/engine/code/cgame/cg_servercmds.c
@@ -1288,10 +1288,13 @@ static void CG_ServerCommand( void ) {
 		return;
 	}
 
-	if ( !strcmp( cmd, "newLapTime" ) ) {
-		CG_NewLapTime( atoi(CG_Argv(1)), atoi(CG_Argv(2)) );
-		return;
-	}
+       if ( !strcmp( cmd, "newLapTime" ) ) {
+               int client = atoi(CG_Argv(1));
+               int lap = atoi(CG_Argv(2));
+               int time = atoi(CG_Argv(3));
+               CG_NewLapTime( client, lap, time );
+               return;
+       }
 
 	if ( !strcmp( cmd, "positions" ) ) {
 		CG_ParsePositions();

--- a/engine/code/game/g_rally_mapents.c
+++ b/engine/code/game/g_rally_mapents.c
@@ -115,7 +115,7 @@ void Touch_StartFinish (gentity_t *self, gentity_t *other, trace_t *trace ){
 			other->client->ps.stats[STAT_NEXT_CHECKPOINT] = other->number;
 			other->client->ps.stats[STAT_FRAC_TO_NEXT_CHECKPOINT] = FLOAT2SHORT(0.1f);
 //			Com_Printf( "resetting frac, sf\n" );
-			trap_SendServerCommand( other->client->ps.clientNum, va("newLapTime %i %i\n", other->currentLap, level.time));
+                       trap_SendServerCommand( -1, va("newLapTime %i %i %i", other->s.clientNum, other->currentLap, level.time));
 		}
 
 		


### PR DESCRIPTION
## Summary
- Broadcast `newLapTime` to all clients with the racer’s client number
- Parse new lap update format on the client and track lap data per-entity
- Update race tools to maintain per-client best lap times

## Testing
- `make -C engine` *(fails: SDL_version.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68ab4e845a7483248785104cc503dbbe