### PR TITLE
Adjust GFX loading progress baseline

### DIFF
--- a/engine/code/q3_ui/ui_rally_gfxloading.c
+++ b/engine/code/q3_ui/ui_rally_gfxloading.c
@@ -208,7 +208,7 @@ static void UI_GFX_Loading_MenuDraw(void) {
 
     /* Draw progress bar with enhanced visuals */
     bar_x = 200;
-    bar_y = 240;
+    bar_y = 240 + 50;
     bar_w = 240;
     bar_h = 24;
 


### PR DESCRIPTION
## Summary
- Raise graphics loading progress bar baseline by 50px to make space for icon and text
- Percentage and waiting messages now anchor to the new baseline

## Testing
- `make -C engine` *(fails: SDL_version.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b22602ddc08324b06b77c71d0efce9