### PR TITLE
Support separate lap records for bots and humans

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,11 @@ For compiling, see [engine/README.md](engine/README.md).
 ## Records
 
 Per-map records are stored under `baseq3r/records/`.
-Each map's file is named `<mapname>.record` and contains either
-`best_lap_time=<milliseconds>` or `best_score=<value>` followed by the
-player name.  Remove the file to reset the record.
+Each map's file is named `<mapname>.record` and contains key/value pairs
+such as `best_lap_time_player=<milliseconds>` or `best_lap_time_bot=<milliseconds>`
+for lap times and `best_score=<value>` for score records. The holder's name
+is stored with a corresponding `player_<key>=<name>` entry. Remove the file
+to reset the record.
 
 ## Resources
 

--- a/engine/code/cgame/cg_rally_racetools.c
+++ b/engine/code/cgame/cg_rally_racetools.c
@@ -30,9 +30,18 @@ static char     cg_mapBestPlayer[64];
 static void CG_LoadMapRecord( void ) {
        fileHandle_t    f;
        char            filename[MAX_QPATH];
-       char            buffer[128];
+       char            buffer[256];
        int             len;
        char            mapname[MAX_QPATH];
+       typedef struct {
+               char    key[64];
+               char    value[128];
+       } record_t;
+       record_t       records[16];
+       int             count = 0;
+       char            *line;
+       int             i;
+       const char      *val;
 
        cg_mapBestLapTime = 0;
        cg_mapBestScore = 0;
@@ -52,11 +61,70 @@ static void CG_LoadMapRecord( void ) {
        buffer[len] = '\0';
        trap_FS_FCloseFile( f );
 
-       if ( sscanf( buffer, "best_lap_time=%d\nplayer=%63s", &cg_mapBestLapTime, cg_mapBestPlayer ) != 2 ) {
-               if ( sscanf( buffer, "best_score=%d\nplayer=%63s", &cg_mapBestScore, cg_mapBestPlayer ) != 2 ) {
-                       cg_mapBestLapTime = 0;
-                       cg_mapBestScore = 0;
-                       Q_strncpyz( cg_mapBestPlayer, "Unknown", sizeof( cg_mapBestPlayer ) );
+       for ( line = strtok( buffer, "\n" ); line && count < ARRAY_LEN( records ); line = strtok( NULL, "\n" ) ) {
+               char *eq = strchr( line, '=' );
+               if ( !eq ) {
+                       continue;
+               }
+               *eq = '\0';
+               Q_strncpyz( records[count].key, line, sizeof( records[count].key ) );
+               Q_strncpyz( records[count].value, eq + 1, sizeof( records[count].value ) );
+               count++;
+       }
+
+       // new format: prefer player lap time, then score
+       val = NULL;
+       for ( i = 0; i < count; i++ ) {
+               if ( !strcmp( records[i].key, "best_lap_time_player" ) ) {
+                       cg_mapBestLapTime = atoi( records[i].value );
+               } else if ( !strcmp( records[i].key, "player_best_lap_time_player" ) ) {
+                       Q_strncpyz( cg_mapBestPlayer, records[i].value, sizeof( cg_mapBestPlayer ) );
+               } else if ( !strcmp( records[i].key, "best_score" ) ) {
+                       cg_mapBestScore = atoi( records[i].value );
+               } else if ( !strcmp( records[i].key, "player_best_score" ) ) {
+                       if ( !cg_mapBestLapTime ) {
+                               Q_strncpyz( cg_mapBestPlayer, records[i].value, sizeof( cg_mapBestPlayer ) );
+                       }
+               }
+       }
+
+       if ( cg_mapBestLapTime ) {
+               // ensure we have player name for lap time
+               val = NULL;
+               for ( i = 0; i < count; i++ ) {
+                       if ( !strcmp( records[i].key, "player_best_lap_time_player" ) ) {
+                               val = records[i].value;
+                               break;
+                       }
+               }
+               if ( val ) {
+                       Q_strncpyz( cg_mapBestPlayer, val, sizeof( cg_mapBestPlayer ) );
+               }
+       } else if ( cg_mapBestScore ) {
+               val = NULL;
+               for ( i = 0; i < count; i++ ) {
+                       if ( !strcmp( records[i].key, "player_best_score" ) ) {
+                               val = records[i].value;
+                               break;
+                       }
+               }
+               if ( val ) {
+                       Q_strncpyz( cg_mapBestPlayer, val, sizeof( cg_mapBestPlayer ) );
+               }
+       } else {
+               // old format fallback
+               const char *player = NULL;
+               for ( i = 0; i < count; i++ ) {
+                       if ( !strcmp( records[i].key, "best_lap_time" ) ) {
+                               cg_mapBestLapTime = atoi( records[i].value );
+                       } else if ( !strcmp( records[i].key, "best_score" ) ) {
+                               cg_mapBestScore = atoi( records[i].value );
+                       } else if ( !strcmp( records[i].key, "player" ) ) {
+                               player = records[i].value;
+                       }
+               }
+               if ( player ) {
+                       Q_strncpyz( cg_mapBestPlayer, player, sizeof( cg_mapBestPlayer ) );
                }
        }
 }

--- a/engine/code/game/g_rally_racetools.c
+++ b/engine/code/game/g_rally_racetools.c
@@ -24,12 +24,13 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #include "g_local.h"
 
 
-static int G_ReadBestValue( const char *mapname ) {
+static int G_ReadBestValue( const char *mapname, const char *key ) {
        fileHandle_t    f;
        char            filename[MAX_QPATH];
-       char            buffer[128];
+       char            buffer[1024];
        int             len;
        int             value = 0;
+       char            *line;
 
        Com_sprintf( filename, sizeof( filename ), "records/%s.record", mapname );
        len = trap_FS_FOpenFile( filename, &f, FS_READ );
@@ -43,19 +44,90 @@ static int G_ReadBestValue( const char *mapname ) {
        buffer[len] = '\0';
        trap_FS_FCloseFile( f );
 
-       sscanf( buffer, "%*[^=]=%d", &value );
+       for ( line = strtok( buffer, "\n" ); line; line = strtok( NULL, "\n" ) ) {
+               if ( !Q_strncmp( line, key, strlen( key ) ) && line[strlen( key )] == '=' ) {
+                       value = atoi( line + strlen( key ) + 1 );
+                       break;
+               }
+       }
        return value;
 }
 
 static void G_WriteRecord( const char *mapname, const char *key, int value, const char *player ) {
        fileHandle_t    f;
        char            filename[MAX_QPATH];
-       char            buffer[256];
+       char            buffer[1024];
+       int             len;
+       typedef struct {
+               char    key[64];
+               char    value[128];
+       } record_t;
+       record_t       records[16];
+       int             count = 0;
+       int             i;
+       char            *line;
+       char            val[64];
+       char            playerKey[64];
 
        Com_sprintf( filename, sizeof( filename ), "records/%s.record", mapname );
+
+       len = trap_FS_FOpenFile( filename, &f, FS_READ );
+       if ( len > 0 ) {
+               if ( len >= sizeof( buffer ) ) {
+                       len = sizeof( buffer ) - 1;
+               }
+               trap_FS_Read( buffer, len, f );
+               buffer[len] = '\0';
+               trap_FS_FCloseFile( f );
+
+               for ( line = strtok( buffer, "\n" ); line && count < ARRAY_LEN( records ); line = strtok( NULL, "\n" ) ) {
+                       char *eq = strchr( line, '=' );
+                       if ( !eq ) {
+                               continue;
+                       }
+                       *eq = '\0';
+                       Q_strncpyz( records[count].key, line, sizeof( records[count].key ) );
+                       Q_strncpyz( records[count].value, eq + 1, sizeof( records[count].value ) );
+                       count++;
+               }
+       } else {
+               buffer[0] = '\0';
+       }
+
+       // update or add the value
+       Com_sprintf( val, sizeof( val ), "%d", value );
+       for ( i = 0; i < count; i++ ) {
+               if ( !Q_stricmp( records[i].key, key ) ) {
+                       Q_strncpyz( records[i].value, val, sizeof( records[i].value ) );
+                       break;
+               }
+       }
+       if ( i == count && count < ARRAY_LEN( records ) ) {
+               Q_strncpyz( records[count].key, key, sizeof( records[count].key ) );
+               Q_strncpyz( records[count].value, val, sizeof( records[count].value ) );
+               count++;
+       }
+
+       // update or add the player name for this key
+       Com_sprintf( playerKey, sizeof( playerKey ), "player_%s", key );
+       for ( i = 0; i < count; i++ ) {
+               if ( !Q_stricmp( records[i].key, playerKey ) ) {
+                       Q_strncpyz( records[i].value, player, sizeof( records[i].value ) );
+                       break;
+               }
+       }
+       if ( i == count && count < ARRAY_LEN( records ) ) {
+               Q_strncpyz( records[count].key, playerKey, sizeof( records[count].key ) );
+               Q_strncpyz( records[count].value, player, sizeof( records[count].value ) );
+               count++;
+       }
+
        trap_FS_FOpenFile( filename, &f, FS_WRITE );
-       Com_sprintf( buffer, sizeof( buffer ), "%s=%d\nplayer=%s\n", key, value, player );
-       trap_FS_Write( buffer, strlen( buffer ), f );
+       for ( i = 0; i < count; i++ ) {
+               char out[256];
+               Com_sprintf( out, sizeof( out ), "%s=%s\n", records[i].key, records[i].value );
+               trap_FS_Write( out, strlen( out ), f );
+       }
        trap_FS_FCloseFile( f );
 }
 
@@ -63,13 +135,16 @@ void G_UpdateLapRecord( gentity_t *player, int lapTime ) {
        char            serverinfo[MAX_INFO_STRING];
        char            mapname[MAX_QPATH];
        int             best;
+       const char      *key;
 
        trap_GetServerinfo( serverinfo, sizeof( serverinfo ) );
        Q_strncpyz( mapname, Info_ValueForKey( serverinfo, "mapname" ), sizeof( mapname ) );
 
-       best = G_ReadBestValue( mapname );
+       key = ( player->r.svFlags & SVF_BOT ) ? "best_lap_time_bot" : "best_lap_time_player";
+
+       best = G_ReadBestValue( mapname, key );
        if ( !best || lapTime < best ) {
-               G_WriteRecord( mapname, "best_lap_time", lapTime, player->client->pers.netname );
+               G_WriteRecord( mapname, key, lapTime, player->client->pers.netname );
        }
 }
 
@@ -82,7 +157,7 @@ void G_UpdateScoreRecord( gentity_t *player ) {
        trap_GetServerinfo( serverinfo, sizeof( serverinfo ) );
        Q_strncpyz( mapname, Info_ValueForKey( serverinfo, "mapname" ), sizeof( mapname ) );
 
-       best = G_ReadBestValue( mapname );
+       best = G_ReadBestValue( mapname, "best_score" );
        if ( !best || score > best ) {
                G_WriteRecord( mapname, "best_score", score, player->client->pers.netname );
        }


### PR DESCRIPTION
## Summary
- Track lap records separately for human players and bots
- Preserve multiple key/value pairs in record files and expose them to clients
- Document new `player_<key>` record format

## Testing
- `make -C engine/code/game/tests`
- `make -C engine` *(fails: SDL_version.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68ab721c1a448324abd56e0dee011f58