### PR TITLE
Add rally ball entity

### DIFF
--- a/engine/Makefile
+++ b/engine/Makefile
@@ -2814,6 +2814,7 @@ Q3GOBJ_ = \
   $(B)/$(BASEGAME)/game/g_rally_rearweapon.o \
   $(B)/$(BASEGAME)/game/g_rally_scripted_objects.o \
   $(B)/$(BASEGAME)/game/g_rally_tools.o \
+  $(B)/$(BASEGAME)/game/g_rallyball_ball.o \
   $(B)/$(BASEGAME)/game/g_session.o \
   $(B)/$(BASEGAME)/game/g_spawn.o \
   $(B)/$(BASEGAME)/game/g_svcmds.o \

--- a/engine/code/cgame/cg_ents.c
+++ b/engine/code/cgame/cg_ents.c
@@ -1258,17 +1258,20 @@ void CG_AddCEntity( centity_t *cent ) {
 	case ET_AUXENT:
 		CG_Auxent( cent );
 		break;
-	case ET_WEATHER:
-		CG_Weather( cent );
-		break;
-	case ET_SCRIPTED:
-		CG_Scripted_Object( cent );
-		break;
+        case ET_WEATHER:
+                CG_Weather( cent );
+                break;
+        case ET_SCRIPTED:
+                CG_Scripted_Object( cent );
+                break;
+        case ET_RALLYBALL:
+                CG_General( cent );
+                break;
 // Q3Rally Code END
-	case ET_TEAM:
-		CG_TeamBase( cent );
-		break;
-	}
+        case ET_TEAM:
+                CG_TeamBase( cent );
+                break;
+        }
 }
 
 /*

--- a/engine/code/game/bg_public.h
+++ b/engine/code/game/bg_public.h
@@ -888,9 +888,10 @@ typedef enum {
         ET_WEATHER,                             // used to specify per area weather
         ET_CHECKPOINT,
         ET_SCRIPTED,                    // used for our new scripted map objects
-        ET_AUXENT,                              // extra ent for passing car info to client
+	ET_AUXENT,                              // extra ent for passing car info to client
+	ET_RALLYBALL,                   // rally ball entity
 // END
-        ET_EVENTS                               // any of the EV_* events can be added freestanding
+	ET_EVENTS                               // any of the EV_* events can be added freestanding
                                                         // by setting eType to ET_EVENTS + eventNum
                                                         // this avoids having to set eFlags and eventNum
 } entityType_t;

--- a/engine/code/game/g_local.h
+++ b/engine/code/game/g_local.h
@@ -828,6 +828,8 @@ void G_RallyObject_ApplyForce( gentity_t *self, vec3_t force, vec3_t at );
 qboolean G_RallyObject_ApplyCollision( gentity_t *self, vec3_t at, vec3_t normal, float elasticity );
 void G_RallyObject_TracePhysics( gentity_t *self, float time );
 void G_RallyObject_IntegratePhysics( gentity_t *self, float time );
+// g_rallyball_ball.c
+gentity_t *G_SpawnRallyBall( vec3_t origin );
 // END
 
 

--- a/engine/code/game/g_rallyball_ball.c
+++ b/engine/code/game/g_rallyball_ball.c
@@ -1,0 +1,56 @@
+/*
+=============================================================================
+Copyright (C) 1999-2005 Id Software, Inc.
+Copyright (C) 2002-2025 Q3Rally Team (Per Thormann - q3rally@gmail.com)
+
+This file is part of q3rally source code.
+
+q3rally source code is free software; you can redistribute it
+and/or modify it under the terms of the GNU General Public License as
+published by the Free Software Foundation; either version 2 of the License,
+or (at your option) any later version.
+
+q3rally source code is distributed in the hope that it will be
+useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with q3rally; if not, write to the Free Software
+Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+=============================================================================
+*/
+
+#include "g_local.h"
+
+/*
+ * Basic rally ball entity implementation. The ball uses the
+ * generic item physics to move and bounce through the world.
+ */
+static void G_RallyBall_Think( gentity_t *ent ) {
+	ent->nextthink = level.time + FRAMETIME;
+}
+
+gentity_t *G_SpawnRallyBall( vec3_t origin ) {
+	gentity_t *ball;
+
+	ball = G_Spawn();
+	ball->classname = "rallyball";
+	ball->s.eType = ET_RALLYBALL;
+
+	ball->physicsObject = qtrue;
+	ball->physicsBounce = 0.6f;
+	ball->clipmask = MASK_SOLID;
+	ball->r.contents = CONTENTS_BODY;
+
+	ball->s.pos.trType = TR_GRAVITY;
+	ball->s.pos.trTime = level.time;
+	VectorCopy( origin, ball->s.pos.trBase );
+	VectorClear( ball->s.pos.trDelta );
+
+	ball->think = G_RallyBall_Think;
+	ball->nextthink = level.time + FRAMETIME;
+
+	trap_LinkEntity( ball );
+	return ball;
+}


### PR DESCRIPTION
## Summary
- add `ET_RALLYBALL` to shared entity types and compile in new rally ball logic
- render rally ball entities on the client
- register rally ball game code in the build system

## Testing
- `make -C engine` *(fails: SDL_version.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b42520e54c832480718bb11f287213