### PR TITLE
Replace gfxloading macros with constants

### DIFF
--- a/engine/code/q3_ui/ui_rally_gfxloading.c
+++ b/engine/code/q3_ui/ui_rally_gfxloading.c
@@ -32,8 +32,8 @@ for improved user experience and better visual feedback.
 
 #include "ui_local.h"
 
-#define MIN_STAGE_TIME 450      /* minimum milliseconds per stage */
-#define FINAL_DISPLAY_TIME 1200 /* time to display 100% before transition */
+static const int MIN_STAGE_TIME = 450;      /* minimum milliseconds per stage */
+static const int FINAL_DISPLAY_TIME = 1200; /* time to display 100% before transition */
 
 typedef struct {
     const char *name;


### PR DESCRIPTION
## Summary
- replace MIN_STAGE_TIME and FINAL_DISPLAY_TIME macros with static const integers in rally gfx loading screen

## Testing
- `make BUILD_CLIENT=0 BUILD_SERVER=0 BUILD_GAME_SO=1 BUILD_BASEGAME=1`
- `make` *(fails: SDL_version.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b21790dd708324b45b4bb8ee18e273