### PR TITLE
Avoid armor when vehicles collide

### DIFF
--- a/engine/code/game/g_rally_object_physics.c
+++ b/engine/code/game/g_rally_object_physics.c
@@ -305,8 +305,8 @@ void G_RallyObject_TracePhysics( gentity_t *self, float time )
                         }
                     }
 
-                    G_Damage( self, hit, hit, tr.plane.normal, tr.endpos, damageSelf, 0, MOD_VEHICLE_COLLISION );
-                    G_Damage( hit, self, self, invNormal, tr.endpos, damageHit, 0, MOD_VEHICLE_COLLISION );
+                    G_Damage( self, hit, hit, tr.plane.normal, tr.endpos, damageSelf, DAMAGE_NO_ARMOR, MOD_VEHICLE_COLLISION );
+                    G_Damage( hit, self, self, invNormal, tr.endpos, damageHit, DAMAGE_NO_ARMOR, MOD_VEHICLE_COLLISION );
                 }
             }
 


### PR DESCRIPTION
## Summary
- Avoid armor mitigation for vehicle collision damage by passing `DAMAGE_NO_ARMOR` to `G_Damage`

## Testing
- `make` *(fails: SDL_version.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b36205f3648324954abca26c0915d8