### PR TITLE
Hide lap-time column when laplimit <= 1

### DIFF
--- a/engine/code/cgame/cg_scoreboard.c
+++ b/engine/code/cgame/cg_scoreboard.c
@@ -179,7 +179,12 @@ static void CG_InitScoreboardColumns(void) {
             showScore = qtrue;
             break;
     }
-    
+
+    /* Hide lap time column for A-to-B style races */
+    if (cgs.laplimit <= 1) {
+        showLapTimes = qfalse;
+    }
+
     /* Configure base columns (always visible) */
     columns[SBCOL_RANK].type = SBCOL_RANK;
     columns[SBCOL_RANK].width = COL_RANK_WIDTH;


### PR DESCRIPTION
## Summary
- Hide the BEST lap column for A-to-B style races by disabling lap-time display when `laplimit` is set to 1.
- Scoreboard layout automatically recalculates based on visible columns, ensuring the RACE TIME column centers correctly.

## Testing
- ⚠️ `make -C engine release BUILD_GAME_SO=0 BUILD_SERVER=0` *(fails: SDL_version.h missing)*


------
https://chatgpt.com/codex/tasks/task_e_68ae1c998864832481b57ca80a16b6bd