### PR TITLE
Add digital speedometer mode

### DIFF
--- a/baseq3r/default.cfg
+++ b/baseq3r/default.cfg
@@ -38,3 +38,4 @@ bind MOUSE4 "stoprecord"
 bind MOUSE5 "record"
 bind MWHEELDOWN "weapnext"
 bind MWHEELUP "weapprev"
+seta cg_speedometerMode "0" // 0 = Analog, 1 = Digital

--- a/engine/code/cgame/cg_local.h
+++ b/engine/code/cgame/cg_local.h
@@ -1440,6 +1440,7 @@ extern	vmCvar_t		cg_obeliskRespawnDelay;
 #endif
 // Q3Rally Code Start
 extern	vmCvar_t		cg_metricUnits;
+extern  vmCvar_t                cg_speedometerMode;
 extern	vmCvar_t		cg_minSkidLength;
 extern	vmCvar_t		cg_controlMode;
 extern	vmCvar_t		cg_manualShift;

--- a/engine/code/cgame/cg_main.c
+++ b/engine/code/cgame/cg_main.c
@@ -250,6 +250,7 @@ vmCvar_t	cg_obeliskRespawnDelay;
 
 // Q3Rally Code Start
 vmCvar_t	cg_metricUnits;
+vmCvar_t        cg_speedometerMode;
 vmCvar_t	cg_controlMode;
 vmCvar_t	cg_manualShift;
 vmCvar_t	cg_minSkidLength;
@@ -359,6 +360,7 @@ static cvarTable_t cvarTable[] = {
 	{ &cg_thirdPersonAngle, "cg_thirdPersonAngle", "0", 0 },
 	{ &cg_thirdPerson, "cg_thirdPerson", "1", CVAR_ROM },
 	{ &cg_metricUnits, "cg_metricUnits", "0", CVAR_ARCHIVE },
+        { &cg_speedometerMode, "cg_speedometerMode", "0", CVAR_ARCHIVE },
 	{ &cg_minSkidLength, "cg_minSkidLength", "12", CVAR_ARCHIVE },
 	{ &cg_drawRearView, "cg_drawRearView", "0", CVAR_ARCHIVE },
 	{ &cg_drawMMap, "cg_drawMMap", "1", CVAR_ARCHIVE }, //TBB minimap - default on

--- a/engine/code/cgame/cg_rally_hud.c
+++ b/engine/code/cgame/cg_rally_hud.c
@@ -704,8 +704,18 @@ static float CG_DrawSpeed( float y ) {
 
 	AngleVectors( ps->viewangles, forward, NULL, NULL );
 
-	// use actual speed
-	vel_speed = (int)fabs( Q3VelocityToRL( DotProduct(ps->velocity, forward) ) );
+        // use actual speed
+        vel_speed = (int)fabs( Q3VelocityToRL( DotProduct(ps->velocity, forward) ) );
+
+        if ( cg_speedometerMode.integer ) {
+                x -= 48 + (CG_DrawStrlen(va("%i", vel_speed)) * SMALLCHAR_WIDTH) / 2;
+                y -= 35;
+                CG_DrawSmallDigitalStringColor( x, y, va("%i", vel_speed), colorWhite);
+                y = yorg;
+                y -= 39;
+                y -= SMALLCHAR_HEIGHT;
+                return y;
+        }
 /*
 #ifdef Q3_VM
 	if (ps->stats[STAT_GEAR] == -1)

--- a/engine/code/q3_ui/ui_local.h
+++ b/engine/code/q3_ui/ui_local.h
@@ -139,6 +139,7 @@ extern vmCvar_t ui_trackReversed;
 
 
 extern vmCvar_t	ui_metricUnits;
+extern vmCvar_t     ui_speedometerMode;
 extern vmCvar_t	ui_controlMode;
 extern vmCvar_t	ui_manualShift;
 extern vmCvar_t	ui_minSkidLength;

--- a/engine/code/q3_ui/ui_main.c
+++ b/engine/code/q3_ui/ui_main.c
@@ -197,6 +197,7 @@ vmCvar_t	ui_trackReversed;
 
 
 vmCvar_t	ui_metricUnits;
+vmCvar_t        ui_speedometerMode;
 vmCvar_t	ui_controlMode;
 vmCvar_t	ui_manualShift;
 vmCvar_t	ui_minSkidLength;
@@ -302,6 +303,7 @@ static cvarTable_t		cvarTable[] = {
 	{ &ui_trackReversed, "g_trackReversed", "0", CVAR_LATCH },
 
 	{ &ui_metricUnits, "cg_metricUnits", "0", CVAR_ARCHIVE },
+        { &ui_speedometerMode, "cg_speedometerMode", "0", CVAR_ARCHIVE },
 	{ &ui_controlMode, "cg_controlMode", "0", CVAR_ARCHIVE },
 	{ &ui_manualShift, "cg_manualShift", "0", CVAR_ARCHIVE },
 	{ &ui_minSkidLength, "cg_minSkidLength", "12", CVAR_ARCHIVE },

--- a/engine/code/q3_ui/ui_rally_options.c
+++ b/engine/code/q3_ui/ui_rally_options.c
@@ -48,6 +48,7 @@ qboolean isRaceObserver( int clientNum )
 
 #define ID_MMAP_SIZE            26
 #define ID_MMAP_FOV             27
+#define ID_SPEEDOMETER_MODE     28
 
 #define ID_MVRL_PLAYERS         30
 #define ID_MVRL_OBJECTS         31
@@ -63,6 +64,7 @@ typedef struct {
 	menutext_s		banner;
 
 	menulist_s		units;
+        menulist_s              speedometer;
 	menulist_s		arrowMode;
 	menulist_s		controlMode;
 	menulist_s		atomspheric;
@@ -99,9 +101,15 @@ typedef struct {
 static q3roptionsmenu_t	s_q3roptions;
 
 static const char *q3roptions_units[] = {
-	"Imperial",
-	"Metric",
-	0
+        "Imperial",
+        "Metric",
+        0
+};
+
+static const char *q3roptions_speedometer_mode[] = {
+        "Analog",
+        "Digital",
+        0
 };
 
 static const char *q3roptions_control_mode[] = {
@@ -140,13 +148,17 @@ static void Q3ROptions_MenuEvent( void* ptr, int event ) {
 
 	switch( ((menucommon_s*)ptr)->id )
 	{
-	case ID_UNITS:
-		trap_Cvar_SetValue( "cg_metricUnits", s_q3roptions.units.curvalue );
-		break;
+        case ID_UNITS:
+                trap_Cvar_SetValue( "cg_metricUnits", s_q3roptions.units.curvalue );
+                break;
 
-	case ID_CP_ARROW_MODE:
-		trap_Cvar_SetValue( "cg_checkpointArrowMode", s_q3roptions.arrowMode.curvalue );
-		break;
+        case ID_SPEEDOMETER_MODE:
+                trap_Cvar_SetValue( "cg_speedometerMode", s_q3roptions.speedometer.curvalue );
+                break;
+
+        case ID_CP_ARROW_MODE:
+                trap_Cvar_SetValue( "cg_checkpointArrowMode", s_q3roptions.arrowMode.curvalue );
+                break;
 
 	case ID_CONTROL_MODE:
 		trap_Cvar_SetValue( "cg_controlMode", s_q3roptions.controlMode.curvalue );
@@ -254,13 +266,17 @@ static void Q3ROptions_StatusBar( void *self )
 
 	switch( ((menucommon_s*)self)->id )
 	{
-	case ID_UNITS:
-		text = "Use KPH or MPH on the speedometer.";
-		break;
+        case ID_UNITS:
+                text = "Use KPH or MPH on the speedometer.";
+                break;
 
-	case ID_CP_ARROW_MODE:
-		text = "Display options for the next checkpoint arrow.";
-		break;
+        case ID_SPEEDOMETER_MODE:
+                text = "Select analog or digital speedometer.";
+                break;
+
+        case ID_CP_ARROW_MODE:
+                text = "Display options for the next checkpoint arrow.";
+                break;
 
 	case ID_CONTROL_MODE:
 		if( s_q3roptions.controlMode.curvalue == 0 )
@@ -369,8 +385,9 @@ void Q3ROptions_MenuInit( void ) {
 
 
 	// load current values
-	s_q3roptions.units.curvalue = ui_metricUnits.integer;
-	s_q3roptions.arrowMode.curvalue = ui_checkpointArrowMode.integer;
+        s_q3roptions.units.curvalue = ui_metricUnits.integer;
+        s_q3roptions.speedometer.curvalue = ui_speedometerMode.integer;
+        s_q3roptions.arrowMode.curvalue = ui_checkpointArrowMode.integer;
 	s_q3roptions.controlMode.curvalue = ui_controlMode.integer;
 	s_q3roptions.atomspheric.curvalue = ui_atmosphericLevel.integer;
 
@@ -454,6 +471,16 @@ void Q3ROptions_MenuInit( void ) {
 	s_q3roptions.atomspheric.generic.x			= 200;
 	s_q3roptions.atomspheric.generic.y			= 90 + 60;
 	s_q3roptions.atomspheric.itemnames			= q3roptions_atmospheric;
+        s_q3roptions.speedometer.generic.type           = MTYPE_SPINCONTROL;
+        s_q3roptions.speedometer.generic.name           = "Speedometer Mode:";
+        s_q3roptions.speedometer.generic.flags          = QMF_PULSEIFFOCUS|QMF_SMALLFONT;
+        s_q3roptions.speedometer.generic.callback       = Q3ROptions_MenuEvent;
+        s_q3roptions.speedometer.generic.statusbar      = Q3ROptions_StatusBar;
+        s_q3roptions.speedometer.generic.id             = ID_SPEEDOMETER_MODE;
+        s_q3roptions.speedometer.generic.x              = 200;
+        s_q3roptions.speedometer.generic.y              = 90 + 80;
+        s_q3roptions.speedometer.itemnames              = q3roptions_speedometer_mode;
+
 
 
 
@@ -683,6 +710,7 @@ void Q3ROptions_MenuInit( void ) {
 	Menu_AddItem( &s_q3roptions.menu, ( void * ) &s_q3roptions.arrowMode );
 	Menu_AddItem( &s_q3roptions.menu, ( void * ) &s_q3roptions.controlMode );
 	Menu_AddItem( &s_q3roptions.menu, ( void * ) &s_q3roptions.atomspheric );
+        Menu_AddItem( &s_q3roptions.menu, ( void * ) &s_q3roptions.speedometer );
 
 	Menu_AddItem( &s_q3roptions.menu, ( void * ) &s_q3roptions.manualShift );
 	Menu_AddItem( &s_q3roptions.menu, ( void * ) &s_q3roptions.rearView );


### PR DESCRIPTION
## Summary
- add `cg_speedometerMode` cvar for choosing analog or digital speed display
- support digital-only speedometer rendering in HUD
- expose Speedometer Mode toggle in options menu with default analog setting

## Testing
- `make` *(fails: build interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_68af5da5dc6c8324ab77455a8533ae24