### PR TITLE
Call listbox callback on arrow key navigation

### DIFF
--- a/engine/code/q3_ui/ui_qmenu.c
+++ b/engine/code/q3_ui/ui_qmenu.c
@@ -1054,6 +1054,9 @@ sfxHandle_t ListBox_Key( menulist_s *l, int key )
 					l->top = l->curvalue;
 				if( l->top + l->height <= l->curvalue )
 					l->top = l->curvalue - l->height + 1;
+				if (l->generic.callback) {
+					l->generic.callback(l, QM_GOTFOCUS);
+				}
 				return (menu_move_sound);
 			}
 			break;
@@ -1074,6 +1077,9 @@ sfxHandle_t ListBox_Key( menulist_s *l, int key )
 					l->top = l->curvalue;
 				if( l->top + l->height <= l->curvalue )
 					l->top = l->curvalue - l->height + 1;
+				if (l->generic.callback) {
+					l->generic.callback(l, QM_GOTFOCUS);
+				}
 				return (menu_move_sound);
 			}
 			break;
@@ -1091,6 +1097,9 @@ sfxHandle_t ListBox_Key( menulist_s *l, int key )
 					l->top = l->curvalue;
 				if( l->top + l->height <= l->curvalue )
 					l->top = l->curvalue - l->height + 1;
+				if (l->generic.callback) {
+					l->generic.callback(l, QM_GOTFOCUS);
+				}
 				return (menu_move_sound);
 			}
 			break;
@@ -1108,6 +1117,9 @@ sfxHandle_t ListBox_Key( menulist_s *l, int key )
 					l->top = l->curvalue;
 				if( l->top + l->height <= l->curvalue )
 					l->top = l->curvalue - l->height + 1;
+				if (l->generic.callback) {
+					l->generic.callback(l, QM_GOTFOCUS);
+				}
 				return (menu_move_sound);
 			}
 			break;


### PR DESCRIPTION
## Summary
- trigger menu callback after changing selection via arrow keys or page up/down in UI list boxes

## Testing
- `cd engine && make release BUILD_CLIENT=0 BUILD_SERVER=0 BUILD_GAME_SO=0`

------
https://chatgpt.com/codex/tasks/task_e_68b12f0f74008324a227cc062ffa63ea