### PR TITLE
Fix deadmodel registration for scripted objects

### DIFF
--- a/engine/code/cgame/cg_rally_scripted_objects.c
+++ b/engine/code/cgame/cg_rally_scripted_objects.c
@@ -331,7 +331,7 @@ qboolean CG_ParseScriptedObject( centity_t *cent, const char *scriptName ){
 		if ( !SeekToSection( &text_p, model ) ){
 //			Com_Printf( "'%s' section not found in script file, assuming it was an actual filename\n", model );
 
-			cent->modelHandle = trap_R_RegisterModel( model );
+			cent->modelHandle = trap_R_RegisterModel( deadmodel );
 		}
 		else {
 			Com_Printf( "Loading model info for '%s'\n", model );
@@ -346,7 +346,7 @@ qboolean CG_ParseScriptedObject( centity_t *cent, const char *scriptName ){
 		if ( !SeekToSection( &text_p, deadmodel ) ){
 //			Com_Printf( "'%s' section not found in script file, assuming it was an actual filename\n", model );
 
-			cent->deadModelHandle = trap_R_RegisterModel( model );
+			cent->deadModelHandle = trap_R_RegisterModel( deadmodel );
 		}
 		else {
 			Com_Printf( "Loading deadmodel info for '%s'\n", deadmodel );


### PR DESCRIPTION
## Summary
- Correct dead model registration for scripted objects
- Ensure EF_DEAD entities render with their deadmodel

## Testing
- `make -C engine` (fails: SDL_version.h: No such file or directory)

------
https://chatgpt.com/codex/tasks/task_e_68af49037b0883249f4d93327b7b97c5