### PR TITLE
Use keyed record lookup for race records

### DIFF
--- a/engine/code/game/g_rally_racetools.c
+++ b/engine/code/game/g_rally_racetools.c
@@ -135,21 +135,17 @@ void G_UpdateLapRecord( gentity_t *player, int lapTime ) {
        char            serverinfo[MAX_INFO_STRING];
        char            mapname[MAX_QPATH];
        int             best;
-       const char      *key;
 
        trap_GetServerinfo( serverinfo, sizeof( serverinfo ) );
        Q_strncpyz( mapname, Info_ValueForKey( serverinfo, "mapname" ), sizeof( mapname ) );
 
-
-       key = ( player->r.svFlags & SVF_BOT ) ? "best_lap_time_bot" : "best_lap_time_player";
-
-       best = G_ReadBestValue( mapname, key );
+       best = G_ReadBestValue( mapname, "best_lap_time" );
        if ( player->r.svFlags & SVF_BOT ) {
                return;
        }
 
        if ( !best || lapTime < best ) {
-               G_WriteRecord( mapname, key, lapTime, player->client->pers.netname );
+               G_WriteRecord( mapname, "best_lap_time", lapTime, player->client->pers.netname );
        }
 }
 


### PR DESCRIPTION
## Summary
- Update lap record logic to read/write "best_lap_time" via new key-based record loader
- Ensure score records continue using key-based lookup

## Testing
- `make -C engine BUILD_GAME_QVM=1 BUILD_SERVER=0 BUILD_CLIENT=0 BUILD_GAME_SO=0` *(fails: code/cgame/cg_rally_racetools.c:64: operands of = have illegal types `pointer to char` and `int`)*

------
https://chatgpt.com/codex/tasks/task_e_68ab848e7ca08324a16a88e79505bf01