### PR TITLE
Enable ref entity local effects without mission pack

### DIFF
--- a/engine/code/cgame/cg_local.h
+++ b/engine/code/cgame/cg_local.h
@@ -307,8 +307,8 @@ typedef enum {
 	LE_KAMIKAZE,
 	LE_INVULIMPACT,
 	LE_INVULJUICED,
-	LE_SHOWREFENTITY
 #endif
+	LE_SHOWREFENTITY
 } leType_t;
 
 typedef enum {

--- a/engine/code/cgame/cg_localents.c
+++ b/engine/code/cgame/cg_localents.c
@@ -810,6 +810,8 @@ void CG_AddInvulnerabilityJuiced( localEntity_t *le ) {
 	}
 }
 
+#endif
+
 /*
 ===================
 CG_AddRefEntity
@@ -823,7 +825,6 @@ void CG_AddRefEntity( localEntity_t *le ) {
 	trap_R_AddRefEntityToScene( &le->refEntity );
 }
 
-#endif
 /*
 ===================
 CG_AddScorePlum
@@ -986,10 +987,10 @@ void CG_AddLocalEntities( void ) {
 		case LE_INVULJUICED:
 			CG_AddInvulnerabilityJuiced( le );
 			break;
+#endif
 		case LE_SHOWREFENTITY:
 			CG_AddRefEntity( le );
 			break;
-#endif
 		}
 	}
 }


### PR DESCRIPTION
## Summary
- Always include `LE_SHOWREFENTITY` in local-entity type definitions
- Allow non-mission-pack builds to add and render `LE_SHOWREFENTITY`

## Testing
- `make` *(fails: SDL_version.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b3a99930788324a3a6d6ed44ea7297