### PR TITLE
Add speed-based derby ram damage

### DIFF
--- a/engine/code/game/g_local.h
+++ b/engine/code/game/g_local.h
@@ -1012,6 +1012,8 @@ extern  vmCvar_t        g_derbyRammerDamageRatio;
 extern  vmCvar_t        g_derbyIgnoreDamageScale;
 extern  vmCvar_t        g_derbyRamRadius;
 extern  vmCvar_t        g_derbyRamDamage;
+extern  vmCvar_t        g_derbyRamDamageScale;
+extern  vmCvar_t        g_derbyRamDamageMax;
 
 // car variables
 extern	vmCvar_t	car_spring;

--- a/engine/code/game/g_main.c
+++ b/engine/code/game/g_main.c
@@ -119,6 +119,8 @@ vmCvar_t        g_derbyRammerDamageRatio;
 vmCvar_t        g_derbyIgnoreDamageScale;
 vmCvar_t        g_derbyRamRadius;
 vmCvar_t        g_derbyRamDamage;
+vmCvar_t        g_derbyRamDamageScale;
+vmCvar_t        g_derbyRamDamageMax;
 vmCvar_t  g_humanplayers;
 
 // car variables
@@ -271,10 +273,12 @@ static cvarTable_t		gameCvarTable[] = {
         { &g_vehicleHealth, "g_vehicleHealth", "100", CVAR_ARCHIVE, 0, qfalse },
         { &g_derbyDamageFactor, "g_derbyDamageFactor", "1.0", CVAR_ARCHIVE, 0, qfalse },
         { &g_derbyRammerDamageRatio, "g_derbyRammerDamageRatio", "1.0", CVAR_ARCHIVE, 0, qfalse },
-       { &g_derbyIgnoreDamageScale, "g_derbyIgnoreDamageScale", "0", CVAR_ARCHIVE, 0, qfalse },
-       { &g_derbyRamRadius, "g_derbyRamRadius", "0", CVAR_ARCHIVE, 0, qfalse },
-       { &g_derbyRamDamage, "g_derbyRamDamage", "100", CVAR_ARCHIVE, 0, qfalse },
-// END
+        { &g_derbyIgnoreDamageScale, "g_derbyIgnoreDamageScale", "0", CVAR_ARCHIVE, 0, qfalse },
+        { &g_derbyRamRadius, "g_derbyRamRadius", "0", CVAR_ARCHIVE, 0, qfalse },
+        { &g_derbyRamDamage, "g_derbyRamDamage", "100", CVAR_ARCHIVE, 0, qfalse },
+        { &g_derbyRamDamageScale, "g_derbyRamDamageScale", "0.05", CVAR_ARCHIVE, 0, qfalse },
+        { &g_derbyRamDamageMax, "g_derbyRamDamageMax", "50", CVAR_ARCHIVE, 0, qfalse },
+        // END
 
 	{ &g_rankings, "g_rankings", "0", 0, 0, qfalse},
 	{ &g_localTeamPref, "g_localTeamPref", "", 0, 0, qfalse },

--- a/engine/code/game/g_weapon.c
+++ b/engine/code/game/g_weapon.c
@@ -208,19 +208,25 @@ void SnapVectorTowards( vec3_t v, vec3_t to ) {
 #define DERBYRAM_MAX_ENTITIES MAX_GENTITIES
 
 void Weapon_DerbyRam( gentity_t *ent ) {
-	float radius;
+        float radius;
+        float speed;
+        float damage;
 
-	if ( !ent->client ) {
-		return;
-	}
+        if ( !ent->client ) {
+                return;
+        }
 
-	if ( g_derbyRamRadius.value > 0 ) {
-		radius = g_derbyRamRadius.value;
-	} else {
-		radius = CAR_WIDTH;
-	}
+        if ( g_derbyRamRadius.value > 0 ) {
+                radius = g_derbyRamRadius.value;
+        } else {
+                radius = CAR_WIDTH;
+        }
 
-	G_RadiusDamage( ent->r.currentOrigin, ent, g_derbyRamDamage.integer, radius, ent, MOD_VEHICLE_COLLISION );
+        speed = VectorLength( ent->s.pos.trDelta );
+        damage = speed * g_derbyRamDamageScale.value;
+        damage = Com_Clamp( 1.0f, g_derbyRamDamageMax.value, damage );
+
+        G_RadiusDamage( ent->r.currentOrigin, ent, damage, radius, ent, MOD_VEHICLE_COLLISION );
 }
 
 


### PR DESCRIPTION
## Summary
- add CVars to scale derby ram damage based on speed and cap it
- compute vehicle speed in Weapon_DerbyRam and clamp resulting damage

## Testing
- `make -C engine/code/game/tests`

------
https://chatgpt.com/codex/tasks/task_e_68b38902e5c48324a2ccf5643b812a63