### PR TITLE
Add per-map record tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,13 @@ Q3Rally is a standalone game based on ioquake3.
 
 For compiling, see [engine/README.md](engine/README.md).
 
+## Records
+
+Per-map records are stored under `baseq3r/records/`.
+Each map's file is named `<mapname>.record` and contains either
+`best_lap_time=<milliseconds>` or `best_score=<value>` followed by the
+player name.  Remove the file to reset the record.
+
 ## Resources
 
 * [Q3Rally Website](http://www.q3rally.com)

--- a/changelog.txt
+++ b/changelog.txt
@@ -26,6 +26,7 @@ Added:
 - finished the flag status hud for domination
 - finished 4 Teams Domination
 - main menu music rotation
+- per-map record files for best lap times or scores
 
 new since v0.3b
 

--- a/engine/code/cgame/cg_rally_racetools.c
+++ b/engine/code/cgame/cg_rally_racetools.c
@@ -23,6 +23,43 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 
 #include "cg_local.h"
 
+static int      cg_mapBestLapTime;
+static int      cg_mapBestScore;
+static char     cg_mapBestPlayer[64];
+
+static void CG_LoadMapRecord( void ) {
+       fileHandle_t    f;
+       char            filename[MAX_QPATH];
+       char            buffer[128];
+       int             len;
+       char            mapname[MAX_QPATH];
+
+       cg_mapBestLapTime = 0;
+       cg_mapBestScore = 0;
+       Q_strncpyz( cg_mapBestPlayer, "Unknown", sizeof( cg_mapBestPlayer ) );
+
+       COM_StripExtension( cgs.mapname, mapname, sizeof( mapname ) );
+       Com_sprintf( filename, sizeof( filename ), "records/%s.record", mapname );
+
+       len = trap_FS_FOpenFile( filename, &f, FS_READ );
+       if ( len <= 0 ) {
+               return;
+       }
+       if ( len >= sizeof( buffer ) ) {
+               len = sizeof( buffer ) - 1;
+       }
+       trap_FS_Read( buffer, len, f );
+       buffer[len] = '\0';
+       trap_FS_FCloseFile( f );
+
+       if ( sscanf( buffer, "best_lap_time=%d\nplayer=%63s", &cg_mapBestLapTime, cg_mapBestPlayer ) != 2 ) {
+               if ( sscanf( buffer, "best_score=%d\nplayer=%63s", &cg_mapBestScore, cg_mapBestPlayer ) != 2 ) {
+                       cg_mapBestLapTime = 0;
+                       cg_mapBestScore = 0;
+                       Q_strncpyz( cg_mapBestPlayer, "Unknown", sizeof( cg_mapBestPlayer ) );
+               }
+       }
+}
 
 void CG_NewLapTime( int client, int lap, int time ) {
 	centity_t	*cent;
@@ -72,6 +109,8 @@ void CG_StartRace( int time ) {
 	int			i;
 	centity_t	*player;
 
+	CG_LoadMapRecord();
+
 	for (i = 0; i < MAX_CLIENTS; i++){
 		player = &cg_entities[i];
 		if (!player) continue;
@@ -105,9 +144,19 @@ void CG_DrawRaceCountDown( void ){
 	scale = cg.countDownEnd < cg.time ? 0.8f : ((cg.countDownEnd - cg.time) % 1000) / 1000.0f;
 	w = 3*GIANTCHAR_WIDTH * scale;
 	h = 3*GIANTCHAR_HEIGHT * scale;
-	x = 320 - (strlen(cg.countDownPrint) * w) / 2;
-	y = 240 - h/2;
-	CG_DrawStringExt( x, y, cg.countDownPrint, color, qfalse, qtrue, w, h, 0 );
+       x = 320 - (strlen(cg.countDownPrint) * w) / 2;
+       y = 240 - h/2;
+       CG_DrawStringExt( x, y, cg.countDownPrint, color, qfalse, qtrue, w, h, 0 );
+
+       if ( cg_mapBestLapTime || cg_mapBestScore ) {
+               char    line[128];
+               if ( cg_mapBestLapTime ) {
+                       Com_sprintf( line, sizeof( line ), "Best Lap: %s by %s", getStringForTime( cg_mapBestLapTime ), cg_mapBestPlayer );
+               } else {
+                       Com_sprintf( line, sizeof( line ), "Best Score: %d by %s", cg_mapBestScore, cg_mapBestPlayer );
+               }
+               CG_DrawStringExt( 5, 5, line, colorWhite, qfalse, qtrue, SMALLCHAR_WIDTH, SMALLCHAR_HEIGHT, 0 );
+       }
 }
 
 void CG_RaceCountDown( const char *str, int secondsLeft ){

--- a/engine/code/game/g_local.h
+++ b/engine/code/game/g_local.h
@@ -411,6 +411,8 @@ struct gclient_s {
 	int			horn_sound_time;
 
 	int			lastCheckpointTime;
+	int			startLapTime;
+	int			bestLapTime;
 // END
 
 	char		*areabits;
@@ -799,6 +801,8 @@ void Cmd_RacePositions_f( void );
 void Cmd_Times_f( gentity_t *ent );
 gentity_t *SelectLastMarkerForSpawn( gentity_t *ent, vec3_t origin, vec3_t angles, qboolean isbot );
 gentity_t *SelectGridPositionSpawn( gentity_t *ent, vec3_t origin, vec3_t angles, qboolean isbot );
+void G_UpdateLapRecord( gentity_t *player, int lapTime );
+void G_UpdateScoreRecord( gentity_t *player );
 
 //
 // g_rally_rearweapon.c

--- a/engine/code/game/g_main.c
+++ b/engine/code/game/g_main.c
@@ -1701,13 +1701,14 @@ void CheckExitRules( void ) {
 			winner = cl;
 		}
 
-		if (winner && count == 1) {
-			level.winnerNumber = winner->ps.clientNum;
-			level.finishRaceTime = level.time;
+               if (winner && count == 1) {
+                       level.winnerNumber = winner->ps.clientNum;
+                       level.finishRaceTime = level.time;
 
-			trap_SendServerCommand( -1, va("print \"%s won the demolition derby!\n\"", winner->pers.netname ));
-			trap_SendServerCommand( level.winnerNumber, "cp \"You won the demolition derby!\n\"");
-		}
+                       trap_SendServerCommand( -1, va("print \"%s won the demolition derby!\n\"", winner->pers.netname ));
+                       trap_SendServerCommand( level.winnerNumber, "cp \"You won the demolition derby!\n\"");
+                       G_UpdateScoreRecord( &g_entities[level.winnerNumber] );
+               }
 
 		return;
 	}
@@ -1726,13 +1727,14 @@ void CheckExitRules( void ) {
 			winner = cl;
 		}
 
-		if (winner && count == 1) {
-			level.winnerNumber = winner->ps.clientNum;
-			level.finishRaceTime = level.time;
+               if (winner && count == 1) {
+                       level.winnerNumber = winner->ps.clientNum;
+                       level.finishRaceTime = level.time;
 
-			trap_SendServerCommand( -1, va("print \"%s won the last car standing!\n\"", winner->pers.netname ));
-			trap_SendServerCommand( level.winnerNumber, "cp \"You won the last car standing!\n\"");
-		}
+                       trap_SendServerCommand( -1, va("print \"%s won the last car standing!\n\"", winner->pers.netname ));
+                       trap_SendServerCommand( level.winnerNumber, "cp \"You won the last car standing!\n\"");
+                       G_UpdateScoreRecord( &g_entities[level.winnerNumber] );
+               }
 
 		return;
 	}

--- a/engine/code/game/g_rally_mapents.c
+++ b/engine/code/game/g_rally_mapents.c
@@ -51,14 +51,23 @@ void Touch_StartFinish (gentity_t *self, gentity_t *other, trace_t *trace ){
 		return;
 	}
 
-	if (self->number == other->number){
-		other->client->lastCheckpointTime = level.time;
-		other->currentLap++;
-		// increment lap
-		if ( other->currentLap > level.numberOfLaps && level.numberOfLaps ){
-			other->client->finishRaceTime = level.time;
-			other->s.weapon = WP_NONE;
-			other->takedamage = qfalse;
+       if (self->number == other->number){
+               int lapTime = 0;
+               if ( other->client->startLapTime ) {
+                       lapTime = level.time - other->client->startLapTime;
+                       if ( lapTime < other->client->bestLapTime || other->client->bestLapTime == 0 ) {
+                               other->client->bestLapTime = lapTime;
+                       }
+                       G_UpdateLapRecord( other, lapTime );
+               }
+               other->client->startLapTime = level.time;
+               other->client->lastCheckpointTime = level.time;
+               other->currentLap++;
+               // increment lap
+               if ( other->currentLap > level.numberOfLaps && level.numberOfLaps ){
+                       other->client->finishRaceTime = level.time;
+                       other->s.weapon = WP_NONE;
+                       other->takedamage = qfalse;
 
 			trap_SendServerCommand( -1, va("raceFinishTime %i %i", other->s.clientNum, other->client->finishRaceTime) );
 

--- a/engine/code/game/g_rally_racetools.c
+++ b/engine/code/game/g_rally_racetools.c
@@ -24,6 +24,70 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #include "g_local.h"
 
 
+static int G_ReadBestValue( const char *mapname ) {
+       fileHandle_t    f;
+       char            filename[MAX_QPATH];
+       char            buffer[128];
+       int             len;
+       int             value = 0;
+
+       Com_sprintf( filename, sizeof( filename ), "records/%s.record", mapname );
+       len = trap_FS_FOpenFile( filename, &f, FS_READ );
+       if ( len <= 0 ) {
+               return 0;
+       }
+       if ( len >= sizeof( buffer ) ) {
+               len = sizeof( buffer ) - 1;
+       }
+       trap_FS_Read( buffer, len, f );
+       buffer[len] = '\0';
+       trap_FS_FCloseFile( f );
+
+       sscanf( buffer, "%*[^=]=%d", &value );
+       return value;
+}
+
+static void G_WriteRecord( const char *mapname, const char *key, int value, const char *player ) {
+       fileHandle_t    f;
+       char            filename[MAX_QPATH];
+       char            buffer[256];
+
+       Com_sprintf( filename, sizeof( filename ), "records/%s.record", mapname );
+       trap_FS_FOpenFile( filename, &f, FS_WRITE );
+       Com_sprintf( buffer, sizeof( buffer ), "%s=%d\nplayer=%s\n", key, value, player );
+       trap_FS_Write( buffer, strlen( buffer ), f );
+       trap_FS_FCloseFile( f );
+}
+
+void G_UpdateLapRecord( gentity_t *player, int lapTime ) {
+       char            serverinfo[MAX_INFO_STRING];
+       char            mapname[MAX_QPATH];
+       int             best;
+
+       trap_GetServerinfo( serverinfo, sizeof( serverinfo ) );
+       Q_strncpyz( mapname, Info_ValueForKey( serverinfo, "mapname" ), sizeof( mapname ) );
+
+       best = G_ReadBestValue( mapname );
+       if ( !best || lapTime < best ) {
+               G_WriteRecord( mapname, "best_lap_time", lapTime, player->client->pers.netname );
+       }
+}
+
+void G_UpdateScoreRecord( gentity_t *player ) {
+       char            serverinfo[MAX_INFO_STRING];
+       char            mapname[MAX_QPATH];
+       int             best;
+       int             score = player->client->ps.persistant[PERS_SCORE];
+
+       trap_GetServerinfo( serverinfo, sizeof( serverinfo ) );
+       Q_strncpyz( mapname, Info_ValueForKey( serverinfo, "mapname" ), sizeof( mapname ) );
+
+       best = G_ReadBestValue( mapname );
+       if ( !best || score > best ) {
+               G_WriteRecord( mapname, "best_score", score, player->client->pers.netname );
+       }
+}
+
 int GetTeamAtRank( int rank ){
 	int		i, j, count;
 	int		ranks[4];
@@ -371,15 +435,22 @@ void RallyStarter_Think( gentity_t *ent ){
 	if (isRallyRace()){
 		t = NULL;
 		t = G_Find (t, FOFS(classname), "rally_checkpoint");
-		if (t == NULL){
-			// start race right away
-			level.startRaceTime = level.time;
-			trap_SendServerCommand( -1, va("raceTime %i", level.startRaceTime) );
-			CenterPrint_All("GO..");
+               if (t == NULL){
+                       // start race right away
+                       level.startRaceTime = level.time;
+                       trap_SendServerCommand( -1, va("raceTime %i", level.startRaceTime) );
+                       CenterPrint_All("GO..");
 
-			G_FreeEntity( ent );
-			return;
-		}
+                       for ( i = 0; i < level.maxclients; i++ ) {
+                               player = &g_entities[i];
+                               if ( !player->inuse || !player->client ) continue;
+                               player->client->startLapTime = level.startRaceTime;
+                               player->client->bestLapTime = 0;
+                       }
+
+                       G_FreeEntity( ent );
+                       return;
+               }
 	}
 	ent->nextthink = level.time + 1000;
 	t = NULL;
@@ -428,17 +499,24 @@ void RallyStarter_Think( gentity_t *ent ){
 	if ( ent->pain_debounce_time == 0 )
 		ent->pain_debounce_time = level.time;
 
-	if ( level.time > ent->pain_debounce_time + 5000 ){
-		level.startRaceTime = level.time;
+       if ( level.time > ent->pain_debounce_time + 5000 ){
+               level.startRaceTime = level.time;
 
-		trap_SendServerCommand( -1, va("raceTime %i", level.startRaceTime) );
-		RaceCountdown("GO!", 0);
+               for ( i = 0; i < level.maxclients; i++ ) {
+                       player = &g_entities[i];
+                       if ( !player->inuse || !player->client ) continue;
+                       player->client->startLapTime = level.startRaceTime;
+                       player->client->bestLapTime = 0;
+               }
 
-		Rally_Sound( ent, EV_GLOBAL_SOUND, CHAN_ANNOUNCER, G_SoundIndex("sound/rally/race/go.wav") );
+               trap_SendServerCommand( -1, va("raceTime %i", level.startRaceTime) );
+               RaceCountdown("GO!", 0);
 
-		if (g_gametype.integer != GT_DERBY)
-			ent->think = RallyRace_Think;
-	}
+               Rally_Sound( ent, EV_GLOBAL_SOUND, CHAN_ANNOUNCER, G_SoundIndex("sound/rally/race/go.wav") );
+
+               if (g_gametype.integer != GT_DERBY)
+                       ent->think = RallyRace_Think;
+       }
 	else if ( level.time > ent->pain_debounce_time + 4000 ){
 		RaceCountdown("1", 1);
 


### PR DESCRIPTION
## Summary
- track best lap times and scores in new `records` files
- show map records in the HUD when a race starts
- document record files and mention new feature in changelog

## Testing
- `make -C engine release BUILD_GAME_SO=0 BUILD_SERVER=0` *(fails: SDL_version.h missing)*

------
https://chatgpt.com/codex/tasks/task_e_68ab5ef08ce48324aab168ae751e898f