### PR TITLE
Use Q_strncpyz instead of strncpy

### DIFF
--- a/engine/code/botlib/be_ai_char.c
+++ b/engine/code/botlib/be_ai_char.c
@@ -758,8 +758,7 @@ void Characteristic_String(int character, int index, char *buf, int size)
 	//an integer will be converted to a float
 	if (ch->c[index].type == CT_STRING)
 	{
-		strncpy(buf, ch->c[index].value.string, size-1);
-		buf[size-1] = '\0';
+                Q_strncpyz(buf, ch->c[index].value.string, size);
 	} //end if
 	else
 	{

--- a/engine/code/botlib/be_ai_chat.c
+++ b/engine/code/botlib/be_ai_chat.c
@@ -1496,11 +1496,10 @@ void BotMatchVariable(bot_match_t *match, int variable, char *buf, int size)
 
 	if (match->variables[variable].offset >= 0)
 	{
-		if (match->variables[variable].length < size)
-			size = match->variables[variable].length+1;
-		assert( match->variables[variable].offset >= 0 );
-		strncpy(buf, &match->string[ (int) match->variables[variable].offset], size-1);
-		buf[size-1] = '\0';
+                if (match->variables[variable].length < size)
+                        size = match->variables[variable].length+1;
+                assert( match->variables[variable].offset >= 0 );
+                Q_strncpyz(buf, &match->string[(int) match->variables[variable].offset], size);
 	} //end if
 	else
 	{
@@ -2845,9 +2844,8 @@ void BotGetChatMessage(int chatstate, char *buf, int size)
 	cs = BotChatStateFromHandle(chatstate);
 	if (!cs) return;
 
-	BotRemoveTildes(cs->chatmessage);
-	strncpy(buf, cs->chatmessage, size-1);
-	buf[size-1] = '\0';
+        BotRemoveTildes(cs->chatmessage);
+        Q_strncpyz(buf, cs->chatmessage, size);
 	//clear the chat message from the state
 	strcpy(cs->chatmessage, "");
 } //end of the function BotGetChatMessage
@@ -2882,10 +2880,9 @@ void BotSetChatName(int chatstate, char *name, int client)
 
 	cs = BotChatStateFromHandle(chatstate);
 	if (!cs) return;
-	cs->client = client;
-	Com_Memset(cs->name, 0, sizeof(cs->name));
-	strncpy(cs->name, name, sizeof(cs->name)-1);
-	cs->name[sizeof(cs->name)-1] = '\0';
+        cs->client = client;
+        Com_Memset(cs->name, 0, sizeof(cs->name));
+        Q_strncpyz(cs->name, name, sizeof(cs->name));
 } //end of the function BotSetChatName
 //===========================================================================
 //

--- a/engine/code/botlib/be_interface.c
+++ b/engine/code/botlib/be_interface.c
@@ -235,8 +235,7 @@ int Export_BotLibVarGet(const char *var_name, char *value, int size)
 	char *varvalue;
 
 	varvalue = LibVarGetString(var_name);
-	strncpy(value, varvalue, size-1);
-	value[size-1] = '\0';
+        Q_strncpyz(value, varvalue, size);
 	return BLERR_NOERROR;
 } //end of the function Export_BotLibVarGet
 //===========================================================================

--- a/engine/code/botlib/l_struct.c
+++ b/engine/code/botlib/l_struct.c
@@ -220,10 +220,8 @@ int ReadString(source_t *source, fielddef_t *fd, void *p)
 	if (!PC_ExpectTokenType(source, TT_STRING, 0, &token)) return 0;
 	//remove the double quotes
 	StripDoubleQuotes(token.string);
-	//copy the string
-	strncpy((char *) p, token.string, MAX_STRINGFIELD-1);
-	//make sure the string is closed with a zero
-	((char *)p)[MAX_STRINGFIELD-1] = '\0';
+        //copy the string
+        Q_strncpyz((char *) p, token.string, MAX_STRINGFIELD);
 	//
 	return 1;
 } //end of the function ReadString

--- a/engine/code/game/ai_chat.c
+++ b/engine/code/game/ai_chat.c
@@ -238,8 +238,7 @@ char *BotMapTitle(void) {
 
 	trap_GetServerinfo(info, sizeof(info));
 
-	strncpy(mapname, Info_ValueForKey( info, "mapname" ), sizeof(mapname)-1);
-	mapname[sizeof(mapname)-1] = '\0';
+        Q_strncpyz(mapname, Info_ValueForKey( info, "mapname" ), sizeof(mapname));
 
 	return mapname;
 }

--- a/engine/code/game/ai_cmd.c
+++ b/engine/code/game/ai_cmd.c
@@ -1105,9 +1105,8 @@ void BotMatch_JoinSubteam(bot_state_t *bs, bot_match_t *match) {
 	if (!BotAddressedToBot(bs, match)) return;
 	//get the sub team name
 	trap_BotMatchVariable(match, TEAMNAME, teammate, sizeof(teammate));
-	//set the sub team name
-	strncpy(bs->subteam, teammate, 32);
-	bs->subteam[31] = '\0';
+        //set the sub team name
+        Q_strncpyz(bs->subteam, teammate, sizeof(bs->subteam));
 	//
 	trap_BotMatchVariable(match, NETNAME, netname, sizeof(netname));
 	BotAI_BotInitialChat(bs, "joinedteam", teammate, NULL);
@@ -1296,10 +1295,9 @@ void BotMatch_StartTeamLeaderShip(bot_state_t *bs, bot_match_t *match) {
 	if (!TeamPlayIsOn()) return;
 	//if chats for him or herself
 	if (match->subtype & ST_I) {
-		//get the team mate that will be the team leader
-		trap_BotMatchVariable(match, NETNAME, teammate, sizeof(teammate));
-		strncpy(bs->teamleader, teammate, sizeof(bs->teamleader));
-		bs->teamleader[sizeof(bs->teamleader)-1] = '\0';
+                //get the team mate that will be the team leader
+                trap_BotMatchVariable(match, NETNAME, teammate, sizeof(teammate));
+                Q_strncpyz(bs->teamleader, teammate, sizeof(bs->teamleader));
 	}
 	//chats for someone else
 	else {

--- a/engine/code/game/ai_dmq3.c
+++ b/engine/code/game/ai_dmq3.c
@@ -1416,8 +1416,7 @@ char *ClientName(int client, char *name, int size) {
 		return "[client out of range]";
 	}
 	trap_GetConfigstring(CS_PLAYERS+client, buf, sizeof(buf));
-	strncpy(name, Info_ValueForKey(buf, "n"), size-1);
-	name[size-1] = '\0';
+        Q_strncpyz(name, Info_ValueForKey(buf, "n"), size);
 	Q_CleanStr( name );
 	return name;
 }
@@ -1435,8 +1434,7 @@ char *ClientSkin(int client, char *skin, int size) {
 		return "[client out of range]";
 	}
 	trap_GetConfigstring(CS_PLAYERS+client, buf, sizeof(buf));
-	strncpy(skin, Info_ValueForKey(buf, "model"), size-1);
-	skin[size-1] = '\0';
+        Q_strncpyz(skin, Info_ValueForKey(buf, "model"), size);
 	return skin;
 }
 
@@ -1539,8 +1537,7 @@ char *EasyClientName(int client, char *buf, int size) {
 			memmove(ptr, ptr+1, strlen(ptr + 1)+1);
 		}
 	}
-	strncpy(buf, name, size-1);
-	buf[size-1] = '\0';
+        Q_strncpyz(buf, name, size);
 	return buf;
 }
 
@@ -3774,8 +3771,7 @@ void BotMapScripts(bot_state_t *bs) {
 
 	trap_GetServerinfo(info, sizeof(info));
 
-	strncpy(mapname, Info_ValueForKey( info, "mapname" ), sizeof(mapname)-1);
-	mapname[sizeof(mapname)-1] = '\0';
+        Q_strncpyz(mapname, Info_ValueForKey( info, "mapname" ), sizeof(mapname));
 
 	if (!Q_stricmp(mapname, "q3tourney6") || !Q_stricmp(mapname, "q3tourney6_ctf") || !Q_stricmp(mapname, "mpq3tourney6")) {
 		vec3_t mins = {694, 200, 480}, maxs = {968, 472, 680};

--- a/engine/code/game/ai_team.c
+++ b/engine/code/game/ai_team.c
@@ -1957,8 +1957,7 @@ void BotTeamAI(bot_state_t *bs) {
 				trap_BotEnterChat(bs->cs, 0, CHAT_TEAM);
 				BotSayVoiceTeamOrder(bs, -1, VOICECHAT_STARTLEADER);
 				ClientName(bs->client, netname, sizeof(netname));
-				strncpy(bs->teamleader, netname, sizeof(bs->teamleader));
-				bs->teamleader[sizeof(bs->teamleader)-1] = '\0';
+                                Q_strncpyz(bs->teamleader, netname, sizeof(bs->teamleader));
 				bs->becometeamleader_time = 0;
 			}
 			return;

--- a/engine/code/q3_ui/ui_menu.c
+++ b/engine/code/q3_ui/ui_menu.c
@@ -127,12 +127,10 @@ static void MainMenu_BuildList( void )
         // choose one from list randomly
         if (numItems){
                car = UI_RandomInt( numItems );
-                strncpy(carName, cars[car], sizeof(carName) - 1);
-                carName[sizeof(carName) - 1] = '\0';
+                Q_strncpyz(carName, cars[car], sizeof(carName));
         }
         else {
-                strncpy(carName, DEFAULT_MODEL, sizeof(carName) - 1);
-                carName[sizeof(carName) - 1] = '\0';
+                Q_strncpyz(carName, DEFAULT_MODEL, sizeof(carName));
         }
 
         // get skins for the choosen car
@@ -141,12 +139,10 @@ static void MainMenu_BuildList( void )
         // choose a skin from the list randomly
         if (numItems){
                skin = UI_RandomInt( numItems );
-                strncpy(skinName, cars[skin], sizeof(skinName) - 1);
-                skinName[sizeof(skinName) - 1] = '\0';
+                Q_strncpyz(skinName, cars[skin], sizeof(skinName));
         }
         else {
-                strncpy(skinName, DEFAULT_SKIN, sizeof(skinName) - 1);
-                skinName[sizeof(skinName) - 1] = '\0';
+                Q_strncpyz(skinName, DEFAULT_SKIN, sizeof(skinName));
         }
 
         // FIXME: choose rim randomly?

--- a/engine/code/q3_ui/ui_rally_tools.c
+++ b/engine/code/q3_ui/ui_rally_tools.c
@@ -80,7 +80,7 @@ int UI_BuildFileList( const char *directory, const char *extension, const char *
 		prefix++;
 	}
 
-	strncpy(p, prefix, sizeof(p));
+        Q_strncpyz(p, prefix, sizeof(p));
 	for (sizeofPrefix = 0; sizeofPrefix < sizeof(p); sizeofPrefix++){
 		if (p[sizeofPrefix] == 0)
 			break;

--- a/engine/code/server/sv_rankings.c
+++ b/engine/code/server/sv_rankings.c
@@ -138,8 +138,8 @@ void SV_RankBegin( char *gamekey )
 
 	// initialize rankings
 	GRankLogLevel( GRLOG_OFF );
-	memset(SV_RankGameKey,0,sizeof(SV_RankGameKey));
-	strncpy(SV_RankGameKey,gamekey,sizeof(SV_RankGameKey)-1);
+        memset(SV_RankGameKey,0,sizeof(SV_RankGameKey));
+        Q_strncpyz(SV_RankGameKey, gamekey, sizeof(SV_RankGameKey));
 	init = GRankInit( 1, SV_RankGameKey, GR_OPT_POLL, GR_OPT_END );
 	s_server_context = init.context;
 	s_rankings_contexts++;

--- a/engine/code/ui/ui_shared.c
+++ b/engine/code/ui/ui_shared.c
@@ -3031,14 +3031,17 @@ void Item_Text_Wrapped_Paint(itemDef_t *item) {
 	y = item->textRect.y;
 	start = textPtr;
 	p = strchr(textPtr, '\r');
-	while (p && *p) {
-		strncpy(buff, start, p-start+1);
-		buff[p-start] = '\0';
-		DC->drawText(x, y, item->textscale, color, buff, 0, 0, item->textStyle);
-		y += height + 5;
-		start += p - start + 1;
-		p = strchr(p+1, '\r');
-	}
+        while (p && *p) {
+                int len = p - start;
+                if (len >= sizeof(buff)) {
+                        len = sizeof(buff) - 1;
+                }
+                Q_strncpyz(buff, start, len + 1);
+                DC->drawText(x, y, item->textscale, color, buff, 0, 0, item->textStyle);
+                y += height + 5;
+                start += len + 1;
+                p = strchr(p + 1, '\r');
+        }
 	DC->drawText(x, y, item->textscale, color, start, 0, 0, item->textStyle);
 }
 


### PR DESCRIPTION
## Summary
- Replace `strncpy` + manual terminators with `Q_strncpyz` in game AI code
- Update botlib and UI utilities to use safe string copying
- Clean up server ranking initialization to use `Q_strncpyz`

## Testing
- `make -C engine -j2` *(fails: SDL_version.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b1dcd35e788324aa8aa0c7ac1e65eb