### PR TITLE
Add configurable vehicle health and tune collision damage

### DIFF
--- a/engine/code/game/g_local.h
+++ b/engine/code/game/g_local.h
@@ -1004,6 +1004,7 @@ extern	vmCvar_t	g_trackLength;
 extern	vmCvar_t	g_developer;
 extern	vmCvar_t	g_damageScale;
 extern	vmCvar_t	g_vehicleDamageScale;
+extern	vmCvar_t	g_vehicleHealth;
 
 // car variables
 extern	vmCvar_t	car_spring;

--- a/engine/code/game/g_main.c
+++ b/engine/code/game/g_main.c
@@ -112,6 +112,7 @@ vmCvar_t	g_developer;
 
 vmCvar_t	g_damageScale;
 vmCvar_t	g_vehicleDamageScale;
+vmCvar_t	g_vehicleHealth;
 vmCvar_t  g_humanplayers;
 
 // car variables
@@ -259,7 +260,8 @@ static cvarTable_t		gameCvarTable[] = {
 	{ &car_friction_scale, "car_friction_scale", "1.1", 0, 0, qfalse },
 
 	{ &g_damageScale, "g_damageScale", "0.3", CVAR_ARCHIVE, 0, qfalse },
-	{ &g_vehicleDamageScale, "g_vehicleDamageScale", "0.1", CVAR_ARCHIVE, 0, qfalse },
+	{ &g_vehicleDamageScale, "g_vehicleDamageScale", "1.0", CVAR_ARCHIVE, 0, qfalse },
+	{ &g_vehicleHealth, "g_vehicleHealth", "100", CVAR_ARCHIVE, 0, qfalse },
 // END
 
 	{ &g_rankings, "g_rankings", "0", 0, 0, qfalse},

--- a/engine/code/game/g_rally_object_physics.c
+++ b/engine/code/game/g_rally_object_physics.c
@@ -295,13 +295,13 @@ void G_RallyObject_TracePhysics( gentity_t *self, float time )
                         if( !self->takedamage ) {
                             self->takedamage = qtrue;
                             if( self->health <= 0 ) {
-                                self->health = 1000;
+                                self->health = g_vehicleHealth.integer;
                             }
                         }
                         if( !hit->takedamage ) {
                             hit->takedamage = qtrue;
                             if( hit->health <= 0 ) {
-                                hit->health = 1000;
+                                hit->health = g_vehicleHealth.integer;
                             }
                         }
 


### PR DESCRIPTION
## Summary
- add `g_vehicleHealth` cvar for initial vehicle health
- scale vehicle collision damage via `g_vehicleDamageScale` default 1.0
- apply vehicle health when enabling damage in collisions

## Testing
- `cd engine && make` *(fails: SDL_version.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b34eb4a39c8324b722323710a4a7b4