### PR TITLE
Fix typo in Q3Map2 comment

### DIFF
--- a/tools/radiant-config/radiant15-netradiant/q3rally.game/baseq3r/entities.def
+++ b/tools/radiant-config/radiant15-netradiant/q3rally.game/baseq3r/entities.def
@@ -3,7 +3,7 @@
 // Upgraded by Eutectic: eutectic@ritualistic.com
 // (visible models added by raYGunn - paths provided by Suicide 20)
 // (terrain information added to func_group entity by Paul Jaquays)
-// Q3Map2 entitys/keys added by ydnar
+// Q3Map2 entities/keys added by ydnar
 // Adapted for EntityPlus
 
 //=============================================================================


### PR DESCRIPTION
## Summary
- fix misspelling in Q3Map2 entities comment

## Testing
- `make test` *(fails: No rule to make target 'test')*

------
https://chatgpt.com/codex/tasks/task_e_68acd41404fc83248f0b53512a7cd7f2