### PR TITLE
Prevent bots from updating lap records

### DIFF
--- a/engine/code/game/g_rally_racetools.c
+++ b/engine/code/game/g_rally_racetools.c
@@ -68,6 +68,9 @@ void G_UpdateLapRecord( gentity_t *player, int lapTime ) {
        Q_strncpyz( mapname, Info_ValueForKey( serverinfo, "mapname" ), sizeof( mapname ) );
 
        best = G_ReadBestValue( mapname );
+       if ( player->r.svFlags & SVF_BOT ) {
+               return;
+       }
        if ( !best || lapTime < best ) {
                G_WriteRecord( mapname, "best_lap_time", lapTime, player->client->pers.netname );
        }


### PR DESCRIPTION
## Summary
- skip lap record updates for bot players in `G_UpdateLapRecord`

## Testing
- `make` *(fails: SDL_version.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68ab70afa8148324bd63fc0dd1221daa