### PR TITLE
Reduce additive backlight intensity

### DIFF
--- a/engine/code/cgame/cg_players.c
+++ b/engine/code/cgame/cg_players.c
@@ -4012,7 +4012,7 @@ VectorCopy( cent->lerpOrigin, backlight.lightingOrigin );
 
         /* Single additive red light cast along the vehicle backward axis */
         VectorMA( backlight.origin, 50, back, beamPos );
-        trap_R_AddAdditiveLightToScene( beamPos, 100, 1.0f, 0.0f, 0.0f );
+        trap_R_AddAdditiveLightToScene( beamPos, 80, 0.6f, 0.0f, 0.0f );
 
         /* Render the backlight glow model itself at the tag */
         trap_R_AddRefEntityToScene( &backlight );

--- a/engine/code/game/g_client.c
+++ b/engine/code/game/g_client.c
@@ -1493,10 +1493,15 @@ void ClientSpawn(gentity_t *ent) {
 		client->pers.maxHealth = 100;
 	}
 	// clear entity values
-	client->ps.stats[STAT_MAX_HEALTH] = client->pers.maxHealth;
-	client->ps.eFlags = flags;
+       client->ps.stats[STAT_MAX_HEALTH] = client->pers.maxHealth;
+       client->ps.eFlags = flags;
+       ent->s.eFlags &= ~EF_HEADLIGHTS;
+       if ( client->sess.headlights ) {
+               client->ps.extra_eFlags |= CF_HEADLIGHTS;
+               ent->s.eFlags |= EF_HEADLIGHTS;
+       }
 
-	ent->s.groundEntityNum = ENTITYNUM_NONE;
+       ent->s.groundEntityNum = ENTITYNUM_NONE;
 	ent->client = &level.clients[index];
 	ent->takedamage = qtrue;
 	ent->inuse = qtrue;

--- a/engine/code/game/g_cmds.c
+++ b/engine/code/game/g_cmds.c
@@ -2047,6 +2047,7 @@ void Cmd_Headlight_Toggle_f( gentity_t *ent ) {
        } else {
                ent->s.eFlags &= ~EF_HEADLIGHTS;
        }
+       ent->client->sess.headlights = (ent->client->ps.extra_eFlags & CF_HEADLIGHTS) ? qtrue : qfalse;
 }
 // END
 

--- a/engine/code/game/g_local.h
+++ b/engine/code/game/g_local.h
@@ -299,6 +299,7 @@ typedef struct {
 	int			spectatorClient;	// for chasecam and follow mode
 	int			wins, losses;		// tournament stats
 	qboolean	teamLeader;			// true when this client is a team leader
+	qboolean	headlights;			// headlight state persists across restarts
 } clientSession_t;
 
 //

--- a/engine/code/game/g_session.c
+++ b/engine/code/game/g_session.c
@@ -45,15 +45,16 @@ void G_WriteClientSessionData( gclient_t *client ) {
 	const char	*s;
 	const char	*var;
 
-	s = va("%i %i %i %i %i %i %i", 
+	s = va("%i %i %i %i %i %i %i %i", 
 		client->sess.sessionTeam,
 		client->sess.spectatorNum,
 		client->sess.spectatorState,
 		client->sess.spectatorClient,
 		client->sess.wins,
 		client->sess.losses,
-		client->sess.teamLeader
-		);
+		client->sess.teamLeader,
+			client->sess.headlights
+			);
 
 	var = va( "session%i", (int)(client - level.clients) );
 
@@ -73,23 +74,26 @@ void G_ReadSessionData( gclient_t *client ) {
 	int teamLeader;
 	int spectatorState;
 	int sessionTeam;
+	int headlights = 0;
 
 	var = va( "session%i", (int)(client - level.clients) );
 	trap_Cvar_VariableStringBuffer( var, s, sizeof(s) );
 
-	sscanf( s, "%i %i %i %i %i %i %i",
+	sscanf( s, "%i %i %i %i %i %i %i %i",
 		&sessionTeam,
 		&client->sess.spectatorNum,
 		&spectatorState,
 		&client->sess.spectatorClient,
 		&client->sess.wins,
 		&client->sess.losses,
-		&teamLeader
-		);
+		&teamLeader,
+			&headlights
+			);
 
 	client->sess.sessionTeam = (team_t)sessionTeam;
 	client->sess.spectatorState = (spectatorState_t)spectatorState;
 	client->sess.teamLeader = (qboolean)teamLeader;
+	client->sess.headlights = (qboolean)headlights;
 }
 
 
@@ -106,6 +110,7 @@ void G_InitSessionData( gclient_t *client, char *userinfo ) {
 
 	sess = &client->sess;
 
+	sess->headlights = qfalse;
 	// check for team preference, mainly for bots
 	value = Info_ValueForKey( userinfo, "teampref" );
 

--- a/engine/code/q3_ui/ui_rally_controls.c
+++ b/engine/code/q3_ui/ui_rally_controls.c
@@ -275,7 +275,7 @@ static bind_t g_bindings[] =
 	{"messagemode3", 	"chat - target",	ID_CHAT3,		ANIM_CHAT,		-1,				-1,		-1, -1},
 	{"messagemode4", 	"chat - attacker",	ID_CHAT4,		ANIM_CHAT,		-1,				-1,		-1, -1},
 	{"dropWeapon", 		"drop rear weapon",	ID_DROP_REAR,	ANIM_DROPREAR,	'r',			-1,		-1, -1},
-    {"headlights", 		"headlight toggle",	ID_HEADLIGHT,	ANIM_HEADLIGHT,	'l',		    -1,		-1, -1},
+    {"headlights", 		"lights",	ID_HEADLIGHT,	ANIM_HEADLIGHT,	'l',		    -1,		-1, -1},
     {"record",          "start demo record",            ID_STARTDEMO,   ANIM_STARTDEMO, 'z',            -1,     -1, -1},
     {"stoprecord",      "stop demo record",             ID_STOPDEMO,    ANIM_STOPDEMO,  'u',            -1,     -1, -1},
 	{"nextcamera",		"next camera",		  ID_NEXTCAMERA,	  ANIM_IDLE,		  'c',			-1,		-1, -1},


### PR DESCRIPTION
## Summary
- Dim vehicle backlight effect by reducing radius and red component
- Preserve headlight state across map restarts via session storage
- Rename Controls menu entry from "Headlights" to "Lights"

## Testing
- `make -C engine release BUILD_GAME_SO=0 BUILD_SERVER=0` *(fails: SDL_version.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b0c62d3a3c8324bf82276e9f4ee072