### PR TITLE
Predeclare loop counters in Lightning chain fire

### DIFF
--- a/engine/code/game/g_weapon.c
+++ b/engine/code/game/g_weapon.c
@@ -1110,6 +1110,7 @@ void Weapon_LightningChainFire( gentity_t *ent ) {
         int                     damage;
         gentity_t       *hit[LIGHTNING_CHAIN_MAX];
         int                     numHit = 0;
+        int                     chain;
 
         damage = 8 * s_quadFactor;
 
@@ -1145,20 +1146,23 @@ void Weapon_LightningChainFire( gentity_t *ent ) {
         VectorCopy( traceEnt->r.currentOrigin, start );
 
         // chain to additional targets
-        for ( int chain = 1 ; chain < LIGHTNING_CHAIN_MAX ; chain++ ) {
+        for ( chain = 1 ; chain < LIGHTNING_CHAIN_MAX ; chain++ ) {
                 int             entityList[MAX_GENTITIES];
                 int             numEnts;
                 vec3_t          mins, maxs;
                 gentity_t       *best = NULL;
                 float           bestDist = LIGHTNING_CHAIN_RADIUS * LIGHTNING_CHAIN_RADIUS;
+                int             i;
+                int             e;
+                int             k;
 
-                for ( int i = 0 ; i < 3 ; i++ ) {
+                for ( i = 0 ; i < 3 ; i++ ) {
                         mins[i] = start[i] - LIGHTNING_CHAIN_RADIUS;
                         maxs[i] = start[i] + LIGHTNING_CHAIN_RADIUS;
                 }
 
                 numEnts = trap_EntitiesInBox( mins, maxs, entityList, MAX_GENTITIES );
-                for ( int e = 0 ; e < numEnts ; e++ ) {
+                for ( e = 0 ; e < numEnts ; e++ ) {
                         gentity_t *cand = &g_entities[ entityList[e] ];
                         vec3_t      distVec;
                         float       distSq;
@@ -1168,7 +1172,7 @@ void Weapon_LightningChainFire( gentity_t *ent ) {
                                 continue;
                         }
 
-                        for ( int k = 0 ; k < numHit ; k++ ) {
+                        for ( k = 0 ; k < numHit ; k++ ) {
                                 if ( hit[k] == cand ) {
                                         already = qtrue;
                                         break;


### PR DESCRIPTION
## Summary
- Predeclare `chain`, `i`, `e`, and `k` counters in `Weapon_LightningChainFire`
- Update loops to use the predeclared variables and keep declarations at block starts

## Testing
- `make -C engine/code/game/tests clean all run`
- `make -C engine release BUILD_GAME_SO=0 BUILD_SERVER=0` *(fails: SDL_version.h missing)*

------
https://chatgpt.com/codex/tasks/task_e_68b3ac0ea3f8832493e507fc52387d89