### PR TITLE
Use integer-based random selection in UI

### DIFF
--- a/engine/code/q3_ui/ui_local.h
+++ b/engine/code/q3_ui/ui_local.h
@@ -958,9 +958,10 @@ void UI_SoundOptionsMenu( void );
 #define BL_ONLY			2
 
 float UI_Random( void );
+int UI_RandomInt( int max );
 int UI_BuildFileList( const char *directory, const char *extension, const char *prefix,
-					 qboolean excludeDirectory, qboolean excludeFileNames,
-					 int specialCases, int startIndex, char list[256][64]);
+                                         qboolean excludeDirectory, qboolean excludeFileNames,
+                                         int specialCases, int startIndex, char list[256][64]);
 
 //
 // ui_rally_favorites.c

--- a/engine/code/q3_ui/ui_menu.c
+++ b/engine/code/q3_ui/ui_menu.c
@@ -126,7 +126,7 @@ static void MainMenu_BuildList( void )
 
         // choose one from list randomly
         if (numItems){
-                car = (int)(UI_Random() * numItems);
+               car = UI_RandomInt( numItems );
                 strncpy(carName, cars[car], sizeof(carName) - 1);
                 carName[sizeof(carName) - 1] = '\0';
         }
@@ -140,7 +140,7 @@ static void MainMenu_BuildList( void )
 
         // choose a skin from the list randomly
         if (numItems){
-                skin = UI_Random() * numItems;
+               skin = UI_RandomInt( numItems );
                 strncpy(skinName, cars[skin], sizeof(skinName) - 1);
                 skinName[sizeof(skinName) - 1] = '\0';
         }

--- a/engine/code/q3_ui/ui_qmenu.c
+++ b/engine/code/q3_ui/ui_qmenu.c
@@ -2297,7 +2297,7 @@ void Menu_Cache( void )
 		char	shader[MAX_QPATH];
 
 		numItems = UI_BuildFileList("gfx/2d", "tga", "menucar", qtrue, qfalse, qfalse, 0, pics);
-		backPic = (int)(UI_Random() * numItems);
+               backPic = UI_RandomInt( numItems );
 		Com_sprintf(shader, sizeof(shader), "gfx/2d/menucar%s", pics[backPic]);
 		uis.menuBackShader	= trap_R_RegisterShaderNoMip( shader );
 	}

--- a/engine/code/q3_ui/ui_rally_tools.c
+++ b/engine/code/q3_ui/ui_rally_tools.c
@@ -41,6 +41,11 @@ float UI_Random( void ){
 	return Q_random( &seed );
 //	return random();
 }
+int UI_RandomInt( int max ){
+	int seed = trap_Milliseconds();
+	return Q_rand( &seed ) % max;
+}
+
 
 
 int UI_BuildFileList( const char *directory, const char *extension, const char *prefix,


### PR DESCRIPTION
## Summary
- add `UI_RandomInt` helper for integer random numbers
- use `UI_RandomInt` when choosing random menu elements

## Testing
- `make -C engine` *(fails: SDL_version.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b1da8b86648324940c80aa4427bcf2