### PR TITLE
Remove duplicated phrase in entity definition

### DIFF
--- a/tools/radiant-config/radiant15-netradiant/q3rally.game/baseq3r/entities.def
+++ b/tools/radiant-config/radiant15-netradiant/q3rally.game/baseq3r/entities.def
@@ -154,7 +154,7 @@ target : picking up the item will trigger the entity this points to.
 target2 : picking up the item will trigger the entity this points to.
 targetname : a target_give entity can point to this for respawn freebies.
 targetname2 : a target_give entity can point to this for respawn freebies.
-notfree : when set to 1, when set to 1, entity will not spawn in "Free for all" and "Tournament" modes.
+notfree : when set to 1, entity will not spawn in "Free for all" and "Tournament" modes.
 notteam : when set to 1, entity will not spawn in "Teamplay" and "CTF" modes.
 notsingle : when set to 1, entity will not spawn in Single Player mode.
 notbot : used to make an item invisible for bot attraction.


### PR DESCRIPTION
## Summary
- fix duplicated "when set to 1" description for notfree spawn option

## Testing
- `make -C engine` *(fails: interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_68acd72365c083248cc4d6af50986a13