### PR TITLE
Adjust vehicle damage scaling and introduce offset CVAR

### DIFF
--- a/engine/code/game/g_local.h
+++ b/engine/code/game/g_local.h
@@ -1004,6 +1004,7 @@ extern	vmCvar_t	g_trackLength;
 extern	vmCvar_t	g_developer;
 extern	vmCvar_t	g_damageScale;
 extern	vmCvar_t	g_vehicleDamageScale;
+extern  vmCvar_t        g_vehicleDamageOffset;
 extern	vmCvar_t	g_vehicleHealth;
 
 // car variables

--- a/engine/code/game/g_main.c
+++ b/engine/code/game/g_main.c
@@ -112,6 +112,7 @@ vmCvar_t	g_developer;
 
 vmCvar_t	g_damageScale;
 vmCvar_t	g_vehicleDamageScale;
+vmCvar_t        g_vehicleDamageOffset;
 vmCvar_t	g_vehicleHealth;
 vmCvar_t  g_humanplayers;
 
@@ -259,9 +260,10 @@ static cvarTable_t		gameCvarTable[] = {
 	{ &car_air_frac_to_df, "car_air_frac_to_df", "0.5", 0, 0, qfalse },
 	{ &car_friction_scale, "car_friction_scale", "1.1", 0, 0, qfalse },
 
-	{ &g_damageScale, "g_damageScale", "0.3", CVAR_ARCHIVE, 0, qfalse },
-	{ &g_vehicleDamageScale, "g_vehicleDamageScale", "1.0", CVAR_ARCHIVE, 0, qfalse },
-	{ &g_vehicleHealth, "g_vehicleHealth", "100", CVAR_ARCHIVE, 0, qfalse },
+        { &g_damageScale, "g_damageScale", "0.3", CVAR_ARCHIVE, 0, qfalse },
+        { &g_vehicleDamageScale, "g_vehicleDamageScale", "5.0", CVAR_ARCHIVE, 0, qfalse },
+        { &g_vehicleDamageOffset, "g_vehicleDamageOffset", "0", CVAR_ARCHIVE, 0, qfalse },
+        { &g_vehicleHealth, "g_vehicleHealth", "100", CVAR_ARCHIVE, 0, qfalse },
 // END
 
 	{ &g_rankings, "g_rankings", "0", 0, 0, qfalse},

--- a/engine/code/game/g_rally_object_physics.c
+++ b/engine/code/game/g_rally_object_physics.c
@@ -288,7 +288,7 @@ void G_RallyObject_TracePhysics( gentity_t *self, float time )
                 }
                 closing = vSelf + vHit;
                 if( closing > 0.0f ) {
-                    totalDamage = closing * g_vehicleDamageScale.value;
+                    totalDamage = ( closing + g_vehicleDamageOffset.value ) * g_vehicleDamageScale.value;
                     damageSelf = (int)max( 1.0f, totalDamage * ( vHit / closing ) );
                     damageHit = (int)max( 1.0f, totalDamage * ( vSelf / closing ) );
 


### PR DESCRIPTION
## Summary
- Increase default vehicle damage scaling for more impactful collisions
- Add optional `g_vehicleDamageOffset` CVAR to ensure damage even at low speeds
- Apply offset in rally object physics collision damage computation

## Testing
- `make` *(fails: SDL_version.h missing)*

------
https://chatgpt.com/codex/tasks/task_e_68b35d86e5388324820b3648cb3d2446