### PR TITLE
Fix newline in race placing message

### DIFF
--- a/engine/code/game/g_rally_mapents.c
+++ b/engine/code/game/g_rally_mapents.c
@@ -115,8 +115,7 @@ place = "eighth";
 break;
 default:
 place = NULL;
-Com_Printf( "Unknown placing: %i
-", other->client->ps.stats[STAT_POSITION] );
+Com_Printf( "Unknown placing: %i\n", other->client->ps.stats[STAT_POSITION] );
 break;
 }
 


### PR DESCRIPTION
## Summary
- replace broken unknown placing print with single line including newline

## Testing
- `make -C engine/code/game/tests run`


------
https://chatgpt.com/codex/tasks/task_e_68adf4e3ed7083249d548ef562d2432c