### PR TITLE
Guarantee minimum damage from vehicle collisions

### DIFF
--- a/engine/code/game/g_rally_object_physics.c
+++ b/engine/code/game/g_rally_object_physics.c
@@ -289,8 +289,8 @@ void G_RallyObject_TracePhysics( gentity_t *self, float time )
                 closing = vSelf + vHit;
                 if( closing > 0.0f ) {
                     totalDamage = closing * g_vehicleDamageScale.value;
-                    damageSelf = (int)( totalDamage * ( vHit / closing ) );
-                    damageHit = (int)( totalDamage * ( vSelf / closing ) );
+                    damageSelf = (int)max( 1.0f, totalDamage * ( vHit / closing ) );
+                    damageHit = (int)max( 1.0f, totalDamage * ( vSelf / closing ) );
 
                     if( !self->takedamage ) {
                         self->takedamage = qtrue;


### PR DESCRIPTION
## Summary
- Ensure vehicle collisions always inflict at least 1 HP by clamping computed damage before converting to int

## Testing
- `make BUILD_GAME_SO=1 BUILD_CLIENT=0 BUILD_SERVER=0 BUILD_BASEGAME=1`

------
https://chatgpt.com/codex/tasks/task_e_68b353b9b0308324933585749b1c919d