### PR TITLE
Implement headlight toggling and flags

### DIFF
--- a/engine/code/game/bg_misc.c
+++ b/engine/code/game/bg_misc.c
@@ -2026,10 +2026,12 @@ void BG_PlayerStateToEntityState( playerState_t *ps, entityState_t *s, qboolean 
 	else if ( ps->stats[STAT_HEALTH] <= 50 )
 		s->eFlags |= EF_SMOKE_LIGHT;
 
-	if (ps->extra_eFlags & CF_REVERSE)
-		s->eFlags |= EF_REVERSE;
-	if (ps->extra_eFlags & CF_BRAKE)
-		s->eFlags |= EF_BRAKE;
+        if (ps->extra_eFlags & CF_REVERSE)
+                s->eFlags |= EF_REVERSE;
+        if (ps->extra_eFlags & CF_BRAKE)
+                s->eFlags |= EF_BRAKE;
+        if (ps->extra_eFlags & CF_HEADLIGHTS)
+                s->eFlags |= EF_HEADLIGHTS;
 // END
 
 	if ( ps->externalEvent ) {

--- a/engine/code/game/bg_physics.h
+++ b/engine/code/game/bg_physics.h
@@ -157,6 +157,7 @@ extern	float CP_GEAR_RATIOS[];
 
 #define CF_REVERSE			1
 #define CF_BRAKE			2
+#define CF_HEADLIGHTS                   4
 
 // assign sign bit of b to a, floats only
 // #define SetSign(a,b)		(*(DWORD *)&(a)) = ((*(DWORD *)&(b)) & 0x80000000) | ((*(DWORD *)&(a)) & 0x7FFFFFFF)

--- a/engine/code/game/bg_public.h
+++ b/engine/code/game/bg_public.h
@@ -390,6 +390,7 @@ typedef enum {
 #define EF_BOUNCE_HALF                  0x00800000              // for missiles
 #define EF_BOUNCE_NONE                  0x01000000              // for mines
 #define EF_MOVER_STOP                   0x02000000              // will push otherwise
+#define EF_HEADLIGHTS                   0x04000000
 
 // NOTE: may not have more than 16
 typedef enum {

--- a/engine/code/game/g_cmds.c
+++ b/engine/code/game/g_cmds.c
@@ -2026,14 +2026,27 @@ void Cmd_MoveBHandle_f( gentity_t *other )
 
 	Com_Printf( "Moving Checkpoint %i by (%f %f %f)\n", curCheckpoint, delta[0], delta[1], delta[2] );
 
-	while ((ent = G_Find (ent, FOFS(classname), "rally_checkpoint")) != NULL) {
-		if ( ent->number == curCheckpoint )
-		{
-			VectorAdd( ent->s.angles2, delta, ent->s.angles2 );
+        while ((ent = G_Find (ent, FOFS(classname), "rally_checkpoint")) != NULL) {
+                if ( ent->number == curCheckpoint )
+                {
+                        VectorAdd( ent->s.angles2, delta, ent->s.angles2 );
 
-			break;
-		}
-	}
+                        break;
+                }
+        }
+}
+
+void Cmd_Headlight_Toggle_f( gentity_t *ent ) {
+       if ( !ent->client ) {
+               return;
+       }
+
+       ent->client->ps.extra_eFlags ^= CF_HEADLIGHTS;
+       if ( ent->client->ps.extra_eFlags & CF_HEADLIGHTS ) {
+               ent->s.eFlags |= EF_HEADLIGHTS;
+       } else {
+               ent->s.eFlags &= ~EF_HEADLIGHTS;
+       }
 }
 // END
 
@@ -2189,20 +2202,18 @@ void ClientCommand( int clientNum ) {
 
 		G_PrintMapStats( ent, atoi(buffer), name );
 	}
-	else if (Q_stricmp (cmd, "times") == 0) {
-		Cmd_Times_f (ent);
-		return;
-	}
-/*
-	else if (Q_stricmp (cmd, "headlights") == 0) {
-		Cmd_Headlight_Toggle_f (ent);
-		return;
-	}
-*/
-	else if (Q_stricmp (cmd, "saveBPoints") == 0) {
-		Cmd_SaveBPoints_f (ent);
-		return;
-	}
+        else if (Q_stricmp (cmd, "times") == 0) {
+                Cmd_Times_f (ent);
+                return;
+        }
+        else if (Q_stricmp (cmd, "headlights") == 0) {
+                Cmd_Headlight_Toggle_f (ent);
+                return;
+        }
+        else if (Q_stricmp (cmd, "saveBPoints") == 0) {
+                Cmd_SaveBPoints_f (ent);
+                return;
+        }
 	else if (Q_stricmp (cmd, "moveBPoint") == 0) {
 		Cmd_MoveBPoint_f (ent);
 		return;


### PR DESCRIPTION
## Summary
- add `CF_HEADLIGHTS` and `EF_HEADLIGHTS` to track headlight state
- implement `Cmd_Headlight_Toggle_f` and expose `headlights` client command
- propagate headlight flag in player state to entity state

## Testing
- `make` *(fails: SDL_version.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68afda39135883248dfb39fd277d3841