### PR TITLE
Add vehicle collision damage with scaling

### DIFF
--- a/engine/code/cgame/cg_event.c
+++ b/engine/code/cgame/cg_event.c
@@ -456,10 +456,10 @@ static void CG_Obituary( entityState_t *ent ) {
 			message = "got too close to";
 			message2 = "'s mine";
 			break;
-		case MOD_CAR_COLLISION:
-			message = "got rammed by";
-			message2 = "'s vehicle";
-			break;
+                case MOD_VEHICLE_COLLISION:
+                        message = "got rammed by";
+                        message2 = "'s vehicle";
+                        break;
 // Q3Rally Code END
 		default:
 			message = "was killed by";

--- a/engine/code/game/bg_physics.c
+++ b/engine/code/game/bg_physics.c
@@ -2185,7 +2185,7 @@ static void PM_Trace_Points( car_t *car, carPoint_t *sPoints, carPoint_t *tPoint
 		VectorCopy(hitOrigin, pm->damage.origin);
 		VectorCopy(normal, pm->damage.dir);
 		pm->damage.dflags = DAMAGE_NO_KNOCKBACK;
-		pm->damage.mod = MOD_CAR_COLLISION;
+                pm->damage.mod = MOD_VEHICLE_COLLISION;
 		pm->damage.otherEnt = trace.entityNum;
 
 		PM_CopyTargetToSource(&car->tBody, &car->sBody, tPoints, sPoints);

--- a/engine/code/game/bg_public.h
+++ b/engine/code/game/bg_public.h
@@ -757,7 +757,7 @@ typedef enum {
 #endif
         MOD_UPSIDEDOWN,
         MOD_BO_SHOCKS,
-        MOD_CAR_COLLISION,
+        MOD_VEHICLE_COLLISION,
         MOD_WORLD_COLLISION,
         MOD_HIGH_FORCES,
 
@@ -769,6 +769,8 @@ typedef enum {
         MOD_GRAPPLE,
         MOD_BREAKABLE_SPLASH
 } meansOfDeath_t;
+
+#define MOD_CAR_COLLISION MOD_VEHICLE_COLLISION
 
 
 //---------------------------------------------------------

--- a/engine/code/game/g_combat.c
+++ b/engine/code/game/g_combat.c
@@ -357,7 +357,7 @@ char	*modNames[] = {
 // Q3Rally Code Start
 	"MOD_UPSIDEDOWN",
 	"MOD_BO_SHOCKS",
-	"MOD_CAR_COLLISION",
+        "MOD_VEHICLE_COLLISION",
 	"MOD_WORLD_COLLISION",
 	"MOD_HIGH_FORCES",
 

--- a/engine/code/game/g_local.h
+++ b/engine/code/game/g_local.h
@@ -1003,6 +1003,7 @@ extern	vmCvar_t	g_trackReversed;
 extern	vmCvar_t	g_trackLength;
 extern	vmCvar_t	g_developer;
 extern	vmCvar_t	g_damageScale;
+extern	vmCvar_t	g_vehicleDamageScale;
 
 // car variables
 extern	vmCvar_t	car_spring;

--- a/engine/code/game/g_main.c
+++ b/engine/code/game/g_main.c
@@ -111,6 +111,7 @@ vmCvar_t	g_trackLength;
 vmCvar_t	g_developer;
 
 vmCvar_t	g_damageScale;
+vmCvar_t	g_vehicleDamageScale;
 vmCvar_t  g_humanplayers;
 
 // car variables
@@ -258,6 +259,7 @@ static cvarTable_t		gameCvarTable[] = {
 	{ &car_friction_scale, "car_friction_scale", "1.1", 0, 0, qfalse },
 
 	{ &g_damageScale, "g_damageScale", "0.3", CVAR_ARCHIVE, 0, qfalse },
+	{ &g_vehicleDamageScale, "g_vehicleDamageScale", "0.1", CVAR_ARCHIVE, 0, qfalse },
 // END
 
 	{ &g_rankings, "g_rankings", "0", 0, 0, qfalse},

--- a/engine/code/game/g_rally_object_physics.c
+++ b/engine/code/game/g_rally_object_physics.c
@@ -273,6 +273,42 @@ void G_RallyObject_TracePhysics( gentity_t *self, float time )
             if( G_RallyObject_ApplyCollision( self, tr.endpos, tr.plane.normal, self->elasticity ) ) {
                 VectorScale( tr.plane.normal, -1.0f, invNormal );
                 G_RallyObject_ApplyCollision( hit, tr.endpos, invNormal, self->elasticity );
+
+                {
+                    float vSelf, vHit, closing, totalDamage;
+                    int damageSelf, damageHit;
+
+                    vSelf = DotProduct( self->s.pos.trDelta, tr.plane.normal );
+                    vHit = -DotProduct( hit->s.pos.trDelta, tr.plane.normal );
+                    if( vSelf < 0.0f ) {
+                        vSelf = 0.0f;
+                    }
+                    if( vHit < 0.0f ) {
+                        vHit = 0.0f;
+                    }
+                    closing = vSelf + vHit;
+                    if( closing > 0.0f ) {
+                        totalDamage = closing * g_vehicleDamageScale.value;
+                        damageSelf = (int)( totalDamage * ( vHit / closing ) );
+                        damageHit = (int)( totalDamage * ( vSelf / closing ) );
+
+                        if( !self->takedamage ) {
+                            self->takedamage = qtrue;
+                            if( self->health <= 0 ) {
+                                self->health = 1000;
+                            }
+                        }
+                        if( !hit->takedamage ) {
+                            hit->takedamage = qtrue;
+                            if( hit->health <= 0 ) {
+                                hit->health = 1000;
+                            }
+                        }
+
+                        G_Damage( self, hit, hit, tr.plane.normal, tr.endpos, damageSelf, 0, MOD_VEHICLE_COLLISION );
+                        G_Damage( hit, self, self, invNormal, tr.endpos, damageHit, 0, MOD_VEHICLE_COLLISION );
+                    }
+                }
             }
 
             return;


### PR DESCRIPTION
## Summary
- compute relative speeds on collision to inflict vehicle damage
- add `g_vehicleDamageScale` cvar to scale collision damage
- introduce `MOD_VEHICLE_COLLISION` damage type (alias for legacy `MOD_CAR_COLLISION`)

## Testing
- `make release BUILD_GAME_SO=0 BUILD_SERVER=0` *(fails: SDL_version.h missing)*

------
https://chatgpt.com/codex/tasks/task_e_68b33aa607f08324b4f95ce0125d1aa1