### PR TITLE
Implement rallyball game mode logic

### DIFF
--- a/engine/Makefile
+++ b/engine/Makefile
@@ -2815,6 +2815,7 @@ Q3GOBJ_ = \
   $(B)/$(BASEGAME)/game/g_rally_scripted_objects.o \
   $(B)/$(BASEGAME)/game/g_rally_tools.o \
   $(B)/$(BASEGAME)/game/g_rallyball_ball.o \
+  $(B)/$(BASEGAME)/game/g_rallyball.o \
   $(B)/$(BASEGAME)/game/g_session.o \
   $(B)/$(BASEGAME)/game/g_spawn.o \
   $(B)/$(BASEGAME)/game/g_svcmds.o \

--- a/engine/code/game/g_local.h
+++ b/engine/code/game/g_local.h
@@ -528,6 +528,11 @@ typedef struct {
 
         int                     testModelID;
 // END
+
+	// rallyball state
+	gentity_t	*rallyball;
+	vec3_t	rallyballSpawn;
+	int	rallyballEndTime;
 } level_locals_t;
 
 
@@ -556,6 +561,11 @@ extern void SP_team_CTF_redflag( gentity_t *ent );
 extern void SP_team_CTF_blueflag( gentity_t *ent );
 extern void SP_team_CTF_greenflag( gentity_t *ent );
 extern void SP_team_CTF_yellowflag( gentity_t *ent );
+
+extern void SP_trigger_rallyball_goal( gentity_t *ent );
+extern void SP_rallyball_spawn( gentity_t *ent );
+void G_RallyBall_Init( void );
+void G_RallyBall_RunFrame( void );
 
 
 //

--- a/engine/code/game/g_main.c
+++ b/engine/code/game/g_main.c
@@ -628,6 +628,11 @@ void G_InitGame( int levelTime, int randomSeed, int restart ) {
 	// parse the key/value pairs and spawn gentities
 	G_SpawnEntitiesFromString();
 
+
+        if ( g_gametype.integer == GT_RALLYBALL ) {
+                G_RallyBall_Init();
+        }
+
 	// general initialization
 	G_FindTeams();
 
@@ -2345,6 +2350,10 @@ void G_RunFrame( int levelTime ) {
 	// check team votes
 	CheckTeamVote( TEAM_RED );
 	CheckTeamVote( TEAM_BLUE );
+
+        if ( g_gametype.integer == GT_RALLYBALL ) {
+                G_RallyBall_RunFrame();
+        }
 
 	// for tracking changes
 	CheckCvars();

--- a/engine/code/game/g_rallyball.c
+++ b/engine/code/game/g_rallyball.c
@@ -1,0 +1,144 @@
+/*
+=============================================================================
+Copyright (C) 1999-2005 Id Software, Inc.
+Copyright (C) 2002-2025 Q3Rally Team (Per Thormann - q3rally@gmail.com)
+
+This file is part of q3rally source code.
+
+q3rally source code is free software; you can redistribute it
+and/or modify it under the terms of the GNU General Public License as
+published by the Free Software Foundation; either version 2 of the License,
+or (at your option) any later version.
+
+q3rally source code is distributed in the hope that it will be
+useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with q3rally; if not, write to the Free Software
+Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+=============================================================================
+*/
+
+#include "g_local.h"
+
+// forward declarations for functions from other modules
+void InitTrigger( gentity_t *self );
+void LogExit( const char *string );
+
+static void G_RallyBall_SpawnBall( void );
+
+/*
+=================
+G_RallyBall_Init
+
+Called when the level is initialized for the rallyball gametype.
+=================
+*/
+void G_RallyBall_Init( void ) {
+    // default spawn origin at world origin; maps can override via rallyball_spawn entity
+    VectorClear( level.rallyballSpawn );
+    G_RallyBall_SpawnBall();
+
+    if ( g_timelimit.integer ) {
+        level.rallyballEndTime = level.time + g_timelimit.integer * 60000;
+    } else {
+        level.rallyballEndTime = 0;
+    }
+}
+
+/*
+=================
+G_RallyBall_SpawnBall
+
+Spawns a new ball at the stored spawn origin.
+=================
+*/
+static void G_RallyBall_SpawnBall( void ) {
+    if ( level.rallyball ) {
+        G_FreeEntity( level.rallyball );
+        level.rallyball = NULL;
+    }
+    level.rallyball = G_SpawnRallyBall( level.rallyballSpawn );
+}
+
+/*
+=================
+G_RallyBall_RunFrame
+
+Per-frame updates for rallyball.
+=================
+*/
+void G_RallyBall_RunFrame( void ) {
+    if ( level.rallyballEndTime && level.time >= level.rallyballEndTime ) {
+        LogExit( "Rallyball time limit hit." );
+    }
+}
+
+/*
+=================
+G_RallyBall_GoalTouch
+
+Called when the rallyball touches a goal trigger.
+=================
+*/
+static void G_RallyBall_GoalTouch( gentity_t *self, gentity_t *other, trace_t *trace ) {
+    int team = TEAM_FREE;
+
+    if ( other->s.eType != ET_RALLYBALL ) {
+        return;
+    }
+
+    if ( self->spawnflags & 1 ) {
+        team = TEAM_RED;
+    } else if ( self->spawnflags & 2 ) {
+        team = TEAM_BLUE;
+    } else if ( self->spawnflags & 4 ) {
+        team = TEAM_GREEN;
+    } else if ( self->spawnflags & 8 ) {
+        team = TEAM_YELLOW;
+    }
+
+    if ( team != TEAM_FREE ) {
+        level.teamScores[ team ]++;
+        switch ( team ) {
+            case TEAM_RED:
+                trap_SetConfigstring( CS_SCORES1, va("%i", level.teamScores[TEAM_RED]) );
+                break;
+            case TEAM_BLUE:
+                trap_SetConfigstring( CS_SCORES2, va("%i", level.teamScores[TEAM_BLUE]) );
+                break;
+            case TEAM_GREEN:
+                trap_SetConfigstring( CS_SCORES3, va("%i", level.teamScores[TEAM_GREEN]) );
+                break;
+            case TEAM_YELLOW:
+                trap_SetConfigstring( CS_SCORES4, va("%i", level.teamScores[TEAM_YELLOW]) );
+                break;
+        }
+    }
+
+    // remove old ball and spawn a new one
+    if ( other == level.rallyball ) {
+        level.rallyball = NULL;
+    }
+    G_FreeEntity( other );
+    G_RallyBall_SpawnBall();
+}
+
+/*QUAKED trigger_rallyball_goal (.5 .5 .5) ? RED_GOAL BLUE_GOAL GREEN_GOAL YELLOW_GOAL
+A trigger volume that scores for the specified team when the rallyball touches it.
+*/
+void SP_trigger_rallyball_goal( gentity_t *ent ) {
+    ent->touch = G_RallyBall_GoalTouch;
+    InitTrigger( ent );
+    trap_LinkEntity( ent );
+}
+
+/*QUAKED rallyball_spawn (0 0.5 0.5) (-8 -8 -8) (8 8 8)
+Defines the spawn location for the rallyball.
+*/
+void SP_rallyball_spawn( gentity_t *ent ) {
+    VectorCopy( ent->s.origin, level.rallyballSpawn );
+    G_FreeEntity( ent );
+}


### PR DESCRIPTION
## Summary
- Add rallyball gametype implementation with goal scoring, ball respawn, and timer handling
- Integrate rallyball init and per-frame updates into main game loop
- Support rallyball goal triggers and spawn points
- Include new game source in build

## Testing
- `make release BUILD_GAME_QVM=1 BUILD_CLIENT=0 BUILD_SERVER=0 BUILD_GAME_SO=0 BUILD_BASEGAME=1 BUILD_RENDERER_OPENGL1=0 BUILD_RENDERER_OPENGL2=0 BUILD_AUTOUPDATER=0`

------
https://chatgpt.com/codex/tasks/task_e_68b42bee9b688324bd731e563fb5d874