### PR TITLE
Restore custom death and pain sounds

### DIFF
--- a/engine/code/cgame/cg_event.c
+++ b/engine/code/cgame/cg_event.c
@@ -709,6 +709,7 @@ void CG_EntityEvent( centity_t *cent, vec3_t position ) {
 	int				event;
 	vec3_t			dir;
 	const char		*s;
+        sfxHandle_t             sfx;
 	int				clientNum;
 	clientInfo_t	*ci;
 
@@ -800,16 +801,15 @@ void CG_EntityEvent( centity_t *cent, vec3_t position ) {
 			cg.landTime = cg.time;
 		}
 		break;
-	case EV_FALL_MEDIUM:
-		DEBUGNAME("EV_FALL_MEDIUM");
-		// use normal pain sound
-		trap_S_StartSound( NULL, es->number, CHAN_VOICE, CG_CustomSound( es->number, "*pain100_1.wav" ) );
-		if ( clientNum == cg.predictedPlayerState.clientNum ) {
-			// smooth landing z changes
-			cg.landChange = -16;
-			cg.landTime = cg.time;
-		}
-		break;
+        case EV_FALL_MEDIUM:
+                DEBUGNAME("EV_FALL_MEDIUM");
+                trap_S_StartSound( NULL, es->number, CHAN_VOICE, cgs.media.damage100[(int)(random() * 2)] );
+                if ( clientNum == cg.predictedPlayerState.clientNum ) {
+                        // smooth landing z changes
+                        cg.landChange = -16;
+                        cg.landTime = cg.time;
+                }
+                break;
 	case EV_FALL_FAR:
 		DEBUGNAME("EV_FALL_FAR");
 // Q3Rally Code Start
@@ -1246,24 +1246,30 @@ void CG_EntityEvent( centity_t *cent, vec3_t position ) {
 		break;
 
 	case EV_GENERAL_SOUND:
-		DEBUGNAME("EV_GENERAL_SOUND");
-		if ( cgs.gameSounds[ es->eventParm ] ) {
-			trap_S_StartSound (NULL, es->number, CHAN_VOICE, cgs.gameSounds[ es->eventParm ] );
-		} else {
-			s = CG_ConfigString( CS_SOUNDS + es->eventParm );
-			trap_S_StartSound (NULL, es->number, CHAN_VOICE, CG_CustomSound( es->number, s ) );
-		}
-		break;
+                DEBUGNAME("EV_GENERAL_SOUND");
+                if ( cgs.gameSounds[ es->eventParm ] ) {
+                        trap_S_StartSound (NULL, es->number, CHAN_VOICE, cgs.gameSounds[ es->eventParm ] );
+                } else {
+                        s = CG_ConfigString( CS_SOUNDS + es->eventParm );
+                        sfx = CG_CustomSound( es->number, s );
+                        if ( sfx ) {
+                                trap_S_StartSound (NULL, es->number, CHAN_VOICE, sfx );
+                        }
+                }
+                break;
 
 	case EV_GLOBAL_SOUND:	// play from the player's head so it never diminishes
-		DEBUGNAME("EV_GLOBAL_SOUND");
-		if ( cgs.gameSounds[ es->eventParm ] ) {
-			trap_S_StartSound (NULL, cg.snap->ps.clientNum, CHAN_AUTO, cgs.gameSounds[ es->eventParm ] );
-		} else {
-			s = CG_ConfigString( CS_SOUNDS + es->eventParm );
-			trap_S_StartSound (NULL, cg.snap->ps.clientNum, CHAN_AUTO, CG_CustomSound( es->number, s ) );
-		}
-		break;
+                DEBUGNAME("EV_GLOBAL_SOUND");
+                if ( cgs.gameSounds[ es->eventParm ] ) {
+                        trap_S_StartSound (NULL, cg.snap->ps.clientNum, CHAN_AUTO, cgs.gameSounds[ es->eventParm ] );
+                } else {
+                        s = CG_ConfigString( CS_SOUNDS + es->eventParm );
+                        sfx = CG_CustomSound( es->number, s );
+                        if ( sfx ) {
+                                trap_S_StartSound (NULL, cg.snap->ps.clientNum, CHAN_AUTO, sfx );
+                        }
+                }
+                break;
 
 	case EV_GLOBAL_TEAM_SOUND:	// play from the player's head so it never diminishes
 		{

--- a/engine/code/cgame/cg_players.c
+++ b/engine/code/cgame/cg_players.c
@@ -34,27 +34,24 @@ char	*cg_customSoundNames[MAX_CUSTOM_SOUNDS] = {
 	"*engine5.wav",
 	"*engine6.wav",
 	"*engine7.wav",
-	"*engine8.wav",
-	"*engine9.wav",
-	"*engine10.wav",
-	"*horn.wav",
-	"*falling1.wav",
-/*
-	"*death1.wav",
-	"*death2.wav",
-	"*death3.wav",
-	"*jump1.wav",
-	"*pain25_1.wav",
-	"*pain50_1.wav",
-	"*pain75_1.wav",
-	"*pain100_1.wav",
-	"*falling1.wav",
-	"*gasp.wav",
-	"*drown.wav",
-	"*fall1.wav",
-	"*taunt.wav"
-*/
+        "*engine8.wav",
+        "*engine9.wav",
+        "*engine10.wav",
+        "*horn.wav",
 // END
+        "*death1.wav",
+        "*death2.wav",
+        "*death3.wav",
+        "*jump1.wav",
+        "*pain25_1.wav",
+        "*pain50_1.wav",
+        "*pain75_1.wav",
+        "*pain100_1.wav",
+        "*falling1.wav",
+        "*gasp.wav",
+        "*drown.wav",
+        "*fall1.wav",
+        "*taunt.wav"
 };
 
 
@@ -67,6 +64,10 @@ CG_CustomSound
 sfxHandle_t	CG_CustomSound( int clientNum, const char *soundName ) {
 	clientInfo_t *ci;
 	int			i;
+
+        if ( !soundName ) {
+                return 0;
+        }
 
 	if ( soundName[0] != '*' ) {
 		return trap_S_RegisterSound( soundName, qfalse );


### PR DESCRIPTION
## Summary
- Re-add classic death, drowning and pain sound names to `cg_customSoundNames`
- Guard `CG_CustomSound` against `NULL` sound names
- Replace direct `CG_CustomSound` usages in events with safe or default sounds

## Testing
- `make -C engine` *(fails: SDL_version.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b38499829883249f2820cbbbfa691a