### PR TITLE
Add dedicated rally start and finish entities

### DIFF
--- a/engine/code/cgame/cg_rally_hud.c
+++ b/engine/code/cgame/cg_rally_hud.c
@@ -462,7 +462,10 @@ static float CG_DrawLaps( float y ) {
 	curLap = cent->currentLap;
 	numLaps = cgs.laplimit;
 
-	Com_sprintf(s, sizeof(s), "LAP: %i/%i", curLap, numLaps);
+        if ( numLaps > 1 )
+                Com_sprintf(s, sizeof(s), "LAP: %i/%i", curLap, numLaps);
+        else
+                Com_sprintf(s, sizeof(s), "LAP: %i", curLap);
 
 	x = 636 - 80;
 	CG_FillRect( x, y, 90, 18, bgColor );

--- a/engine/code/cgame/cg_rally_hud2.c
+++ b/engine/code/cgame/cg_rally_hud2.c
@@ -198,7 +198,10 @@ void CG_DrawHUD_Laps(float x, float y){
 	// draw heading
 	CG_FillRect(x, y, 170, 18, bgColor);
 	CG_DrawSmallDigitalStringColor(x + 12, y, "LAP:", colorWhite);
-	CG_DrawSmallDigitalStringColor(x + 102, y, va("%i/%i", cg_entities[cg.snap->ps.clientNum].currentLap, cgs.laplimit), colorWhite);
+        if ( cgs.laplimit > 1 )
+                CG_DrawSmallDigitalStringColor(x + 102, y, va("%i/%i", cg_entities[cg.snap->ps.clientNum].currentLap, cgs.laplimit), colorWhite);
+        else
+                CG_DrawSmallDigitalStringColor(x + 102, y, va("%i", cg_entities[cg.snap->ps.clientNum].currentLap), colorWhite);
 }
 
 /*

--- a/engine/code/game/g_rally_mapents.c
+++ b/engine/code/game/g_rally_mapents.c
@@ -32,6 +32,199 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #define CHECKPOINT_SOUNDS		1
 #define CHECKPOINT_MESSAGES		2
 
+void Touch_Start (gentity_t *self, gentity_t *other, trace_t *trace ){
+if ( !other->client ) {
+return;
+}
+
+if ( other->client->lastCheckpointTime + 300 > level.time ) {
+return;
+}
+
+if ( g_developer.integer )
+G_Printf( "Client %i touched the start line.\n", other->s.clientNum );
+
+other->client->lastCheckpointTime = level.time;
+other->number = 1;
+other->client->ps.stats[STAT_NEXT_CHECKPOINT] = other->number;
+other->client->ps.stats[STAT_FRAC_TO_NEXT_CHECKPOINT] = FLOAT2SHORT(0.1f);
+
+trap_SendServerCommand( -1, va("newLapTime %i %i %i", other->s.clientNum, 1, level.time) );
+
+Rally_Sound( self, EV_GLOBAL_SOUND, CHAN_ANNOUNCER, G_SoundIndex("sound/rally/race/checkpoint.wav") );
+}
+
+void Touch_Finish (gentity_t *self, gentity_t *other, trace_t *trace ){
+char*place;
+
+if ( !other->client ) {
+return;
+}
+
+if ( other->client->lastCheckpointTime + 300 > level.time ) {
+return;
+}
+
+if ( g_developer.integer )
+G_Printf( "Client %i touched the finish line.\n", other->s.clientNum );
+
+if ( self->number != other->number ) {
+return;
+}
+
+other->client->lastCheckpointTime = level.time;
+other->client->finishRaceTime = level.time;
+other->s.weapon = WP_NONE;
+other->takedamage = qfalse;
+
+trap_SendServerCommand( -1, va("raceFinishTime %i %i", other->s.clientNum, other->client->finishRaceTime) );
+
+if ( !level.finishRaceTime ){
+other->client->ps.stats[STAT_POSITION] = 1;
+
+level.winnerNumber = other->s.clientNum;
+level.finishRaceTime = level.time;
+trap_SendServerCommand( -1, va("print \"%s won the race!\n\"", other->client->pers.netname ));
+trap_SendServerCommand( level.winnerNumber, "cp \"You won the race!\n\"");
+}
+else {
+switch ( other->client->ps.stats[STAT_POSITION] ){
+case 1:
+place = "first";
+break;
+case 2:
+place = "second";
+break;
+case 3:
+place = "third";
+break;
+case 4:
+place = "forth";
+break;
+case 5:
+place = "fifth";
+break;
+case 6:
+place = "sixth";
+break;
+case 7:
+place = "seventh";
+break;
+case 8:
+place = "eighth";
+break;
+default:
+place = NULL;
+Com_Printf( "Unknown placing: %i
+", other->client->ps.stats[STAT_POSITION] );
+break;
+}
+
+if ( other->client->ps.stats[STAT_POSITION] <= 8 ){
+trap_SendServerCommand( -1, va("print \"%s finished the race in %s place!\n\"", other->client->pers.netname, place ));
+}
+else {
+trap_SendServerCommand( -1, va("print \"%s finished the race!\n\"", other->client->pers.netname ));
+}
+}
+}
+
+void Touch_Start (gentity_t *self, gentity_t *other, trace_t *trace ){
+if ( !other->client ) {
+return;
+}
+
+if ( other->client->lastCheckpointTime + 300 > level.time ) {
+return;
+}
+
+if ( g_developer.integer )
+G_Printf( "Client %i touched the start line.\n", other->s.clientNum );
+
+other->client->lastCheckpointTime = level.time;
+other->number = 1;
+other->client->ps.stats[STAT_NEXT_CHECKPOINT] = other->number;
+other->client->ps.stats[STAT_FRAC_TO_NEXT_CHECKPOINT] = FLOAT2SHORT(0.1f);
+
+trap_SendServerCommand( -1, va("newLapTime %i %i %i", other->s.clientNum, 1, level.time) );
+
+Rally_Sound( self, EV_GLOBAL_SOUND, CHAN_ANNOUNCER, G_SoundIndex("sound/rally/race/checkpoint.wav") );
+}
+
+void Touch_Finish (gentity_t *self, gentity_t *other, trace_t *trace ){
+char*place;
+
+if ( !other->client ) {
+return;
+}
+
+if ( other->client->lastCheckpointTime + 300 > level.time ) {
+return;
+}
+
+if ( g_developer.integer )
+G_Printf( "Client %i touched the finish line.\n", other->s.clientNum );
+
+if ( self->number != other->number ) {
+return;
+}
+
+other->client->lastCheckpointTime = level.time;
+other->client->finishRaceTime = level.time;
+other->s.weapon = WP_NONE;
+other->takedamage = qfalse;
+
+trap_SendServerCommand( -1, va("raceFinishTime %i %i", other->s.clientNum, other->client->finishRaceTime) );
+
+if ( !level.finishRaceTime ){
+other->client->ps.stats[STAT_POSITION] = 1;
+
+level.winnerNumber = other->s.clientNum;
+level.finishRaceTime = level.time;
+trap_SendServerCommand( -1, va("print \"%s won the race!\n\"", other->client->pers.netname ));
+trap_SendServerCommand( level.winnerNumber, "cp \"You won the race!\n\"");
+}
+else {
+switch ( other->client->ps.stats[STAT_POSITION] ){
+case 1:
+place = "first";
+break;
+case 2:
+place = "second";
+break;
+case 3:
+place = "third";
+break;
+case 4:
+place = "forth";
+break;
+case 5:
+place = "fifth";
+break;
+case 6:
+place = "sixth";
+break;
+case 7:
+place = "seventh";
+break;
+case 8:
+place = "eighth";
+break;
+default:
+place = NULL;
+Com_Printf( "Unknown placing: %i\n", other->client->ps.stats[STAT_POSITION] );
+break;
+}
+
+if ( other->client->ps.stats[STAT_POSITION] <= 8 ){
+trap_SendServerCommand( -1, va("print \"%s finished the race in %s place!\n\"", other->client->pers.netname, place ));
+}
+else {
+trap_SendServerCommand( -1, va("print \"%s finished the race!\n\"", other->client->pers.netname ));
+}
+}
+}
+
 void Touch_StartFinish (gentity_t *self, gentity_t *other, trace_t *trace ){
 	char	*place;
 
@@ -180,6 +373,11 @@ void Think_StartFinish( gentity_t *self ){
 	self->s.weapon = self->number;
 }
 
+void Think_Finish( gentity_t *self ){
+Think_StartFinish( self );
+self->number++;
+}
+
 
 void SP_rally_startfinish( gentity_t *ent ) {
 	ent->classname = "rally_checkpoint";
@@ -204,6 +402,37 @@ void SP_rally_startfinish( gentity_t *ent ) {
 	ent->s.frame = 0;
 
 	trap_LinkEntity (ent);
+}
+
+void SP_rally_start( gentity_t *ent ) {
+trap_SetBrushModel( ent, ent->model );
+
+level.numberOfLaps = 1;
+trap_Cvar_Set( "laplimit", "1" );
+
+ent->r.svFlags |= SVF_BROADCAST;
+ent->s.eType = ET_CHECKPOINT;
+
+ent->touch = Touch_Start;
+ent->think = Think_StartFinish;
+ent->nextthink = level.time + 100;
+ent->s.frame = 0;
+
+trap_LinkEntity (ent);
+}
+
+void SP_rally_finish( gentity_t *ent ) {
+trap_SetBrushModel( ent, ent->model );
+
+ent->r.svFlags |= SVF_BROADCAST;
+ent->s.eType = ET_CHECKPOINT;
+
+ent->touch = Touch_Finish;
+ent->think = Think_Finish;
+ent->nextthink = level.time + 100;
+ent->s.frame = 0;
+
+trap_LinkEntity (ent);
 }
 
 //

--- a/engine/code/game/g_spawn.c
+++ b/engine/code/game/g_spawn.c
@@ -198,6 +198,8 @@ void SP_item_botroam( gentity_t *ent ) { }
 
 // STONELANCE
 void SP_rally_startfinish( gentity_t *ent );
+void SP_rally_start( gentity_t *ent );
+void SP_rally_finish( gentity_t *ent );
 void SP_rally_checkpoint( gentity_t *ent );
 
 void SP_rally_sun( gentity_t *ent );
@@ -303,8 +305,10 @@ spawn_t	spawns[] = {
 	{"item_botroam", SP_item_botroam},
 
 // STONELANCE
-	{"rally_startfinish", SP_rally_startfinish},
-	{"rally_checkpoint", SP_rally_checkpoint},
+{"rally_start", SP_rally_start},
+{"rally_finish", SP_rally_finish},
+{"rally_startfinish", SP_rally_startfinish},
+{"rally_checkpoint", SP_rally_checkpoint},
 
 	{"rally_sun", SP_rally_sun},
 

--- a/tools/radiant-config/radiant15-netradiant/q3rally.game/baseq3r/entities.def
+++ b/tools/radiant-config/radiant15-netradiant/q3rally.game/baseq3r/entities.def
@@ -2507,7 +2507,25 @@ Q3Rally Entities
 
 */
 
+/*QUAKED rally_start (0 .9 .1) ?
+
+Single lap start line. Sets the race to one lap and begins timing when crossed.
+"origin"        position of the player when they respawn
+"angle"         angle of player when they respawn after death
+
+*/
+
+/*QUAKED rally_finish (0 .9 .1) ?
+
+Race finish line for single lap tracks. Place after the last checkpoint.
+"origin"        position of the player when they respawn
+"angle"         angle of player when they respawn after death
+
+*/
+
 /*QUAKED rally_checkpoint (0 .9 .1) ?
+
+Used between rally_start and rally_finish to mark progress.
 
 "number"	number of the checkpoint, default is 1
 "origin"	position of the player when they respawn


### PR DESCRIPTION
## Summary
- Support one-off rally runs with new `Touch_Start` and `Touch_Finish` handlers and spawn points
- Register `rally_start`/`rally_finish` map entities and simplify HUD lap display for single runs
- Document mapping for start, finish and checkpoints in `entities.def`

## Testing
- `make` *(fails: SDL_version.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68ad3a8b361c8324a6250a00f3cb066e