### PR TITLE
refactor: unify damage mark shaders

### DIFF
--- a/baseq3r/scripts/gfx.shader
+++ b/baseq3r/scripts/gfx.shader
@@ -519,7 +519,7 @@ bloodTrail
 		alphaGen	vertex
 	}
 }
-
+// Damage mark shaders
 gfx/damage/bullet_mrk
 {
 	polygonOffset
@@ -552,18 +552,38 @@ gfx/damage/hole_lg_mrk
 
 gfx/damage/plasma_mrk
 {
-	polygonOffset
-	{
-		map gfx/damage/plasma_mrk.tga
-		blendFunc GL_SRC_ALPHA GL_ONE_MINUS_SRC_ALPHA
-		rgbGen vertex
-		alphaGen vertex
-	}
+        polygonOffset
+        {
+                map gfx/damage/plasma_mrk.tga
+                blendFunc GL_SRC_ALPHA GL_ONE_MINUS_SRC_ALPHA
+                rgbGen vertex
+                alphaGen vertex
+        }
+}
+
+gfx/damage/oil_mark
+{
+        polygonOffset
+        {
+                map gfx/damage/oil_mark.tga
+                blendFunc GL_ZERO GL_ONE_MINUS_SRC_COLOR
+                rgbGen exactVertex
+        }
+        {
+              map textures/reflect/oilreflect.tga
+                blendFunc add
+              rgbGen exactVertex
+        }
+        {
+                map gfx/damage/oil_mark_reflect.tga
+                blendFunc GL_ZERO GL_ONE_MINUS_SRC_COLOR
+                rgbGen exactVertex
+        }
 }
 
 railDic
 {
-	cull disable
+        cull disable
 	deformVertexes autosprite
 	{
 		clampmap textures/oafx/plastrail.tga
@@ -1782,44 +1802,22 @@ gfx/damage/spark
 	}
 }
 
-gfx/damage/oil_mark
-{
-	polygonOffset
-
-
-	{
-		map gfx/damage/oil_mark.tga
-		blendFunc GL_ZERO GL_ONE_MINUS_SRC_COLOR
-		rgbGen exactVertex
-	}
-	{	
-	      map textures/reflect/oilreflect.tga
-		blendFunc add
-	      rgbGen exactVertex
-	}
-	{
-		map gfx/damage/oil_mark_reflect.tga
-		blendFunc GL_ZERO GL_ONE_MINUS_SRC_COLOR
-		rgbGen exactVertex
-	}
-}
-
 // ------------------------------------------------------------
 // 20.goal gfx
 // ------------------------------------------------------------
 
 textures/sfx2/redgoal2
 {
-	surfaceparm nolightmap
-	surfaceparm trans
-	cull none
-	{
-		map textures/sfx2/redgoal2.tga
-		tcgen environment
-		blendfunc add
-		tcmod turb .1 .3 .5 .4
-		tcmod scale .5 .5
-	}
+        surfaceparm nolightmap
+        surfaceparm trans
+        cull none
+        {
+                map textures/sfx2/redgoal2.tga
+                tcgen environment
+                blendfunc add
+                tcmod turb .1 .3 .5 .4
+                tcmod scale .5 .5
+        }
 }
 
 textures/sfx2/bluegoal2

--- a/baseq3r/scripts/sprites.shader
+++ b/baseq3r/scripts/sprites.shader
@@ -36,54 +36,15 @@ gfx/misc/tracer
 }
 
 
-gfx/damage/bullet_mrk
-{
-	polygonoffset
-	{
-		map gfx/damage/bulletmult.tga
-		blendfunc gl_dst_color gl_src_color
-		alphaGen Vertex
-	}
-}
+// Damage mark shaders moved to gfx.shader
 
 oldgfx/damage/bullet_mrk
 {
-	polygonoffset
-	{
-		map gfx/damage/bullet_mrk.tga
+        polygonoffset
+        {
+                map gfx/damage/bullet_mrk.tga
 		blendfunc gl_zero gl_one_minus_src_color
 		rgbGen Vertex
-	}
-}
-
-gfx/damage/burn_med_mrk
-{
-	polygonoffset
-	{
-		map gfx/damage/burn_med_mrk.tga
-		blendfunc gl_zero gl_one_minus_src_color
-		rgbGen Vertex
-	}
-}
-
-gfx/damage/hole_lg_mrk
-{
-	polygonoffset
-	{
-		map gfx/damage/hole_lg_mrk.tga
-		blendfunc gl_zero gl_one_minus_src_color
-		rgbGen Vertex
-	}
-}
-
-gfx/damage/plasma_mrk
-{
-	polygonoffset
-	{
-		map gfx/damage/plasma_mrk.tga
-		blendfunc blend
-		rgbGen Vertex
-		alphaGen Vertex
 	}
 }
 

--- a/baseq3r/scripts/weapons.shader
+++ b/baseq3r/scripts/weapons.shader
@@ -1451,28 +1451,7 @@ gfx/damage/bio_mark
 // ------------------------------------------------------------
 // 13.Rearfire Oilmarks
 // ------------------------------------------------------------
-
-gfx/damage/oil_mark
-{
-	polygonOffset
-
-
-	{
-		map gfx/damage/oil_mark.tga
-		blendFunc GL_ZERO GL_ONE_MINUS_SRC_COLOR
-		rgbGen exactVertex
-	}
-	{	
-	      map textures/reflect/oilreflect.tga
-		blendFunc add
-	      rgbGen exactVertex
-	}
-	{
-		map gfx/damage/oil_mark_reflect.tga
-		blendFunc GL_ZERO GL_ONE_MINUS_SRC_COLOR
-		rgbGen exactVertex
-	}
-}
+// Definition moved to gfx.shader
 
 // ------------------------------------------------------------
 // 14.Rearfire Flameballs


### PR DESCRIPTION
## Summary
- centralize damage mark shader definitions in `gfx.shader`
- drop duplicate shader entries from `sprites.shader` and `weapons.shader`

## Testing
- `make test` (fails: No rule to make target 'test')
- `make` (fails: No targets specified and no makefile found)


------
https://chatgpt.com/codex/tasks/task_e_68acc6fb56e48324b6955ca170f86912