### PR TITLE
Centralize waterBubble and tracer shaders

### DIFF
--- a/baseq3r/scripts/gfx.shader
+++ b/baseq3r/scripts/gfx.shader
@@ -340,18 +340,7 @@ viewBloodBlend
 	}
 }
 
-waterBubble
-{
-	sort	underwater
-	cull none
-	entityMergable		// allow all the sprites to be merged together
-	{
-		map sprites/bubble.tga
-		blendFunc GL_SRC_ALPHA GL_ONE_MINUS_SRC_ALPHA
-		rgbGen		vertex
-		alphaGen	vertex
-	}
-}
+// waterBubble shader defined in sprites.shader
 
 smokePuff
 {
@@ -478,15 +467,7 @@ lightningBolt
 }
 
 // shader used on the occasional machinegun bullet tracers
-
-gfx/misc/tracer
-{
-	cull none
-	{
-		map	gfx/misc/tracer2.tga
-		blendFunc GL_ONE GL_ONE
-	}
-}
+// gfx/misc/tracer defined in sprites.shader
 
 //
 // wall marks

--- a/baseq3r/scripts/powerups.shader
+++ b/baseq3r/scripts/powerups.shader
@@ -1336,18 +1336,7 @@ sprites/balloon3
 	}
 }
 
-waterBubble
-{
-	sort	underwater
-	cull none
-	entityMergable		
-	{
-		map sprites/bubble.tga
-		blendFunc GL_SRC_ALPHA GL_ONE_MINUS_SRC_ALPHA
-		rgbGen		vertex
-		alphaGen	vertex
-	}
-}
+// waterBubble defined in sprites.shader
 
 
 Grareflaader
@@ -1368,14 +1357,8 @@ boens
 		rgbGen vertex
 	}
 }
-gfx/misc/tracer
-{
-	cull none
-	{
-		map	gfx/misc/tracer2.tga
-		blendFunc GL_ONE GL_ONE
-	}
-}
+// gfx/misc/tracer defined in sprites.shader
+
 
 gfx/2d/select
 {


### PR DESCRIPTION
## Summary
- Remove duplicate `waterBubble` shader definitions from `gfx.shader` and `powerups.shader`
- Remove duplicate `gfx/misc/tracer` shader definitions and reference central definition

## Testing
- ⚠️ `cd engine && make` *(interrupted build)*


------
https://chatgpt.com/codex/tasks/task_e_68acc972df28832483c46a04682caa15