### PR TITLE
Add optional damage scaling override for derby collisions

### DIFF
--- a/engine/code/game/g_active.c
+++ b/engine/code/game/g_active.c
@@ -1525,6 +1525,8 @@ void ClientThink_real( gentity_t *ent ) {
 	{
 		if( !(pm.damage.dflags & DAMAGE_NO_PROTECTION) )
 			pm.damage.damage *= g_damageScale.value;
+		if ( g_gametype.integer == GT_DERBY && g_derbyIgnoreDamageScale.integer && g_damageScale.value )
+			pm.damage.damage /= g_damageScale.value;
 
 		if( pm.damage.damage > 0 )
 		{

--- a/engine/code/game/g_local.h
+++ b/engine/code/game/g_local.h
@@ -1008,6 +1008,7 @@ extern  vmCvar_t        g_vehicleDamageOffset;
 extern	vmCvar_t	g_vehicleHealth;
 extern  vmCvar_t        g_derbyDamageFactor;
 extern  vmCvar_t        g_derbyRammerDamageRatio;
+extern  vmCvar_t        g_derbyIgnoreDamageScale;
 
 // car variables
 extern	vmCvar_t	car_spring;

--- a/engine/code/game/g_main.c
+++ b/engine/code/game/g_main.c
@@ -116,6 +116,7 @@ vmCvar_t        g_vehicleDamageOffset;
 vmCvar_t	g_vehicleHealth;
 vmCvar_t        g_derbyDamageFactor;
 vmCvar_t        g_derbyRammerDamageRatio;
+vmCvar_t        g_derbyIgnoreDamageScale;
 vmCvar_t  g_humanplayers;
 
 // car variables
@@ -266,8 +267,9 @@ static cvarTable_t		gameCvarTable[] = {
         { &g_vehicleDamageScale, "g_vehicleDamageScale", "5.0", CVAR_ARCHIVE, 0, qfalse },
         { &g_vehicleDamageOffset, "g_vehicleDamageOffset", "0", CVAR_ARCHIVE, 0, qfalse },
         { &g_vehicleHealth, "g_vehicleHealth", "100", CVAR_ARCHIVE, 0, qfalse },
-	{ &g_derbyDamageFactor, "g_derbyDamageFactor", "1.0", CVAR_ARCHIVE, 0, qfalse },
-	{ &g_derbyRammerDamageRatio, "g_derbyRammerDamageRatio", "1.0", CVAR_ARCHIVE, 0, qfalse },
+        { &g_derbyDamageFactor, "g_derbyDamageFactor", "1.0", CVAR_ARCHIVE, 0, qfalse },
+        { &g_derbyRammerDamageRatio, "g_derbyRammerDamageRatio", "1.0", CVAR_ARCHIVE, 0, qfalse },
+       { &g_derbyIgnoreDamageScale, "g_derbyIgnoreDamageScale", "0", CVAR_ARCHIVE, 0, qfalse },
 // END
 
 	{ &g_rankings, "g_rankings", "0", 0, 0, qfalse},


### PR DESCRIPTION
## Summary
- allow derby mode to ignore g_damageScale when g_derbyIgnoreDamageScale is set
- add new g_derbyIgnoreDamageScale cvar

## Testing
- `make BUILD_GAME_QVM=1 BUILD_CLIENT=0 BUILD_SERVER=0 BUILD_GAME_SO=0 BUILD_BASEGAME=1 BUILD_MISSIONPACK=0`
- `cd engine/code/game/tests && make clean && make && make run`


------
https://chatgpt.com/codex/tasks/task_e_68b36d7cbb008324b9da37b7977b42e2