### PR TITLE
Use persistent UI random seed

### DIFF
--- a/engine/code/q3_ui/ui_atoms.c
+++ b/engine/code/q3_ui/ui_atoms.c
@@ -1320,9 +1320,10 @@ void UI_Init( void ) {
 	char			*slash;
 // END
 
-	UI_RegisterCvars();
+        UI_RegisterCvars();
 
-	UI_InitGameinfo();
+        UI_InitRand();
+        UI_InitGameinfo();
 
 	// cache redundant calulations
 	trap_GetGlconfig( &uis.glconfig );

--- a/engine/code/q3_ui/ui_local.h
+++ b/engine/code/q3_ui/ui_local.h
@@ -956,6 +956,7 @@ void UI_SoundOptionsMenu( void );
 #define BL_INCLUDE		0
 #define BL_EXCLUDE		1
 #define BL_ONLY			2
+void UI_InitRand( void );
 
 float UI_Random( void );
 int UI_RandomInt( int max );

--- a/engine/code/q3_ui/ui_menu.c
+++ b/engine/code/q3_ui/ui_menu.c
@@ -375,21 +375,19 @@ void UI_MainMenu( void ) {
 	
 	int x;
 	int y;
-	int numMusicFiles;
-	int selectedMusic;
-	char musicFiles[256][MAX_QPATH];
-	char musicCommand[MAX_QPATH];
+        int numMusicFiles;
+        int selectedMusic;
+        char musicFiles[256][MAX_QPATH];
+        char musicCommand[MAX_QPATH];
 
-	
-	srand((unsigned int)trap_Milliseconds());
 
-	numMusicFiles = UI_BuildFileList("music", "ogg", "menumusic", qtrue, qfalse, qfalse, 0, musicFiles);
+        numMusicFiles = UI_BuildFileList("music", "ogg", "menumusic", qtrue, qfalse, qfalse, 0, musicFiles);
 
-	if (numMusicFiles > 0) {
-		selectedMusic = rand() % numMusicFiles;
-		Com_sprintf(musicCommand, sizeof(musicCommand), "music music/menumusic%s\n", musicFiles[selectedMusic]);
-		trap_Cmd_ExecuteText(EXEC_APPEND, musicCommand);
-	}
+        if (numMusicFiles > 0) {
+                selectedMusic = UI_RandomInt( numMusicFiles );
+                Com_sprintf(musicCommand, sizeof(musicCommand), "music music/menumusic%s\n", musicFiles[selectedMusic]);
+                trap_Cmd_ExecuteText(EXEC_APPEND, musicCommand);
+        }
 
 	trap_Cvar_Set( "sv_killserver", "1" );
 

--- a/engine/code/q3_ui/ui_players.c
+++ b/engine/code/q3_ui/ui_players.c
@@ -1492,11 +1492,11 @@ void UI_DrawPlayer( float x, float y, float w, float h, playerInfo_t *pi, int ti
 			trap_R_AddRefEntityToScene( &flash );
 		}
 
-		// make a dlight for the flash
-		if ( pi->flashDlightColor[0] || pi->flashDlightColor[1] || pi->flashDlightColor[2] ) {
-			trap_R_AddLightToScene( flash.origin, 200 + (rand()&31), pi->flashDlightColor[0],
-				pi->flashDlightColor[1], pi->flashDlightColor[2] );
-		}
+                // make a dlight for the flash
+                if ( pi->flashDlightColor[0] || pi->flashDlightColor[1] || pi->flashDlightColor[2] ) {
+                        trap_R_AddLightToScene( flash.origin, 200 + UI_RandomInt( 32 ), pi->flashDlightColor[0],
+                                pi->flashDlightColor[1], pi->flashDlightColor[2] );
+                }
 	}
 
 	//

--- a/engine/code/q3_ui/ui_rally_gfxloading.c
+++ b/engine/code/q3_ui/ui_rally_gfxloading.c
@@ -315,6 +315,6 @@ void UI_GFX_Loading(void) {
     s_gfxloading.cacheExecuted = qfalse;
     s_gfxloading.finalPhase = qfalse;
     s_gfxloading.finalDisplayStartTime = 0;
-    s_gfxloading.tipIndex = rand() % ARRAY_LEN(loadingTips);
+    s_gfxloading.tipIndex = UI_RandomInt( ARRAY_LEN(loadingTips) );
 }
 

--- a/engine/code/q3_ui/ui_rally_tools.c
+++ b/engine/code/q3_ui/ui_rally_tools.c
@@ -23,27 +23,18 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 
 #include "ui_local.h"
 
+static int ui_randSeed;
+
+void UI_InitRand( void ) {
+	ui_randSeed = trap_Milliseconds();
+}
 
 float UI_Random( void ){
-/* op stack corrupted
-	int seed = (trap_RealTime() & 0x0fff);
-	int seed2 = Q_rand ( &seed );
-
-	Com_Printf("trap_Milliseconds %i\n", trap_Milliseconds());
-	Com_Printf("trap_RealTime %i\n", trap_RealTime());
-	Com_Printf("seed2 %i\n", seed2);
-
-	return ( trap_RealTime() & 0xffff ) / (float)0x10000;
-*/
-
-
-	int seed = trap_Milliseconds();
-	return Q_random( &seed );
+	return Q_random( &ui_randSeed );
 //	return random();
 }
 int UI_RandomInt( int max ){
-	int seed = trap_Milliseconds();
-	return Q_rand( &seed ) % max;
+	return Q_rand( &ui_randSeed ) % max;
 }
 
 


### PR DESCRIPTION
## Summary
- Initialize a persistent `ui_randSeed` on UI startup and update `UI_Random` helpers to use it
- Remove per-call `srand` and replace direct `rand` calls with `UI_RandomInt`
- Ensure menu music, loading tips, and player light flashes draw from the shared seed

## Testing
- `make` *(fails: SDL_version.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b22e8a51508324bebe627f6e79b636