### PR TITLE
Document rear weapon visuals

### DIFF
--- a/engine/code/cgame/cg_rally_rearweapons.c
+++ b/engine/code/cgame/cg_rally_rearweapons.c
@@ -51,9 +51,13 @@ void CG_FireRearWeapon( centity_t *cent, int weapon ) {
 		CG_Error( "CG_FireRearWeapon: weapon >= WP_NUM_WEAPONS" );
 		return;
 	}
-	weap = &cg_weapons[ weapon ];
+        weap = &cg_weapons[ weapon ];
 
-	// play a sound
+        // Mines, smoke, flame, oil and bio visuals are ultimately handled by
+        // EV_HAZARD events (see CG_Hazard in cg_rally_tools.c); this switch
+        // simply initiates those effects.
+
+        // play a sound
 	for ( c = 0 ; c < 4 ; c++ ) {
 		if ( !weap->flashSound[c] ) {
 			break;
@@ -94,6 +98,7 @@ Sets up the centity to spit out smoke for 600 milliseconds after this is called.
 ================
 */
 void CG_StartSmokeScreen( centity_t *cent ){
+        // Visual handled via EV_HAZARD events -> CG_Hazard in cg_rally_tools.c
 }
 
 /*
@@ -104,6 +109,7 @@ Sets up the centity to spit out flame for 600 milliseconds after this is called.
 ================
 */
 void CG_StartFlameTrail( centity_t *cent ){
+        // Visual handled via EV_HAZARD events -> CG_Hazard in cg_rally_tools.c
 }
 
 /*
@@ -115,6 +121,7 @@ nearby it will add to that one instead.
 ================
 */
 void CG_DropOil( centity_t *cent ){
+        // Visual handled via EV_HAZARD events -> CG_Hazard in cg_rally_tools.c
 }
 
 /*
@@ -126,4 +133,5 @@ nearby it will add to that one instead.
 ================
 */
 void CG_DropBio( centity_t *cent ){
+        // Visual handled via EV_HAZARD events -> CG_Hazard in cg_rally_tools.c
 }


### PR DESCRIPTION
## Summary
- note that rear weapon effects like mines, smoke, flame, oil, and bio rely on EV_HAZARD -> CG_Hazard for visuals
- document empty rear weapon helper stubs with comments about CG_Hazard handling

## Testing
- `make` *(fails: SDL_version.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b418d955e883248ce8eeb75a603494