### PR TITLE
Add developer debug log for track length

### DIFF
--- a/engine/code/game/g_rally_mapents.c
+++ b/engine/code/game/g_rally_mapents.c
@@ -299,6 +299,12 @@ void Think_StartFinish( gentity_t *self ){
                 level.trackLength = level.cpDist[level.numCheckpoints-1] + VectorLength( delta );
         }
 
+        if ( g_developer.integer ) {
+                G_Printf("[DEBUG:] Track length = %i qu (%.1f m)\n",
+                        level.trackLength,
+                        (float)level.trackLength / CP_M_2_QU);
+        }
+
         trap_SetConfigstring( CS_TRACKLENGTH, va( "%i", (int)( level.trackLength / CP_M_2_QU ) ) );
 
         self->number = level.numCheckpoints;


### PR DESCRIPTION
## Summary
- print track length in start/finish logic when `g_developer` is enabled

## Testing
- `cd engine && make` *(fails: SDL_version.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68ae2b4fff608324b17758aad4924fd1