### PR TITLE
Reduce additive backlight intensity

### DIFF
--- a/engine/code/cgame/cg_players.c
+++ b/engine/code/cgame/cg_players.c
@@ -4012,7 +4012,7 @@ VectorCopy( cent->lerpOrigin, backlight.lightingOrigin );
 
         /* Single additive red light cast along the vehicle backward axis */
         VectorMA( backlight.origin, 50, back, beamPos );
-        trap_R_AddAdditiveLightToScene( beamPos, 100, 1.0f, 0.0f, 0.0f );
+        trap_R_AddAdditiveLightToScene( beamPos, 80, 0.6f, 0.0f, 0.0f );
 
         /* Render the backlight glow model itself at the tag */
         trap_R_AddRefEntityToScene( &backlight );


### PR DESCRIPTION
## Summary
- Dim vehicle backlight effect by reducing radius and red component

## Testing
- `make -C engine release BUILD_GAME_SO=0 BUILD_SERVER=0` *(fails: SDL_version.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b0c62d3a3c8324bf82276e9f4ee072