### PR TITLE
Handle negative Q_rand outputs in UI_RandomInt

### DIFF
--- a/engine/code/q3_ui/ui_rally_tools.c
+++ b/engine/code/q3_ui/ui_rally_tools.c
@@ -34,7 +34,8 @@ float UI_Random( void ){
 //	return random();
 }
 int UI_RandomInt( int max ){
-	return Q_rand( &ui_randSeed ) % max;
+	// Q_rand may return negative values, cast to unsigned to guarantee non-negative
+	return (unsigned)Q_rand( &ui_randSeed ) % max;
 }
 
 


### PR DESCRIPTION
## Summary
- Ensure `UI_RandomInt` returns only non-negative values by casting the `Q_rand` result to `unsigned`
- Document that `Q_rand` may produce negative results

## Testing
- `make` *(fails: fatal error: SDL_version.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b23dd87df88324a5ff76c80694ab48