### PR TITLE
Fade garage item during main menu transitions

### DIFF
--- a/engine/code/q3_ui/ui_menu.c
+++ b/engine/code/q3_ui/ui_menu.c
@@ -269,6 +269,7 @@ void MainMenu_RunTransition( float frac ) {
         s_main.singleplayer.color = uis.text_color;
         s_main.multiplayer.color = uis.text_color;
         s_main.setup.color = uis.text_color;
+        s_main.garage.color = uis.text_color;
         s_main.cinematics.color = uis.text_color;
         s_main.demos.color = uis.text_color;
         s_main.mods.color = uis.text_color;


### PR DESCRIPTION
## Summary
- Ensure "The Garage" menu entry fades in/out like other main menu items by applying transition color

## Testing
- `make -j2` *(fails: SDL_version.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b212f792608324bee3db46e5633ea3