### PR TITLE
Use shared MAX_DEMOS limit for demo menus

### DIFF
--- a/engine/code/q3_ui/ui_demo2.c
+++ b/engine/code/q3_ui/ui_demo2.c
@@ -42,7 +42,6 @@ DEMOS MENU
 #define ART_RIGHT0      "menu/art/arrow_r0"
 #define ART_RIGHT1      "menu/art/arrow_r1"
 
-#define MAX_DEMOS			1024
 #define NAMEBUFSIZE			(MAX_DEMOS * 32)
 
 #define ID_BACK				10

--- a/engine/code/q3_ui/ui_local.h
+++ b/engine/code/q3_ui/ui_local.h
@@ -28,6 +28,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #include "../renderercommon/tr_types.h"
 //NOTE: include the ui_public.h from the new UI
 #include "../ui/ui_public.h"
+#include "../ui/ui_shared.h"
 //redefine to old API version
 #undef UI_API_VERSION
 #define UI_API_VERSION	4

--- a/engine/code/ui/ui_local.h
+++ b/engine/code/ui/ui_local.h
@@ -634,7 +634,6 @@ typedef struct {
 #define MAPS_PER_TIER 3
 #define MAX_TIERS 16
 #define MAX_MODS 64
-#define MAX_DEMOS 512
 #define MAX_MOVIES 256
 #define MAX_PLAYERMODELS 256
 

--- a/engine/code/ui/ui_shared.h
+++ b/engine/code/ui/ui_shared.h
@@ -78,6 +78,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #define MAX_STRING_HANDLES 4096
 
 #define MAX_SCRIPT_ARGS 12
+#define MAX_DEMOS 512
 #define MAX_EDITFIELD 256
 
 #define ART_FX_BASE			"menu/art/fx_base"


### PR DESCRIPTION
## Summary
- Move demo limit definition to shared UI header.
- Remove redundant MAX_DEMOS from legacy UI demo code and include shared header.
- Ensure demo list handling respects centralized MAX_DEMOS limit.

## Testing
- `make -C engine` *(fails: SDL_version.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b3f2e0fe70832485264d221218c4e2