### PR TITLE
Add Derby damage configuration cvars

### DIFF
--- a/baseq3r/documents/readme.txt
+++ b/baseq3r/documents/readme.txt
@@ -62,3 +62,11 @@ We wish you much fun trying out this beta of Q3Rally.
 
 Thanks.
 
+
+** Derby Cvars **
+
+The following server cvars adjust vehicle collision damage in Demolition Derby mode:
+
+* `g_derbyDamageFactor` – scales the total damage dealt on impact (default `1.0`).
+* `g_derbyRammerDamageRatio` – controls how damage is split between the rammer and the vehicle hit. `1.0` deals equal damage to both, values above `1.0` favor the target, below `1.0` favor the rammer.
+

--- a/baseq3r/q3r_derby.cfg
+++ b/baseq3r/q3r_derby.cfg
@@ -1,7 +1,9 @@
 g_gametype 3
 timelimit 10
+g_derbyDamageFactor 1.0      // overall collision damage multiplier
+g_derbyRammerDamageRatio 1.0 // damage share for target (remainder to rammer)
 
- 
+
 sv_maxClients 16
 sv_hostname "Q3R Derby Server"
 g_motd "Happy Smashing!"

--- a/engine/code/game/g_local.h
+++ b/engine/code/game/g_local.h
@@ -1006,6 +1006,8 @@ extern	vmCvar_t	g_damageScale;
 extern	vmCvar_t	g_vehicleDamageScale;
 extern  vmCvar_t        g_vehicleDamageOffset;
 extern	vmCvar_t	g_vehicleHealth;
+extern  vmCvar_t        g_derbyDamageFactor;
+extern  vmCvar_t        g_derbyRammerDamageRatio;
 
 // car variables
 extern	vmCvar_t	car_spring;

--- a/engine/code/game/g_main.c
+++ b/engine/code/game/g_main.c
@@ -114,6 +114,8 @@ vmCvar_t	g_damageScale;
 vmCvar_t	g_vehicleDamageScale;
 vmCvar_t        g_vehicleDamageOffset;
 vmCvar_t	g_vehicleHealth;
+vmCvar_t        g_derbyDamageFactor;
+vmCvar_t        g_derbyRammerDamageRatio;
 vmCvar_t  g_humanplayers;
 
 // car variables
@@ -264,6 +266,8 @@ static cvarTable_t		gameCvarTable[] = {
         { &g_vehicleDamageScale, "g_vehicleDamageScale", "5.0", CVAR_ARCHIVE, 0, qfalse },
         { &g_vehicleDamageOffset, "g_vehicleDamageOffset", "0", CVAR_ARCHIVE, 0, qfalse },
         { &g_vehicleHealth, "g_vehicleHealth", "100", CVAR_ARCHIVE, 0, qfalse },
+	{ &g_derbyDamageFactor, "g_derbyDamageFactor", "1.0", CVAR_ARCHIVE, 0, qfalse },
+	{ &g_derbyRammerDamageRatio, "g_derbyRammerDamageRatio", "1.0", CVAR_ARCHIVE, 0, qfalse },
 // END
 
 	{ &g_rankings, "g_rankings", "0", 0, 0, qfalse},

--- a/engine/code/game/g_rally_object_physics.c
+++ b/engine/code/game/g_rally_object_physics.c
@@ -269,7 +269,7 @@ void G_RallyObject_TracePhysics( gentity_t *self, float time )
 
         if( hit->client != NULL || ( hit->r.svFlags & SVF_BOT ) ) {
             vec3_t invNormal;
-            float vSelf, vHit, closing, totalDamage;
+            float vSelf, vHit, closing, totalDamage, damageSelfF, damageHitF;
             int damageSelf, damageHit;
 
             /* store normal velocities before collision response */
@@ -289,8 +289,13 @@ void G_RallyObject_TracePhysics( gentity_t *self, float time )
                 closing = vSelf + vHit;
                 if( closing > 0.0f ) {
                     totalDamage = ( closing + g_vehicleDamageOffset.value ) * g_vehicleDamageScale.value;
-                    damageSelf = (int)max( 1.0f, totalDamage * ( vHit / closing ) );
-                    damageHit = (int)max( 1.0f, totalDamage * ( vSelf / closing ) );
+                    totalDamage *= g_derbyDamageFactor.value;
+                    damageSelfF = totalDamage * ( vHit / closing );
+                    damageHitF  = totalDamage * ( vSelf / closing );
+                    damageHitF  *= g_derbyRammerDamageRatio.value;
+                    damageSelfF *= 2.0f - g_derbyRammerDamageRatio.value;
+                    damageSelf = (int)max( 1.0f, damageSelfF );
+                    damageHit = (int)max( 1.0f, damageHitF );
 
                     if( !self->takedamage ) {
                         self->takedamage = qtrue;


### PR DESCRIPTION
## Summary
- allow tuning of demolition derby collision damage via new `g_derbyDamageFactor` and `g_derbyRammerDamageRatio` cvars
- apply the cvars in rally object collision physics
- document the new cvars in Derby docs and config example

## Testing
- `make` *(fails: SDL_version.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b369441b448324b9d274b0d56e6ac8