### PR TITLE
Rename main menu cache to prepare

### DIFF
--- a/engine/code/q3_ui/ui_atoms.c
+++ b/engine/code/q3_ui/ui_atoms.c
@@ -1204,7 +1204,7 @@ UI_Cache
 =================
 */
 void UI_Cache_f( void ) {
-	MainMenu_Cache();
+        MainMenu_Prepare();
 	InGame_Cache();
 	ConfirmMenu_Cache();
 	PlayerModel_Cache();

--- a/engine/code/q3_ui/ui_local.h
+++ b/engine/code/q3_ui/ui_local.h
@@ -427,7 +427,7 @@ extern sfxHandle_t	MenuField_Key( menufield_s* m, int* key );
 //
 // ui_menu.c
 //
-extern void MainMenu_Cache( void );
+extern void MainMenu_Prepare( void );
 extern void UI_MainMenu(void);
 extern void UI_RegisterCvars( void );
 extern void UI_UpdateCvars( void );

--- a/engine/code/q3_ui/ui_menu.c
+++ b/engine/code/q3_ui/ui_menu.c
@@ -279,10 +279,10 @@ void MainMenu_RunTransition( float frac ) {
 
 /*
 ===============
-MainMenu_Cache
+MainMenu_Prepare
 ===============
 */
-void MainMenu_Cache( void ) {
+void MainMenu_Prepare( void ) {
 
         MainMenu_Update();
 
@@ -404,7 +404,7 @@ void UI_MainMenu( void ) {
 
 	memset( &s_main, 0 ,sizeof(mainmenu_t) );
 
-	MainMenu_Cache();
+        MainMenu_Prepare();
 
         s_main.menu.draw = Main_MenuDraw;
         s_main.menu.fullscreen = qtrue;

--- a/engine/code/ui/ui_local.h
+++ b/engine/code/ui/ui_local.h
@@ -364,7 +364,7 @@ void UI_LoadArenasIntoMapList(void);
 //
 // ui_menu.c
 //
-extern void MainMenu_Cache( void );
+extern void MainMenu_Prepare( void );
 extern void UI_MainMenu(void);
 extern void UI_RegisterCvars( void );
 extern void UI_UpdateCvars( void );


### PR DESCRIPTION
## Summary
- rename `MainMenu_Cache` to `MainMenu_Prepare` to reflect actual behavior
- update all callers and headers to use new name

## Testing
- `make -C engine release BUILD_GAME_SO=0 BUILD_SERVER=0` *(fails: SDL_version.h missing)*

------
https://chatgpt.com/codex/tasks/task_e_68b20e5588248324acd3559b47e3cc3c