### PR TITLE
Unify MAX_MENUITEMS definition across UI modules

### DIFF
--- a/engine/code/q3_ui/ui_local.h
+++ b/engine/code/q3_ui/ui_local.h
@@ -168,7 +168,6 @@ extern vmCvar_t	ui_mmap_fov;
 #define	MAX_EDIT_LINE			256
 
 #define MAX_MENUDEPTH			8
-#define MAX_MENUITEMS			128
 
 
 #define MTYPE_NULL				0

--- a/engine/code/ui/ui_local.h
+++ b/engine/code/ui/ui_local.h
@@ -143,7 +143,6 @@ extern vmCvar_t ui_serverStatusTimeOut;
 #define	MAX_EDIT_LINE			256
 
 #define MAX_MENUDEPTH			8
-#define MAX_MENUITEMS			96
 
 #define MTYPE_NULL				0
 #define MTYPE_SLIDER			1	

--- a/engine/code/ui/ui_shared.h
+++ b/engine/code/ui/ui_shared.h
@@ -35,7 +35,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #define MAX_MENUDEFFILE 4096
 #define MAX_MENUFILE 32768
 #define MAX_MENUS 64
-#define MAX_MENUITEMS 96
+#define MAX_MENUITEMS 128
 #define MAX_COLOR_RANGES 10
 #define MAX_OPEN_MENUS 16
 


### PR DESCRIPTION
## Summary
- Centralize `MAX_MENUITEMS` at 128 in `ui_shared.h` for consistent menu capacity across UI systems.
- Drop redundant local definitions from the Q3 and new UI headers.
- Ensure menu data structures and loops rely on the shared `MAX_MENUITEMS` value.

## Testing
- `make -C engine release BUILD_GAME_SO=0 BUILD_SERVER=0` *(fails: SDL_version.h: No such file or directory)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68b400918f688324bfb2b5375eb5db52