### PR TITLE
Expose lightning bolt event across builds

### DIFF
--- a/engine/code/cgame/cg_event.c
+++ b/engine/code/cgame/cg_event.c
@@ -1187,12 +1187,12 @@ void CG_EntityEvent( centity_t *cent, vec3_t position ) {
 		DEBUGNAME("EV_JUICED");
 		CG_InvulnerabilityJuiced( cent->lerpOrigin );
 		break;
-        case EV_LIGHTNINGBOLT:
-                DEBUGNAME("EV_LIGHTNINGBOLT");
-                CG_LightningArc(es->origin2, es->pos.trBase);
-                break;
 #endif
-	case EV_SCOREPLUM:
+       case EV_LIGHTNINGBOLT:
+               DEBUGNAME("EV_LIGHTNINGBOLT");
+               CG_LightningArc(es->origin2, es->pos.trBase);
+               break;
+       case EV_SCOREPLUM:
 		DEBUGNAME("EV_SCOREPLUM");
 		CG_ScorePlum( cent->currentState.otherEntityNum, cent->lerpOrigin, cent->currentState.time );
 		break;

--- a/engine/code/game/bg_misc.c
+++ b/engine/code/game/bg_misc.c
@@ -1847,8 +1847,9 @@ char *eventnames[] = {
 	"EV_OBELISKPAIN",		// obelisk pain
 	"EV_INVUL_IMPACT",		// invulnerability sphere impact
 	"EV_JUICED",				// invulnerability juiced effect
-	"EV_LIGHTNINGBOLT",		// lightning bolt bounced of invulnerability sphere
 #endif
+	"EV_LIGHTNINGBOLT",		// lightning bolt bounced of invulnerability sphere
+
 
 	"EV_DEBUG_LINE",
 	"EV_STOPLOOPINGSOUND",

--- a/engine/code/game/bg_public.h
+++ b/engine/code/game/bg_public.h
@@ -570,8 +570,8 @@ typedef enum {
         EV_OBELISKPAIN,                 // obelisk is in pain
         EV_INVUL_IMPACT,                // invulnerability sphere impact
         EV_JUICED,                              // invulnerability juiced effect
-        EV_LIGHTNINGBOLT,               // lightning bolt bounced of invulnerability sphere
 #endif
+        EV_LIGHTNINGBOLT,               // lightning bolt bounced of invulnerability sphere
 
         EV_DEBUG_LINE,
         EV_STOPLOOPINGSOUND,


### PR DESCRIPTION
## Summary
- Always define the `EV_LIGHTNINGBOLT` event constant
- Ensure event name table and client event handler include `EV_LIGHTNINGBOLT` unconditionally

## Testing
- `make -C engine` *(fails: SDL_version.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b39a7b5e148324b5251da9c2985b34