### PR TITLE
Add chain lightning alt fire with client effects

### DIFF
--- a/engine/code/cgame/cg_event.c
+++ b/engine/code/cgame/cg_event.c
@@ -1187,10 +1187,10 @@ void CG_EntityEvent( centity_t *cent, vec3_t position ) {
 		DEBUGNAME("EV_JUICED");
 		CG_InvulnerabilityJuiced( cent->lerpOrigin );
 		break;
-	case EV_LIGHTNINGBOLT:
-		DEBUGNAME("EV_LIGHTNINGBOLT");
-		CG_LightningBoltBeam(es->origin2, es->pos.trBase);
-		break;
+        case EV_LIGHTNINGBOLT:
+                DEBUGNAME("EV_LIGHTNINGBOLT");
+                CG_LightningArc(es->origin2, es->pos.trBase);
+                break;
 #endif
 	case EV_SCOREPLUM:
 		DEBUGNAME("EV_SCOREPLUM");

--- a/engine/code/cgame/cg_local.h
+++ b/engine/code/cgame/cg_local.h
@@ -1740,6 +1740,7 @@ void CG_ObeliskPain( vec3_t org );
 void CG_InvulnerabilityImpact( vec3_t org, vec3_t angles );
 void CG_InvulnerabilityJuiced( vec3_t org );
 void CG_LightningBoltBeam( vec3_t start, vec3_t end );
+void CG_LightningArc( vec3_t start, vec3_t end );
 #endif
 void CG_ScorePlum( int client, vec3_t org, int score );
 void CG_ShowDebris( vec3_t srcOrigin, int count, int evType );

--- a/engine/code/cgame/cg_weapons.c
+++ b/engine/code/cgame/cg_weapons.c
@@ -1086,10 +1086,38 @@ static void CG_LightningBolt( centity_t *cent, vec3_t origin ) {
 		angles[0] = rand() % 360;
 		angles[1] = rand() % 360;
 		angles[2] = rand() % 360;
-		AnglesToAxis( angles, beam.axis );
-		trap_R_AddRefEntityToScene( &beam );
-	}
+                AnglesToAxis( angles, beam.axis );
+                trap_R_AddRefEntityToScene( &beam );
+        }
 }
+
+#ifdef MISSIONPACK
+/*
+================
+CG_LightningArc
+
+Render a lightning bolt between two points and play the appropriate
+hit sound. Used for chained lightning segments.
+================
+*/
+void CG_LightningArc( vec3_t start, vec3_t end ) {
+        int r;
+        sfxHandle_t sfx;
+
+        CG_LightningBoltBeam( start, end );
+
+        r = rand() & 3;
+        if ( r < 2 ) {
+                sfx = cgs.media.sfx_lghit2;
+        } else if ( r == 2 ) {
+                sfx = cgs.media.sfx_lghit1;
+        } else {
+                sfx = cgs.media.sfx_lghit3;
+        }
+
+        trap_S_StartSound( end, ENTITYNUM_WORLD, CHAN_AUTO, sfx );
+}
+#endif
 
 /*
 ======================

--- a/engine/code/game/g_weapon.c
+++ b/engine/code/game/g_weapon.c
@@ -1079,6 +1079,144 @@ void Weapon_superLightningFire( gentity_t *ent ) {
 	}
 }
 
+/*
+======================================================================
+
+CHAIN LIGHTNING GUN (ALT FIRE)
+
+======================================================================
+*/
+
+#define LIGHTNING_CHAIN_RADIUS  256
+#define LIGHTNING_CHAIN_MAX     4
+
+/*
+================
+Weapon_LightningChainFire
+
+Fires a lightning beam and chains to nearby additional targets.
+Each additional target must be visible and within a fixed radius of
+the previous strike.  A temporary EV_LIGHTNINGBOLT entity is sent for
+each chained segment so clients can render the arc.
+================
+*/
+void Weapon_LightningChainFire( gentity_t *ent ) {
+        trace_t         tr;
+        vec3_t          end;
+        gentity_t       *traceEnt;
+        gentity_t       *tent;
+        vec3_t          start;
+        vec3_t          dir;
+        int                     damage;
+        gentity_t       *hit[LIGHTNING_CHAIN_MAX];
+        int                     numHit = 0;
+
+        damage = 8 * s_quadFactor;
+
+        // first strike straight out from the muzzle
+        VectorCopy( muzzle, start );
+        VectorMA( start, LIGHTNING_RANGE, forward, end );
+        trap_Trace( &tr, start, NULL, NULL, end, ent->s.number, MASK_SHOT );
+        if ( tr.entityNum == ENTITYNUM_NONE ) {
+                return;
+        }
+
+        if ( g_entities[ tr.entityNum ].flags & FL_EXTRA_BBOX ) {
+                traceEnt = &g_entities[ g_entities[ tr.entityNum ].r.ownerNum ];
+        } else {
+                traceEnt = &g_entities[ tr.entityNum ];
+        }
+
+        if ( !traceEnt->takedamage ) {
+                return;
+        }
+
+        VectorSubtract( traceEnt->r.currentOrigin, start, dir );
+        VectorNormalize( dir );
+
+        if ( LogAccuracyHit( traceEnt, ent ) ) {
+                ent->client->accuracy_hits++;
+        }
+
+        G_Damage( traceEnt, ent, ent, dir, tr.endpos,
+                  damage, DAMAGE_WEAPON, MOD_LIGHTNING );
+
+        hit[numHit++] = traceEnt;
+        VectorCopy( traceEnt->r.currentOrigin, start );
+
+        // chain to additional targets
+        for ( int chain = 1 ; chain < LIGHTNING_CHAIN_MAX ; chain++ ) {
+                int             entityList[MAX_GENTITIES];
+                int             numEnts;
+                vec3_t          mins, maxs;
+                gentity_t       *best = NULL;
+                float           bestDist = LIGHTNING_CHAIN_RADIUS * LIGHTNING_CHAIN_RADIUS;
+
+                for ( int i = 0 ; i < 3 ; i++ ) {
+                        mins[i] = start[i] - LIGHTNING_CHAIN_RADIUS;
+                        maxs[i] = start[i] + LIGHTNING_CHAIN_RADIUS;
+                }
+
+                numEnts = trap_EntitiesInBox( mins, maxs, entityList, MAX_GENTITIES );
+                for ( int e = 0 ; e < numEnts ; e++ ) {
+                        gentity_t *cand = &g_entities[ entityList[e] ];
+                        vec3_t      distVec;
+                        float       distSq;
+                        qboolean    already = qfalse;
+
+                        if ( !cand->takedamage || cand == ent ) {
+                                continue;
+                        }
+
+                        for ( int k = 0 ; k < numHit ; k++ ) {
+                                if ( hit[k] == cand ) {
+                                        already = qtrue;
+                                        break;
+                                }
+                        }
+                        if ( already ) {
+                                continue;
+                        }
+
+                        // verify line of sight
+                        trap_Trace( &tr, start, NULL, NULL, cand->r.currentOrigin,
+                                    ent->s.number, MASK_SHOT );
+                        if ( tr.entityNum != cand->s.number ) {
+                                continue;
+                        }
+
+                        VectorSubtract( cand->r.currentOrigin, start, distVec );
+                        distSq = VectorLengthSquared( distVec );
+                        if ( distSq < bestDist ) {
+                                bestDist = distSq;
+                                best = cand;
+                        }
+                }
+
+                if ( !best ) {
+                        break;
+                }
+
+                // notify clients of the arc
+                tent = G_TempEntity( start, EV_LIGHTNINGBOLT );
+                VectorCopy( best->r.currentOrigin, tent->s.origin2 );
+                SnapVector( tent->s.origin2 );
+
+                // apply damage
+                VectorSubtract( best->r.currentOrigin, start, dir );
+                VectorNormalize( dir );
+                G_Damage( best, ent, ent, dir, best->r.currentOrigin,
+                          damage, DAMAGE_WEAPON, MOD_LIGHTNING );
+
+                if ( LogAccuracyHit( best, ent ) ) {
+                        ent->client->accuracy_hits++;
+                }
+
+                hit[numHit++] = best;
+                VectorCopy( best->r.currentOrigin, start );
+        }
+}
+
 #ifdef MISSIONPACK
 /*
 ======================================================================
@@ -1442,9 +1580,9 @@ void FireAltWeapon( gentity_t *ent ) {
 	case WP_GAUNTLET:
 		Weapon_Gauntlet( ent );
 		break;
-	case WP_LIGHTNING:
-		Weapon_LightningFire( ent );
-		break;
+        case WP_LIGHTNING:
+                Weapon_LightningChainFire( ent );
+                break;
        case WP_SHOTGUN:
                weapon_shotgun_slug_fire( ent );
                break;


### PR DESCRIPTION
## Summary
- Add `Weapon_LightningChainFire` to arc lightning between nearby targets
- Swap lightning alt-fire to use new chain logic
- Show chain arcs with beam and hit sounds client-side

## Testing
- `cd engine && make` *(fails: SDL_version.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b3983a54b08324be36e3264ab6edce