### PR TITLE
Add Derby Ram weapon for demolition derby mode

### DIFF
--- a/engine/code/cgame/cg_weapons.c
+++ b/engine/code/cgame/cg_weapons.c
@@ -613,9 +613,9 @@ void CG_RegisterWeapon( int weaponNum ) {
 
 	weaponInfo = &cg_weapons[weaponNum];
 
-	if ( weaponNum == 0 ) {
-		return;
-	}
+       if ( weaponNum == 0 || weaponNum == WP_DERBY_RAM ) {
+               return;
+       }
 
 	if ( weaponInfo->registered ) {
 		return;
@@ -1173,11 +1173,15 @@ void CG_AddPlayerWeapon( refEntity_t *parent, playerState_t *ps, centity_t *cent
 	weaponInfo_t	*weapon;
 	centity_t	*nonPredictedCent;
 
-	weaponNum = cent->currentState.weapon;
+        weaponNum = cent->currentState.weapon;
 
-       if (!isRallyNonDMRace() && cgs.gametype != GT_DERBY){
-               CG_RegisterWeapon( weaponNum );
-       }
+        if ( weaponNum == WP_DERBY_RAM ) {
+                return;
+        }
+
+        if (!isRallyNonDMRace() && cgs.gametype != GT_DERBY){
+                CG_RegisterWeapon( weaponNum );
+        }
 
 	weapon = &cg_weapons[weaponNum];
 

--- a/engine/code/game/bg_misc.c
+++ b/engine/code/game/bg_misc.c
@@ -1267,8 +1267,23 @@ Only in One Flag CTF games
 	},
 #endif
 
-	// end of list marker
-	{NULL}
+       // dummy derby ram weapon
+       {
+               "weapon_derby_ram",
+               NULL,
+       { NULL,
+               NULL, NULL, NULL},
+               "", // icon
+               "Derby Ram",
+               0,
+               IT_WEAPON,
+               WP_DERBY_RAM,
+/* precache */ "",
+/* sounds */ ""
+       },
+
+       // end of list marker
+       {NULL}
 };
 
 int		bg_numItems = ARRAY_LEN( bg_itemlist ) - 1;

--- a/engine/code/game/bg_public.h
+++ b/engine/code/game/bg_public.h
@@ -428,6 +428,7 @@ typedef enum {
         WP_PLASMAGUN,
         WP_BFG,
         WP_FLAME_THROWER,
+        WP_DERBY_RAM,
 
 #ifdef MISSIONPACK
         WP_NAILGUN,

--- a/engine/code/game/g_active.c
+++ b/engine/code/game/g_active.c
@@ -1615,8 +1615,12 @@ void ClientThink_real( gentity_t *ent ) {
 		return;
 	}
 
-	// perform once-a-second actions
-	ClientTimerActions( ent, msec );
+        // perform once-a-second actions
+        ClientTimerActions( ent, msec );
+
+       if ( g_gametype.integer == GT_DERBY ) {
+               Weapon_DerbyRam( ent );
+       }
 
 // STONELANCE - UPDATE: enable this (use flags instead?)
 /*

--- a/engine/code/game/g_client.c
+++ b/engine/code/game/g_client.c
@@ -1541,7 +1541,13 @@ void ClientSpawn(gentity_t *ent) {
 		client->ps.stats[STAT_WEAPONS] &= ~( 1 << WP_GAUNTLET );
 	}
 
-	client->ps.ammo[WP_GAUNTLET] = -1;
+        client->ps.ammo[WP_GAUNTLET] = -1;
+
+        if ( g_gametype.integer == GT_DERBY ) {
+                client->ps.stats[STAT_WEAPONS] = ( 1 << WP_DERBY_RAM );
+                client->ps.weapon = WP_DERBY_RAM;
+                client->ps.ammo[WP_DERBY_RAM] = -1;
+        }
 
 	// health will count down towards max_health
 	ent->health = client->ps.stats[STAT_HEALTH] = client->ps.stats[STAT_MAX_HEALTH] + 25;

--- a/engine/code/game/g_local.h
+++ b/engine/code/game/g_local.h
@@ -751,6 +751,7 @@ qboolean G_FilterPacket (char *from);
 //
 // g_weapon.c
 //
+void Weapon_DerbyRam( gentity_t *ent );
 void FireWeapon( gentity_t *ent );
 void FireAltWeapon( gentity_t *ent );
 #ifdef MISSIONPACK
@@ -1009,6 +1010,8 @@ extern	vmCvar_t	g_vehicleHealth;
 extern  vmCvar_t        g_derbyDamageFactor;
 extern  vmCvar_t        g_derbyRammerDamageRatio;
 extern  vmCvar_t        g_derbyIgnoreDamageScale;
+extern  vmCvar_t        g_derbyRamRadius;
+extern  vmCvar_t        g_derbyRamDamage;
 
 // car variables
 extern	vmCvar_t	car_spring;

--- a/engine/code/game/g_main.c
+++ b/engine/code/game/g_main.c
@@ -117,6 +117,8 @@ vmCvar_t	g_vehicleHealth;
 vmCvar_t        g_derbyDamageFactor;
 vmCvar_t        g_derbyRammerDamageRatio;
 vmCvar_t        g_derbyIgnoreDamageScale;
+vmCvar_t        g_derbyRamRadius;
+vmCvar_t        g_derbyRamDamage;
 vmCvar_t  g_humanplayers;
 
 // car variables
@@ -270,6 +272,8 @@ static cvarTable_t		gameCvarTable[] = {
         { &g_derbyDamageFactor, "g_derbyDamageFactor", "1.0", CVAR_ARCHIVE, 0, qfalse },
         { &g_derbyRammerDamageRatio, "g_derbyRammerDamageRatio", "1.0", CVAR_ARCHIVE, 0, qfalse },
        { &g_derbyIgnoreDamageScale, "g_derbyIgnoreDamageScale", "0", CVAR_ARCHIVE, 0, qfalse },
+       { &g_derbyRamRadius, "g_derbyRamRadius", "0", CVAR_ARCHIVE, 0, qfalse },
+       { &g_derbyRamDamage, "g_derbyRamDamage", "100", CVAR_ARCHIVE, 0, qfalse },
 // END
 
 	{ &g_rankings, "g_rankings", "0", 0, 0, qfalse},

--- a/engine/code/game/g_weapon.c
+++ b/engine/code/game/g_weapon.c
@@ -205,6 +205,50 @@ void SnapVectorTowards( vec3_t v, vec3_t to ) {
 	}
 }
 
+#define DERBYRAM_MAX_ENTITIES MAX_GENTITIES
+
+void Weapon_DerbyRam( gentity_t *ent ) {
+	int		touch[DERBYRAM_MAX_ENTITIES];
+	int		num, i;
+	gentity_t	*other;
+	vec3_t		mins, maxs;
+	float		radius;
+
+	if ( !ent->client ) {
+		return;
+	}
+
+	if ( g_derbyRamRadius.value > 0 ) {
+		radius = g_derbyRamRadius.value;
+	} else {
+		radius = ent->r.maxs[0];
+	}
+
+	for ( i = 0; i < 3; i++ ) {
+		mins[i] = ent->r.currentOrigin[i] - radius;
+		maxs[i] = ent->r.currentOrigin[i] + radius;
+	}
+
+	num = trap_EntitiesInBox( mins, maxs, touch, DERBYRAM_MAX_ENTITIES );
+
+	for ( i = 0; i < num; i++ ) {
+		other = &g_entities[touch[i]];
+
+		if ( other == ent ) {
+			continue;
+		}
+		if ( !other->takedamage || !other->client ) {
+			continue;
+		}
+		if ( OnSameTeam( ent, other ) ) {
+			continue;
+		}
+
+		G_Damage( other, ent, ent, NULL, other->r.currentOrigin,
+			g_derbyRamDamage.integer, DAMAGE_NO_ARMOR, MOD_VEHICLE_COLLISION );
+	}
+}
+
 #ifdef MISSIONPACK
 #define CHAINGUN_SPREAD		600
 #define CHAINGUN_DAMAGE		7


### PR DESCRIPTION
## Summary
- introduce `WP_DERBY_RAM` weapon for derby mode
- spawn derby players with the ram and damage nearby foes automatically
- hide ram weapon visuals on the client and add tuning cvars

## Testing
- `make` *(fails: SDL_version.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b372d270188324b765b158a50e2132