### PR TITLE
Hide lap details in single-lap races

### DIFF
--- a/engine/code/cgame/cg_rally_hud.c
+++ b/engine/code/cgame/cg_rally_hud.c
@@ -380,7 +380,7 @@ static float CG_DrawTimes( float y ) {
 // Best Time
 //
   
-	if ( cgs.gametype != GT_DERBY && cgs.gametype != GT_LCS ){
+        if ( cgs.laplimit > 1 && cgs.gametype != GT_DERBY && cgs.gametype != GT_LCS ){
 		time = getStringForTime( cent->bestLapTime );
 		
 		Com_sprintf(s, sizeof(s), "B: %s", time);
@@ -399,7 +399,7 @@ static float CG_DrawTimes( float y ) {
 
 	
 
-	if ( cgs.gametype != GT_DERBY && cgs.gametype != GT_LCS ){
+        if ( cgs.laplimit > 1 && cgs.gametype != GT_DERBY && cgs.gametype != GT_LCS ){
 		time = getStringForTime(lapTime);
 
 		Com_sprintf(s, sizeof(s), "L: %s", time);

--- a/engine/code/cgame/cg_rally_hud2.c
+++ b/engine/code/cgame/cg_rally_hud2.c
@@ -63,24 +63,26 @@ void CG_DrawHUD_Times(float x, float y){
 
 	y += 20;
 
-	// draw lap time
-	CG_DrawSmallDigitalStringColor(x + 12, y, "LAP:", colorWhite);
-	time = getStringForTime( lapTime );
-	CG_DrawSmallDigitalStringColor(x + 102, y, time, colorWhite);
+        if ( cgs.laplimit > 1 ){
+                // draw lap time
+                CG_DrawSmallDigitalStringColor(x + 12, y, "LAP:", colorWhite);
+                time = getStringForTime( lapTime );
+                CG_DrawSmallDigitalStringColor(x + 102, y, time, colorWhite);
 
-	y += 20;
+                y += 20;
 
-	// draw last lap time
-	CG_DrawSmallDigitalStringColor(x + 12, y, "LAST:", colorWhite);
-	if ( lastTime ){
-		time = getStringForTime( lastTime );
-		CG_DrawSmallDigitalStringColor(x + 102, y, time, colorWhite);
-	}
-	else {
-		CG_DrawSmallDigitalStringColor(x + 102, y, "N/A", colorWhite);
-	}
+                // draw last lap time
+                CG_DrawSmallDigitalStringColor(x + 12, y, "LAST:", colorWhite);
+                if ( lastTime ){
+                        time = getStringForTime( lastTime );
+                        CG_DrawSmallDigitalStringColor(x + 102, y, time, colorWhite);
+                }
+                else {
+                        CG_DrawSmallDigitalStringColor(x + 102, y, "N/A", colorWhite);
+                }
 
-	y += 20;
+                y += 20;
+        }
 
 	// draw total time
 	CG_DrawSmallDigitalStringColor(x + 12, y, "TOTAL:", colorWhite);


### PR DESCRIPTION
## Summary
- gate Best and Lap time drawing behind `cgs.laplimit > 1`
- skip lap and last time sections on HUD when only one lap is allowed

## Testing
- `make` *(fails: SDL_version.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68ae19ada4288324b90bbe64a6bb16bc