### PR TITLE
Disable weapons in derby mode

### DIFF
--- a/engine/code/cgame/cg_predict.c
+++ b/engine/code/cgame/cg_predict.c
@@ -1004,9 +1004,9 @@ void CG_PredictPlayerState( void ) {
 			cg_pmove.cmd.upmove = 0;
 		}
 
-		if (isRallyNonDMRace()/* TEMP DERBY || cgs.gametype == GT_DERBY*/){
-			cg_pmove.cmd.weapon = cg.predictedPlayerState.weapon = WP_NONE;
-		}
+               if (isRallyNonDMRace() || cgs.gametype == GT_DERBY){
+                       cg_pmove.cmd.weapon = cg.predictedPlayerState.weapon = WP_NONE;
+               }
 // END
 
 // Q3Rally Code Start

--- a/engine/code/cgame/cg_weapons.c
+++ b/engine/code/cgame/cg_weapons.c
@@ -1175,9 +1175,9 @@ void CG_AddPlayerWeapon( refEntity_t *parent, playerState_t *ps, centity_t *cent
 
 	weaponNum = cent->currentState.weapon;
 
-	if (!isRallyNonDMRace()/* TEMP DERBY && cgs.gametype != GT_DERBY*/){
-		CG_RegisterWeapon( weaponNum );
-	}
+       if (!isRallyNonDMRace() && cgs.gametype != GT_DERBY){
+               CG_RegisterWeapon( weaponNum );
+       }
 
 	weapon = &cg_weapons[weaponNum];
 

--- a/engine/code/game/g_active.c
+++ b/engine/code/game/g_active.c
@@ -1171,10 +1171,10 @@ void ClientThink_real( gentity_t *ent ) {
 	}
 */
 
-	if (isRallyNonDMRace()/* TEMP DERBY || g_gametype.integer == GT_DERBY*/){
-		ent->s.weapon = WP_NONE;
-		ucmd->weapon = ent->s.weapon;
-	}
+       if (isRallyNonDMRace() || g_gametype.integer == GT_DERBY){
+               ent->s.weapon = WP_NONE;
+               ucmd->weapon = ent->s.weapon;
+       }
 
 // UPDATE - enable this
 	// sound horn

--- a/engine/code/game/g_client.c
+++ b/engine/code/game/g_client.c
@@ -1534,9 +1534,9 @@ void ClientSpawn(gentity_t *ent) {
 		}
 	}
 
-	if (!isRallyNonDMRace()/* TEMP DERBY && g_gametype.integer != GT_DERBY*/){
-		client->ps.stats[STAT_WEAPONS] |= ( 1 << WP_GAUNTLET );
-	}
+        if (!isRallyNonDMRace() && g_gametype.integer != GT_DERBY){
+                client->ps.stats[STAT_WEAPONS] |= ( 1 << WP_GAUNTLET );
+        }
 	else {
 		client->ps.stats[STAT_WEAPONS] &= ~( 1 << WP_GAUNTLET );
 	}
@@ -1677,9 +1677,9 @@ void ClientSpawn(gentity_t *ent) {
 			if (!isRallyRace() && g_gametype.integer != GT_DERBY ){
 				client->ps.weapon = WP_MACHINEGUN;
 			}
-			else if (!isRallyNonDMRace()/*TEMP DERBY && g_gametype.integer != GT_DERBY*/){
-				client->ps.weapon = WP_GAUNTLET;
-			}
+                        else if (!isRallyNonDMRace() && g_gametype.integer != GT_DERBY){
+                                client->ps.weapon = WP_GAUNTLET;
+                        }
 			else {
 				client->ps.weapon = WP_NONE;
 			}

--- a/engine/code/game/g_items.c
+++ b/engine/code/game/g_items.c
@@ -779,10 +779,14 @@ void FinishSpawningItem( gentity_t *ent ) {
 		ent->nextthink = level.time + respawn * 1000;
 		ent->think = RespawnItem;
 		return;
-	}
+       }
 
+       if ( g_gametype.integer == GT_DERBY && ent->item->giType == IT_WEAPON ) {
+               G_FreeEntity( ent );
+               return;
+       }
 
-	trap_LinkEntity (ent);
+       trap_LinkEntity (ent);
 }
 
 
@@ -895,12 +899,12 @@ void ClearRegisteredItems( void ) {
 
 	// players always start with the base weapon
 // STONELANCE dont start with machinegun in race
-	if (!isRallyRace()/* TEMP DERBY && g_gametype.integer != GT_DERBY*/){
-		RegisterItem( BG_FindItemForWeapon( WP_MACHINEGUN ) );
-	}
-	if (!isRallyNonDMRace()/* TEMP DERBY && g_gametype.integer != GT_DERBY*/){
-		RegisterItem( BG_FindItemForWeapon( WP_GAUNTLET ) );
-	}
+        if (!isRallyRace() && g_gametype.integer != GT_DERBY){
+                RegisterItem( BG_FindItemForWeapon( WP_MACHINEGUN ) );
+        }
+        if (!isRallyNonDMRace() && g_gametype.integer != GT_DERBY){
+                RegisterItem( BG_FindItemForWeapon( WP_GAUNTLET ) );
+        }
 //	RegisterItem( BG_FindItemForWeapon( WP_MACHINEGUN ) );
 //	RegisterItem( BG_FindItemForWeapon( WP_GAUNTLET ) );
 // END


### PR DESCRIPTION
## Summary
- Avoid giving machinegun or gauntlet when the gametype is GT_DERBY
- Skip weapon registration and spawning for Derby matches
- Force WP_NONE on server and client to remove weapon use and display

## Testing
- `make` *(fails: SDL_version.h: No such file or directory)*
- `apt-get update` *(fails: repository 403 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b34542b2988324838c8919f4b09bf8