### PR TITLE
Handle collisions between vehicles and players

### DIFF
--- a/engine/code/game/g_client.c
+++ b/engine/code/game/g_client.c
@@ -22,6 +22,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 */
 //
 #include "g_local.h"
+#include "../botlib/be_aas.h"
 
 extern vmCvar_t g_dominationSpawnStyle;
 
@@ -1513,10 +1514,11 @@ void ClientSpawn(gentity_t *ent) {
 	ent->watertype = 0;
 	ent->flags = 0;
 	
-	VectorCopy (playerMins, ent->r.mins);
-	VectorCopy (playerMaxs, ent->r.maxs);
+       VectorCopy (playerMins, ent->r.mins);
+       VectorCopy (playerMaxs, ent->r.maxs);
+       ent->s.solid = SOLID_BBOX;
 
-	client->ps.pm_flags |= SVF_CAPSULE;
+       client->ps.pm_flags |= SVF_CAPSULE;
 
 
 	client->ps.clientNum = index;
@@ -1570,22 +1572,24 @@ void ClientSpawn(gentity_t *ent) {
 
 //	ent->r.ownerNum = client->ps.clientNum;
 
-	VectorCopy (playerMins, ent->frontBounds->r.mins);
-	VectorCopy (playerMaxs, ent->frontBounds->r.maxs);
-	if ( client->sess.sessionTeam != TEAM_SPECTATOR && !isRaceObserver( ent->s.number ) ) 
-		ent->frontBounds->r.contents = CONTENTS_BODY;
-	else
-		ent->frontBounds->r.contents = 0;
+       VectorCopy (playerMins, ent->frontBounds->r.mins);
+       VectorCopy (playerMaxs, ent->frontBounds->r.maxs);
+       ent->frontBounds->s.solid = SOLID_BBOX;
+       if ( client->sess.sessionTeam != TEAM_SPECTATOR && !isRaceObserver( ent->s.number ) )
+               ent->frontBounds->r.contents = CONTENTS_BODY;
+       else
+               ent->frontBounds->r.contents = 0;
 	ent->frontBounds->r.svFlags = SVF_NOCLIENT;
 	ent->frontBounds->flags = FL_EXTRA_BBOX;
 	ent->frontBounds->r.ownerNum = client->ps.clientNum;
 
-	VectorCopy (playerMins, ent->rearBounds->r.mins);
-	VectorCopy (playerMaxs, ent->rearBounds->r.maxs);
-	if ( client->sess.sessionTeam != TEAM_SPECTATOR && !isRaceObserver( ent->s.number ) ) 
-		ent->rearBounds->r.contents = CONTENTS_BODY;
-	else
-		ent->rearBounds->r.contents = 0;
+       VectorCopy (playerMins, ent->rearBounds->r.mins);
+       VectorCopy (playerMaxs, ent->rearBounds->r.maxs);
+       ent->rearBounds->s.solid = SOLID_BBOX;
+       if ( client->sess.sessionTeam != TEAM_SPECTATOR && !isRaceObserver( ent->s.number ) )
+               ent->rearBounds->r.contents = CONTENTS_BODY;
+       else
+               ent->rearBounds->r.contents = 0;
 	ent->rearBounds->r.svFlags = SVF_NOCLIENT;
 	ent->rearBounds->flags = FL_EXTRA_BBOX;
 	ent->rearBounds->r.ownerNum = client->ps.clientNum;

--- a/engine/code/game/g_rally_object_physics.c
+++ b/engine/code/game/g_rally_object_physics.c
@@ -263,6 +263,22 @@ void G_RallyObject_TracePhysics( gentity_t *self, float time )
     VectorMA( self->s.pos.trBase, time * ( dist + moveDist ), dir, end );
 
     trap_Trace( &tr, start, NULL, NULL, end, self->s.number, MASK_PLAYERSOLID );
+
+    if( tr.fraction < 1.0f && tr.entityNum < ENTITYNUM_MAX_NORMAL ) {
+        gentity_t *hit = &g_entities[ tr.entityNum ];
+
+        if( hit->client != NULL || ( hit->r.svFlags & SVF_BOT ) ) {
+            vec3_t invNormal;
+
+            if( G_RallyObject_ApplyCollision( self, tr.endpos, tr.plane.normal, self->elasticity ) ) {
+                VectorScale( tr.plane.normal, -1.0f, invNormal );
+                G_RallyObject_ApplyCollision( hit, tr.endpos, invNormal, self->elasticity );
+            }
+
+            return;
+        }
+    }
+
     if( tr.startsolid || tr.allsolid )
     {
         trap_Trace( &tr, start, NULL, NULL, end, self->s.number, MASK_PLAYERSOLID & ~CONTENTS_BODY );


### PR DESCRIPTION
## Summary
- apply collision impulses between rally objects and players/bots in trace physics
- mark players and their auxiliary bounds as SOLID_BBOX with body contents for collision detection

## Testing
- `make BUILD_CLIENT=0 BUILD_SERVER=0 BUILD_RENDERER_OPENGL1=0 BUILD_RENDERER_OPENGL2=0 BUILD_GAME_SO=1`

------
https://chatgpt.com/codex/tasks/task_e_68b32cf675048324977884fd8ee6e809