### PR TITLE
Enhance headlight beam lighting

### DIFF
--- a/engine/code/cgame/cg_players.c
+++ b/engine/code/cgame/cg_players.c
@@ -3934,13 +3934,8 @@ void CG_Player( centity_t *cent ) {
 	//
 	// add the headlights
 	//
-        VectorMA(body.origin, 200, body.axis[0], dir);
-        VectorMA(dir, 75, body.axis[1], dir);
-        trap_R_AddAdditiveLightToScene( dir, 200, 0.3f, 0.3f, 0.3f );
-        VectorMA(dir, -150, body.axis[1], dir);
-        trap_R_AddAdditiveLightToScene( dir, 200, 0.3f, 0.3f, 0.3f );
-        if (cent->currentState.eFlags & EF_HEADLIGHTS &&
-                !(cent->currentState.powerups & ( 1 << PW_INVIS ))) {
+       if (cent->currentState.eFlags & EF_HEADLIGHTS &&
+               !(cent->currentState.powerups & ( 1 << PW_INVIS ))) {
 
 		headlight.hModel = cgs.media.headLightGlow;
 		if (!headlight.hModel) {
@@ -3951,15 +3946,28 @@ void CG_Player( centity_t *cent ) {
 		headlight.shadowPlane = shadowPlane;
 		headlight.renderfx = renderfx;
 
-		for (i = 0; i < 4; i++){
-			Com_sprintf(filename, sizeof(filename), "tag_hlite%d", i+1);
-			if (!CG_TagExists(ci->bodyModel, filename)) continue;
+               for (i = 0; i < 4; i++){
+                       vec3_t beamPos;
 
-                        CG_PositionEntityOnTag( &headlight, &body, ci->bodyModel, filename);
-                        trap_R_AddAdditiveLightToScene( headlight.origin, 200, 0.3f, 0.3f, 0.3f );
-                        trap_R_AddRefEntityToScene( &headlight );
-		}
-	}
+                       Com_sprintf(filename, sizeof(filename), "tag_hlite%d", i+1);
+                       if (!CG_TagExists(ci->bodyModel, filename)) continue;
+
+                       CG_PositionEntityOnTag( &headlight, &body, ci->bodyModel, filename);
+
+                       // place stronger light slightly in front of the tag
+                       VectorMA( headlight.origin, 100, headlight.axis[0], beamPos );
+                       trap_R_AddAdditiveLightToScene( beamPos, 400, 1.0f, 1.0f, 1.0f );
+
+                       // additional lights further ahead with decreasing intensity
+                       VectorMA( headlight.origin, 200, headlight.axis[0], beamPos );
+                       trap_R_AddAdditiveLightToScene( beamPos, 250, 0.7f, 0.7f, 0.7f );
+                       VectorMA( headlight.origin, 300, headlight.axis[0], beamPos );
+                       trap_R_AddAdditiveLightToScene( beamPos, 150, 0.5f, 0.5f, 0.5f );
+
+                       trap_R_AddAdditiveLightToScene( headlight.origin, 200, 0.3f, 0.3f, 0.3f );
+                       trap_R_AddRefEntityToScene( &headlight );
+               }
+       }
 
 	//
 	// add the red and blue lights for emergency vehicles


### PR DESCRIPTION
## Summary
- Remove generic front lights and compute per-tag beam positions.
- Add stronger forward lights with decreasing intensity to simulate longer headlight cones.

## Testing
- `make` *(fails: SDL_version.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b0ac61f47c832484175109f081f706