### PR TITLE
Add distance to finish HUD feature

### DIFF
--- a/engine/code/cgame/cg_local.h
+++ b/engine/code/cgame/cg_local.h
@@ -1291,6 +1291,7 @@ typedef struct {
 
 // Q3Rally Code Start
 	int				numRacers;
+        float                   trackLength;
 // Q3Rally Code END
 
 } cgs_t;
@@ -1437,6 +1438,7 @@ extern	vmCvar_t		cg_mmap_fov;
 extern	vmCvar_t		cg_mmap_size;
 extern	vmCvar_t		cg_mmap_renderLevel;
 extern	vmCvar_t		cg_checkpointArrowMode;
+extern      vmCvar_t                cg_distanceFormat;
 
 extern	vmCvar_t		cg_atmosphericLevel;
 extern	vmCvar_t		cg_developer;

--- a/engine/code/cgame/cg_main.c
+++ b/engine/code/cgame/cg_main.c
@@ -254,8 +254,9 @@ vmCvar_t	cg_controlMode;
 vmCvar_t	cg_manualShift;
 vmCvar_t	cg_minSkidLength;
 vmCvar_t	cg_drawRearView;
-vmCvar_t	cg_checkpointArrowMode;
-vmCvar_t	cg_drawMMap;	//TBB - minimap cvar
+vmCvar_t        cg_checkpointArrowMode;
+vmCvar_t        cg_distanceFormat;
+vmCvar_t        cg_drawMMap;	//TBB - minimap cvar
 vmCvar_t	cg_mmap_fov;
 vmCvar_t	cg_mmap_size;
 vmCvar_t	cg_mmap_renderLevel;
@@ -367,8 +368,9 @@ static cvarTable_t cvarTable[] = {
 	{ &cg_controlMode, "cg_controlMode", "0", CVAR_ARCHIVE | CVAR_USERINFO },
 	{ &cg_manualShift, "cg_manualShift", "0", CVAR_ARCHIVE | CVAR_USERINFO },
 	{ &cg_checkpointArrowMode, "cg_checkpointArrowMode", "1", CVAR_ARCHIVE },
+        { &cg_distanceFormat, "cg_distanceFormat", "0", CVAR_ARCHIVE },
 
-	{ &cg_developer, "developer", "0", 0 },
+        { &cg_developer, "developer", "0", 0 },
 
 	{ &cg_atmosphericLevel, "cg_atmosphericLevel", "2", CVAR_ARCHIVE },
 

--- a/engine/code/cgame/cg_rally_hud.c
+++ b/engine/code/cgame/cg_rally_hud.c
@@ -480,6 +480,35 @@ static float CG_DrawLaps( float y ) {
 
 /*
 ======================
+CG_DrawDistanceToFinish
+======================
+*/
+static float CG_DrawDistanceToFinish( float y ) {
+        char            s[64];
+        int             x;
+        float           dist;
+
+        dist = cg.snap->ps.stats[STAT_DISTANCE_REMAIN];
+
+        if ( cg_distanceFormat.integer == 1 && cgs.trackLength > 0.0f ) {
+                float percent = dist / cgs.trackLength * 100.0f;
+                Com_sprintf( s, sizeof( s ), "DIST: %.1f%%", percent );
+        } else {
+                Com_sprintf( s, sizeof( s ), "DIST: %dm", (int)dist );
+        }
+
+        x = 636 - 80;
+        CG_FillRect( x, y, 90, 18, bgColor );
+        x += 10;
+        y += 4;
+        CG_DrawTinyDigitalStringColor( x, y, s, colorWhite );
+        y += TINYCHAR_HEIGHT + 4;
+
+        return y;
+}
+
+/*
+======================
 CG_DrawCurrentPosition
 ======================
 */
@@ -863,7 +892,8 @@ float CG_DrawUpperRightHUD( float y ) {
 			y = CG_DrawArrowToCheckpoint( y );
 			y = CG_DrawTimes( y );
 			y = CG_DrawLaps( y );
-			y = CG_DrawCurrentPosition( y );
+			y = CG_DrawDistanceToFinish( y );
+                        y = CG_DrawCurrentPosition( y );
 			y = CG_DrawCarAheadAndBehind( y );
 		}
 		else if (cgs.gametype == GT_DERBY || cgs.gametype == GT_LCS )

--- a/engine/code/cgame/cg_servercmds.c
+++ b/engine/code/cgame/cg_servercmds.c
@@ -277,11 +277,12 @@ void CG_SetConfigValues( void ) {
 	cgs.scores1 = atoi( CG_ConfigString( CS_SCORES1 ) );
 	cgs.scores2 = atoi( CG_ConfigString( CS_SCORES2 ) );
 // Q3Rally Code Start
-	cgs.scores3 = atoi( CG_ConfigString( CS_SCORES3 ) );
-	cgs.scores4 = atoi( CG_ConfigString( CS_SCORES4 ) );
+cgs.scores3 = atoi( CG_ConfigString( CS_SCORES3 ) );
+cgs.scores4 = atoi( CG_ConfigString( CS_SCORES4 ) );
 // END
-	cgs.levelStartTime = atoi( CG_ConfigString( CS_LEVEL_START_TIME ) );
-	if( cgs.gametype == GT_CTF ) {
+cgs.levelStartTime = atoi( CG_ConfigString( CS_LEVEL_START_TIME ) );
+cgs.trackLength = atof( CG_ConfigString( CS_TRACKLENGTH ) );
+if( cgs.gametype == GT_CTF ) {
 		s = CG_ConfigString( CS_FLAGSTATUS );
 		cgs.redflag = s[0] - '0';
 		cgs.blueflag = s[1] - '0';
@@ -377,11 +378,13 @@ static void CG_ConfigStringModified( void ) {
 // Q3Rally Code Start
 	} else if ( num == CS_SCORES3 ) {
 		cgs.scores3 = atoi( str );
-	} else if ( num == CS_SCORES4 ) {
-		cgs.scores4 = atoi( str );
+        } else if ( num == CS_SCORES4 ) {
+                cgs.scores4 = atoi( str );
 // END
-	} else if ( num == CS_LEVEL_START_TIME ) {
-		cgs.levelStartTime = atoi( str );
+        } else if ( num == CS_TRACKLENGTH ) {
+                cgs.trackLength = atof( str );
+        } else if ( num == CS_LEVEL_START_TIME ) {
+                cgs.levelStartTime = atoi( str );
 	} else if ( num == CS_VOTE_TIME ) {
 		cgs.voteTime = atoi( str );
 		cgs.voteModified = qtrue;

--- a/engine/code/game/bg_public.h
+++ b/engine/code/game/bg_public.h
@@ -104,6 +104,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #define CS_SCORES4                              28
 #define CS_REFLECTION_IMAGE             29
 #define CS_SIGILSTATUS                  30
+#define CS_TRACKLENGTH                  31
 // Q3Rally Code END
 
 #define CS_MODELS                               32
@@ -331,7 +332,8 @@ typedef enum {
         STAT_DAMAGE_TAKEN, // STONELANCE - really need this one?
         STAT_NEXT_CHECKPOINT,
         STAT_POSITION,
-        STAT_FRAC_TO_NEXT_CHECKPOINT
+        STAT_FRAC_TO_NEXT_CHECKPOINT,
+        STAT_DISTANCE_REMAIN
 // END
 } statIndex_t;
 

--- a/engine/code/game/g_active.c
+++ b/engine/code/game/g_active.c
@@ -1554,6 +1554,30 @@ void ClientThink_real( gentity_t *ent ) {
 	// touch other objects
 	ClientImpacts( ent, &pm );
 
+        if ( level.trackLength > 0.0f && level.numCheckpoints > 0 ) {
+                int next = client->ps.stats[STAT_NEXT_CHECKPOINT];
+                if ( next > 0 && next <= level.numCheckpoints ) {
+                        gentity_t *cp = level.checkpoints[next-1];
+                        if ( cp ) {
+                                vec3_t v;
+                                float dist, segs;
+                                VectorSubtract( cp->s.origin, client->ps.origin, v );
+                                dist = VectorLength( v );
+                                segs = level.cpDist[level.numCheckpoints-1] - level.cpDist[next-1];
+                                dist += segs;
+                                if ( level.numberOfLaps && ent->currentLap < level.numberOfLaps ) {
+                                        int lapsRemaining = level.numberOfLaps - ent->currentLap;
+                                        dist += lapsRemaining * level.trackLength;
+                                }
+                                client->ps.stats[STAT_DISTANCE_REMAIN] = (int)( dist / CP_M_2_QU );
+                        }
+                } else {
+                        client->ps.stats[STAT_DISTANCE_REMAIN] = 0;
+                }
+        } else {
+                client->ps.stats[STAT_DISTANCE_REMAIN] = 0;
+        }
+
 	// save results of triggers and client events
 	if (ent->client->ps.eventSequence != oldEventSequence) {
 		ent->eventTime = level.time;

--- a/engine/code/game/g_local.h
+++ b/engine/code/game/g_local.h
@@ -521,7 +521,11 @@ typedef struct {
 	// map variables
 	int			numCheckpoints;
 
-	int			testModelID;
+        float                   cpDist[MAX_GENTITIES];
+        gentity_t       *checkpoints[MAX_GENTITIES];
+        float                   trackLength;
+
+        int                     testModelID;
 // END
 } level_locals_t;
 

--- a/engine/code/game/g_rally_mapents.c
+++ b/engine/code/game/g_rally_mapents.c
@@ -263,18 +263,46 @@ void Think_StartFinish( gentity_t *self ){
 
 	checkpoints = 0;
 
-	ent = NULL;
-	while ((ent = G_Find (ent, FOFS(classname), "rally_checkpoint")) != NULL) checkpoints++;
-	level.numCheckpoints = checkpoints;
-	if (g_trackReversed.integer && level.trackIsReversable){
-		ent = NULL;
-		while ((ent = G_Find (ent, FOFS(classname), "rally_checkpoint")) != NULL) {
-			ent->number = level.numCheckpoints - ent->number;
-		}
-	}
+        ent = NULL;
+        while ((ent = G_Find (ent, FOFS(classname), "rally_checkpoint")) != NULL) checkpoints++;
+        level.numCheckpoints = checkpoints;
+        if (g_trackReversed.integer && level.trackIsReversable){
+                ent = NULL;
+                while ((ent = G_Find (ent, FOFS(classname), "rally_checkpoint")) != NULL) {
+                        ent->number = level.numCheckpoints - ent->number;
+                }
+        }
 
-	self->number = level.numCheckpoints;
-	self->s.weapon = self->number;
+        memset( level.checkpoints, 0, sizeof( level.checkpoints ) );
+        memset( level.cpDist, 0, sizeof( level.cpDist ) );
+        ent = NULL;
+        while ( ( ent = G_Find( ent, FOFS(classname), "rally_checkpoint" ) ) != NULL ) {
+                if ( ent->number > 0 && ent->number <= level.numCheckpoints ) {
+                        level.checkpoints[ ent->number - 1 ] = ent;
+                }
+        }
+
+        level.trackLength = 0.0f;
+        if ( level.numCheckpoints > 0 ) {
+                vec3_t last, first, delta;
+                int i;
+
+                VectorCopy( level.checkpoints[0]->s.origin, first );
+                VectorCopy( first, last );
+                level.cpDist[0] = 0.0f;
+                for ( i = 1; i < level.numCheckpoints; i++ ) {
+                        VectorSubtract( last, level.checkpoints[i]->s.origin, delta );
+                        level.cpDist[i] = level.cpDist[i-1] + VectorLength( delta );
+                        VectorCopy( level.checkpoints[i]->s.origin, last );
+                }
+                VectorSubtract( last, first, delta );
+                level.trackLength = level.cpDist[level.numCheckpoints-1] + VectorLength( delta );
+        }
+
+        trap_SetConfigstring( CS_TRACKLENGTH, va( "%i", (int)( level.trackLength / CP_M_2_QU ) ) );
+
+        self->number = level.numCheckpoints;
+        self->s.weapon = self->number;
 }
 
 void Think_Finish( gentity_t *self ){


### PR DESCRIPTION
## Summary
- compute track segment distances at map load and expose total track length
- track remaining race distance and send to clients via STAT_DISTANCE_REMAIN
- draw distance-to-finish on HUD with configurable meter/percent format

## Testing
- `make` *(fails: SDL_version.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68ae1f8c56848324ad7bbd2042863a70