### PR TITLE
Add scripted object gibs support

### DIFF
--- a/engine/code/cgame/cg_local.h
+++ b/engine/code/cgame/cg_local.h
@@ -188,6 +188,9 @@ typedef struct {
 
 // centity_t have a direct corespondence with gentity_t in the game, but
 // only the entityState_t is directly communicated to the cgame
+
+// number of gib models that can be registered for a scripted object
+#define MAX_SCRIPT_GIBS       5
 typedef struct centity_s {
 	entityState_t	currentState;	// from cg.frame
 	entityState_t	nextState;		// from cg.nextFrame, if available
@@ -261,6 +264,11 @@ typedef struct centity_s {
 
 	qhandle_t		modelHandle;
 	qhandle_t		deadModelHandle;
+
+	int			numGibModels;
+	qhandle_t		gibModels[MAX_SCRIPT_GIBS];
+	qhandle_t		gibSounds[MAX_SCRIPT_GIBS];
+	qboolean		gibsSpawned;
 
 	vec3_t			bezierDir;
 	vec3_t			bezierPos;
@@ -1744,6 +1752,7 @@ void CG_ParticlesFromEntityState( vec3_t origin, int type, entityState_t *es);
 // void CG_GibPlayer( vec3_t playerOrigin );
 void CG_GibPlayer( vec3_t playerOrigin, vec3_t playerVelocity, int client );
 // Q3Rally Code END
+void CG_LaunchGib( vec3_t origin, vec3_t velocity, qhandle_t hModel, qhandle_t hSkin, float radius, qboolean carPart );
 void CG_BigExplode( vec3_t playerOrigin );
 void CG_LightningArc( vec3_t start, vec3_t end );
 void CG_BreakGlass( vec3_t playerOrigin );

--- a/engine/code/cgame/cg_rally_scripted_objects.c
+++ b/engine/code/cgame/cg_rally_scripted_objects.c
@@ -24,6 +24,8 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #include "cg_local.h"
 
 #define		MAX_SCRIPT_TEXT		8192
+#define GIB_VELOCITY 250
+#define GIB_JUMP 100
 
 qboolean SeekToSection( char **pointer, char *str ){
 	char		*token;
@@ -118,8 +120,13 @@ qboolean CG_ParseScriptedObject( centity_t *cent, const char *scriptName ){
 		return qfalse;
 	}
 
-	model[0] = 0;
-	deadmodel[0] = 0;
+       model[0] = 0;
+       deadmodel[0] = 0;
+
+       cent->numGibModels = 0;
+       cent->gibsSpawned = qfalse;
+       memset( cent->gibModels, 0, sizeof( cent->gibModels ) );
+       memset( cent->gibSounds, 0, sizeof( cent->gibSounds ) );
 
 	// read optional parameters
 	while ( 1 ) {
@@ -262,30 +269,55 @@ qboolean CG_ParseScriptedObject( centity_t *cent, const char *scriptName ){
 
 			continue;
 		}
-		else if ( !Q_stricmp( token, "gibs" ) ) {
-			// skip gibs part of script (it is only used client side)
-			token = COM_Parse( &text_p );
-			if ( !token ) {
-				break;
-			}
+               else if ( !Q_stricmp( token, "gibs" ) ) {
+                       token = COM_Parse( &text_p );
+                       if ( !token ) {
+                               break;
+                       }
 
-			if ( !Q_stricmp( token, "{" ) ){
-				// FIXME: add code to load gibs
+                       if ( !Q_stricmp( token, "{" ) ){
+                               int current = -1;
 
-				// loop through this
-				while ( 1 ) {
-					token = COM_Parse( &text_p );
+                               while ( 1 ) {
+                                       token = COM_Parse( &text_p );
 
-					if( !token || token[0] == 0 )
-						return qfalse;
+                                       if( !token || token[0] == 0 )
+                                               return qfalse;
 
-					if ( !Q_stricmp( token, "}" ) )
-						break;
-				}
-			}
+                                       if ( !Q_stricmp( token, "}" ) )
+                                               break;
 
-			continue;
-		}
+                                       if ( !Q_stricmp( token, "model" ) ) {
+                                               token = COM_Parse( &text_p );
+                                               if ( !token ) {
+                                                       break;
+                                               }
+
+                                               if ( cent->numGibModels < MAX_SCRIPT_GIBS ) {
+                                                       current = cent->numGibModels++;
+                                                       cent->gibModels[current] = trap_R_RegisterModel( token );
+                                               }
+                                               continue;
+                                       }
+
+                                       if ( !Q_stricmp( token, "sound" ) ) {
+                                               token = COM_Parse( &text_p );
+                                               if ( !token ) {
+                                                       break;
+                                               }
+
+                                               if ( current >= 0 && current < MAX_SCRIPT_GIBS ) {
+                                                       cent->gibSounds[current] = trap_S_RegisterSound( token, qfalse );
+                                               }
+                                               continue;
+                                       }
+
+                                       // skip any unknown token (like counts)
+                               }
+                       }
+
+                       continue;
+               }
 		else {
 			Com_Printf("Warning: Skipping unknown token %s in %s\n", token, filename);
 			continue;
@@ -360,19 +392,36 @@ void CG_Scripted_Object( centity_t *cent ){
 		return;
 	}
 
-	if ( !cent->scriptLoadTime ){
-		scriptName = CG_ConfigString( CS_SCRIPTS + s1->modelindex );
-		if ( !scriptName[0] ) {
-			return;
-		}
+        if ( !cent->scriptLoadTime ){
+                scriptName = CG_ConfigString( CS_SCRIPTS + s1->modelindex );
+                if ( !scriptName[0] ) {
+                        return;
+                }
 
 		if ( CG_ParseScriptedObject( cent, scriptName ) )
 			cent->scriptLoadTime = cg.time;
 		else
 			return;
-	}
+        }
 
-	memset (&ent, 0, sizeof(ent));
+       if ( (cent->currentState.eFlags & EF_DEAD) && !cent->gibsSpawned ) {
+               int i;
+               vec3_t velocity;
+
+               cent->gibsSpawned = qtrue;
+
+               for ( i = 0; i < cent->numGibModels; i++ ) {
+                       velocity[0] = crandom() * GIB_VELOCITY;
+                       velocity[1] = crandom() * GIB_VELOCITY;
+                       velocity[2] = GIB_JUMP + crandom() * GIB_VELOCITY;
+                       CG_LaunchGib( cent->lerpOrigin, velocity, cent->gibModels[i], -1, 0, qfalse );
+                       if ( cent->gibSounds[i] ) {
+                               trap_S_StartSound( cent->lerpOrigin, ENTITYNUM_WORLD, CHAN_AUTO, cent->gibSounds[i] );
+                       }
+               }
+       }
+
+        memset (&ent, 0, sizeof(ent));
 
 	if ( cent->currentState.eFlags & EF_DEAD )
 		ent.hModel = cent->deadModelHandle;


### PR DESCRIPTION
## Summary
- Parse gib models and sounds from scripted object scripts
- Store registered gib assets per entity and launch them on destruction
- Add capacity in centity_t for scripted object gibs

## Testing
- `make -C engine BUILD_CLIENT=0 BUILD_SERVER=0 BUILD_GAME_QVM=1`


------
https://chatgpt.com/codex/tasks/task_e_68af4288bfe88324a7f1b8f02a737a65