### PR TITLE
Add Rally Ball gametype support

### DIFF
--- a/engine/code/game/bg_public.h
+++ b/engine/code/game/bg_public.h
@@ -152,6 +152,7 @@ typedef enum {
         GT_CTF,                         // capture the flag
         GT_CTF4,                        // 4 team capture the flag
         GT_DOMINATION,              // domination
+        GT_RALLYBALL,               // rally ball
 // Q3Rally Code END
         GT_MAX_GAME_TYPE
 } gametype_t;

--- a/engine/code/game/g_main.c
+++ b/engine/code/game/g_main.c
@@ -1607,7 +1607,7 @@ qboolean ScoreIsTied( void ) {
 	
 // STONELANCE
 	// races or rallys can never be tied, otherwise then the level will not end
-	if ( g_gametype.integer == GT_DERBY || g_gametype.integer == GT_LCS || isRallyRace() )
+        if ( g_gametype.integer == GT_DERBY || g_gametype.integer == GT_LCS || g_gametype.integer == GT_RALLYBALL || isRallyRace() )
 	{
 /*
 		a = level.clients[level.sortedClients[0]].finishRaceTime;
@@ -1804,9 +1804,9 @@ void CheckExitRules( void ) {
 
 // STONELANCE
 	// dont check frags or captures during a race or derby
-	if ( isRallyRace() || g_gametype.integer == GT_DERBY || g_gametype.integer == GT_LCS ){
-		return;
-	}
+        if ( isRallyRace() || g_gametype.integer == GT_DERBY || g_gametype.integer == GT_LCS || g_gametype.integer == GT_RALLYBALL ){
+                return;
+        }
 // END
 
 	if ( g_fraglimit.integer < 0 ) {

--- a/engine/code/ui/ui_gameinfo.c
+++ b/engine/code/ui/ui_gameinfo.c
@@ -205,12 +205,15 @@ void UI_LoadArenasIntoMapList( void ) {
 			if( strstr( type, "overload" ) ) {
 				uiInfo.mapList[uiInfo.mapCount].typeBits |= (1 << GT_OBELISK);
 			}
-			if( strstr( type, "harvester" ) ) {
-				uiInfo.mapList[uiInfo.mapCount].typeBits |= (1 << GT_HARVESTER);
-			}
-		} else {
-			uiInfo.mapList[uiInfo.mapCount].typeBits |= (1 << GT_FFA);
-		}
+                        if( strstr( type, "harvester" ) ) {
+                                uiInfo.mapList[uiInfo.mapCount].typeBits |= (1 << GT_HARVESTER);
+                        }
+                        if( strstr( type, "rallyball" ) ) {
+                                uiInfo.mapList[uiInfo.mapCount].typeBits |= (1 << GT_RALLYBALL);
+                        }
+                } else {
+                        uiInfo.mapList[uiInfo.mapCount].typeBits |= (1 << GT_FFA);
+                }
 
 		uiInfo.mapCount++;
 		if (uiInfo.mapCount >= MAX_MAPS) {

--- a/engine/code/ui/ui_main.c
+++ b/engine/code/ui/ui_main.c
@@ -89,14 +89,15 @@ static const int numServerFilters = ARRAY_LEN( serverFilters );
 
 
 static const char *teamArenaGameTypes[] = {
-	"FFA",
-	"TOURNAMENT",
-	"SP",
-	"TEAM DM",
-	"CTF",
-	"1FCTF",
-	"OVERLOAD",
-	"HARVESTER"
+        "FFA",
+        "TOURNAMENT",
+        "SP",
+        "TEAM DM",
+        "CTF",
+        "1FCTF",
+        "OVERLOAD",
+        "HARVESTER",
+        "RALLY BALL"
 };
 
 static int const numTeamArenaGameTypes = ARRAY_LEN( teamArenaGameTypes );


### PR DESCRIPTION
## Summary
- add `GT_RALLYBALL` to gametype enum
- handle Rally Ball in game rules and exit checks
- allow UI to list Rally Ball maps and display Rally Ball in gametype names

## Testing
- `make` *(fails: SDL_version.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b422898f8c8324ae71bf226c3d795e