### PR TITLE
Interpolate progress bar color in GFX loading screen

### DIFF
--- a/engine/code/q3_ui/ui_rally_gfxloading.c
+++ b/engine/code/q3_ui/ui_rally_gfxloading.c
@@ -221,7 +221,18 @@ static void UI_GFX_Loading_MenuDraw(void) {
     
     /* Actual progress fill */
     if (s_gfxloading.smoothProgress > 0.0f) {
-        UI_FillRect(bar_x, bar_y, (int)(bar_w * s_gfxloading.smoothProgress), bar_h, text_color_highlight);
+        vec4_t startColor = {1.0f, 0.0f, 0.0f, 1.0f};
+        vec4_t endColor = {0.0f, 1.0f, 0.0f, 1.0f};
+        vec4_t progressColor;
+        int    i;
+
+        for (i = 0; i < 4; i++) {
+            progressColor[i] = startColor[i] + (endColor[i] - startColor[i]) * s_gfxloading.smoothProgress;
+        }
+
+        trap_R_SetColor(progressColor);
+        UI_FillRect(bar_x, bar_y, (int)(bar_w * s_gfxloading.smoothProgress), bar_h, progressColor);
+        trap_R_SetColor(NULL);
     }
 
     /* Moving car icon */


### PR DESCRIPTION
## Summary
- Interpolate a dynamic RGBA color for the graphics loading progress bar
- Apply the interpolated color with `trap_R_SetColor` and reset after drawing

## Testing
- `cd engine && make` *(fails: SDL_version.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b2283852248324a23c9d4944ae6e43