### PR TITLE
Fix typo in Radiant decal entity definition

### DIFF
--- a/tools/radiant-config/radiant15-netradiant/q3rally.game/baseq3r/entities.def
+++ b/tools/radiant-config/radiant15-netradiant/q3rally.game/baseq3r/entities.def
@@ -14,7 +14,7 @@
 
 /*QUAKED _decal (0 1.0 0) ?
 -------- KEYS --------
-"target" : the name of the entity targetted at for projection
+"target" : the name of the entity targeted at for projection
 -------- SPAWNFLAGS --------
 (none)
 -------- NOTES --------


### PR DESCRIPTION
## Summary
- fix typo "targetted" -> "targeted" in _decal entity documentation

## Testing
- `make -C engine test` *(fails: No rule to make target 'test')*

------
https://chatgpt.com/codex/tasks/task_e_68acd4aead348324aba02b075fe5288f