### PR TITLE
Fix lap record best value call

### DIFF
--- a/engine/code/game/g_rally_racetools.c
+++ b/engine/code/game/g_rally_racetools.c
@@ -144,8 +144,6 @@ void G_UpdateLapRecord( gentity_t *player, int lapTime ) {
        key = ( player->r.svFlags & SVF_BOT ) ? "best_lap_time_bot" : "best_lap_time_player";
 
        best = G_ReadBestValue( mapname, key );
-
-       best = G_ReadBestValue( mapname );
        if ( player->r.svFlags & SVF_BOT ) {
                return;
        }


### PR DESCRIPTION
## Summary
- fix `G_UpdateLapRecord` to correctly read map best value using `G_ReadBestValue(mapname, key)`

## Testing
- `make -j4` *(fails: SDL_version.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68ab7b5aaa088324b9c3cd9b4c4eba4f