### PR TITLE
Use safe strncpy in StartServer_Update

### DIFF
--- a/engine/code/q3_ui/ui_rally_startserver.c
+++ b/engine/code/q3_ui/ui_rally_startserver.c
@@ -416,7 +416,7 @@ static void StartServer_Update( void ) {
 	if( !s_startserver.nummaps ) {
 
 		// set the map name
-		strcpy( s_startserver.mapname.string, "NO MAPS FOUND" );
+                Q_strncpyz( s_startserver.mapname.string, "NO MAPS FOUND", sizeof( s_startserver.mapname.string ) );
 
 		UI_SetupMapStatsForArena(-1);
 
@@ -424,7 +424,7 @@ static void StartServer_Update( void ) {
 	else {
 
 		// set the map name
-		strcpy( s_startserver.mapname.string, s_startserver.maplist[s_startserver.currentmap] );
+                Q_strncpyz( s_startserver.mapname.string, s_startserver.maplist[s_startserver.currentmap], sizeof( s_startserver.mapname.string ) );
 
 		UI_SetupMapStatsForArena(s_startserver.currentmap);
 	}


### PR DESCRIPTION
## Summary
- prevent buffer overflows when setting map name in StartServer_Update by using `Q_strncpyz`

## Testing
- `make` *(fails: SDL_version.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b280c7345c8324973d5d25c2ca4974