### PR TITLE
Implement rallyball round start and hooks

### DIFF
--- a/engine/code/game/g_main.c
+++ b/engine/code/game/g_main.c
@@ -1089,26 +1089,27 @@ void CalculateRanks( void ) {
 		}
 	}
 
-	// set the CS_SCORES1/2 configstrings, which will be visible to everyone
-	if ( g_gametype.integer >= GT_TEAM ) {
-		trap_SetConfigstring( CS_SCORES1, va("%i", level.teamScores[TEAM_RED] ) );
-		trap_SetConfigstring( CS_SCORES2, va("%i", level.teamScores[TEAM_BLUE] ) );
-// STONELANCE
-		trap_SetConfigstring( CS_SCORES3, va("%i", level.teamScores[TEAM_GREEN] ) );
-		trap_SetConfigstring( CS_SCORES4, va("%i", level.teamScores[TEAM_YELLOW] ) );
-// END
-	} else {
-		if ( level.numConnectedClients == 0 ) {
-			trap_SetConfigstring( CS_SCORES1, va("%i", SCORE_NOT_PRESENT) );
-			trap_SetConfigstring( CS_SCORES2, va("%i", SCORE_NOT_PRESENT) );
-		} else if ( level.numConnectedClients == 1 ) {
-			trap_SetConfigstring( CS_SCORES1, va("%i", level.clients[ level.sortedClients[0] ].ps.persistant[PERS_SCORE] ) );
-			trap_SetConfigstring( CS_SCORES2, va("%i", SCORE_NOT_PRESENT) );
-		} else {
-			trap_SetConfigstring( CS_SCORES1, va("%i", level.clients[ level.sortedClients[0] ].ps.persistant[PERS_SCORE] ) );
-			trap_SetConfigstring( CS_SCORES2, va("%i", level.clients[ level.sortedClients[1] ].ps.persistant[PERS_SCORE] ) );
-		}
-	}
+        // set the CS_SCORES configstrings, which will be visible to everyone
+        if ( g_gametype.integer == GT_RALLYBALL ) {
+                trap_SetConfigstring( CS_SCORES1, va("%i", level.teamScores[TEAM_RED] ) );
+                trap_SetConfigstring( CS_SCORES2, va("%i", level.teamScores[TEAM_BLUE] ) );
+                trap_SetConfigstring( CS_SCORES3, va("%i", level.teamScores[TEAM_GREEN] ) );
+                trap_SetConfigstring( CS_SCORES4, va("%i", level.teamScores[TEAM_YELLOW] ) );
+        } else if ( g_gametype.integer >= GT_TEAM ) {
+                trap_SetConfigstring( CS_SCORES1, va("%i", level.teamScores[TEAM_RED] ) );
+                trap_SetConfigstring( CS_SCORES2, va("%i", level.teamScores[TEAM_BLUE] ) );
+        } else {
+                if ( level.numConnectedClients == 0 ) {
+                        trap_SetConfigstring( CS_SCORES1, va("%i", SCORE_NOT_PRESENT) );
+                        trap_SetConfigstring( CS_SCORES2, va("%i", SCORE_NOT_PRESENT) );
+                } else if ( level.numConnectedClients == 1 ) {
+                        trap_SetConfigstring( CS_SCORES1, va("%i", level.clients[ level.sortedClients[0] ].ps.persistant[PERS_SCORE] ) );
+                        trap_SetConfigstring( CS_SCORES2, va("%i", SCORE_NOT_PRESENT) );
+                } else {
+                        trap_SetConfigstring( CS_SCORES1, va("%i", level.clients[ level.sortedClients[0] ].ps.persistant[PERS_SCORE] ) );
+                        trap_SetConfigstring( CS_SCORES2, va("%i", level.clients[ level.sortedClients[1] ].ps.persistant[PERS_SCORE] ) );
+                }
+        }
 
 	// see if it is time to end the level
 	CheckExitRules();
@@ -1524,11 +1525,18 @@ void CheckIntermissionExit( void ) {
 	gclient_t	*cl;
 	int			readyMask;
 
-	if ( g_gametype.integer == GT_SINGLE_PLAYER ) {
-		return;
-	}
+        if ( g_gametype.integer == GT_SINGLE_PLAYER ) {
+                return;
+        }
 
-	// see which players are ready
+        if ( g_gametype.integer == GT_RALLYBALL ) {
+                if ( level.time >= level.intermissiontime + 5000 ) {
+                        ExitLevel();
+                }
+                return;
+        }
+
+        // see which players are ready
 	ready = 0;
 	notReady = 0;
 	readyMask = 0;

--- a/engine/code/game/g_rallyball.c
+++ b/engine/code/game/g_rallyball.c
@@ -28,6 +28,12 @@ void InitTrigger( gentity_t *self );
 void LogExit( const char *string );
 
 static void G_RallyBall_SpawnBall( void );
+static qboolean G_RallyBall_ScoresTied( void );
+
+static qboolean rbRoundActive;
+static int      rbRoundStartTime;
+static int      rbBallRespawnTime;
+static int      rbLastCountdown;
 
 /*
 =================
@@ -39,7 +45,11 @@ Called when the level is initialized for the rallyball gametype.
 void G_RallyBall_Init( void ) {
     // default spawn origin at world origin; maps can override via rallyball_spawn entity
     VectorClear( level.rallyballSpawn );
-    G_RallyBall_SpawnBall();
+    level.rallyball = NULL;
+    rbRoundActive = qfalse;
+    rbLastCountdown = -1;
+    rbRoundStartTime = level.time + 5000;
+    rbBallRespawnTime = rbRoundStartTime;
 
     if ( g_timelimit.integer ) {
         level.rallyballEndTime = level.time + g_timelimit.integer * 60000;
@@ -63,6 +73,23 @@ static void G_RallyBall_SpawnBall( void ) {
     level.rallyball = G_SpawnRallyBall( level.rallyballSpawn );
 }
 
+static qboolean G_RallyBall_ScoresTied( void ) {
+    int i;
+    int top = -1;
+    int second = -1;
+
+    for ( i = TEAM_RED; i <= TEAM_YELLOW; i++ ) {
+        if ( level.teamScores[i] > top ) {
+            second = top;
+            top = level.teamScores[i];
+        } else if ( level.teamScores[i] > second ) {
+            second = level.teamScores[i];
+        }
+    }
+
+    return top == second;
+}
+
 /*
 =================
 G_RallyBall_RunFrame
@@ -71,8 +98,30 @@ Per-frame updates for rallyball.
 =================
 */
 void G_RallyBall_RunFrame( void ) {
+    if ( !rbRoundActive ) {
+        int secs = ( rbRoundStartTime - level.time + 999 ) / 1000;
+        if ( secs > 0 ) {
+            if ( secs != rbLastCountdown ) {
+                trap_SendServerCommand( -1, va( "cp \"%i\"", secs ) );
+                rbLastCountdown = secs;
+            }
+            return;
+        }
+        rbRoundActive = qtrue;
+        trap_SendServerCommand( -1, "cp \"GO!\"" );
+    }
+
+    if ( !level.rallyball && level.time >= rbBallRespawnTime ) {
+        G_RallyBall_SpawnBall();
+    }
+
     if ( level.rallyballEndTime && level.time >= level.rallyballEndTime ) {
-        LogExit( "Rallyball time limit hit." );
+        if ( G_RallyBall_ScoresTied() ) {
+            level.rallyballEndTime = level.time + 60000;
+            trap_SendServerCommand( -1, "cp \"Overtime!\"" );
+        } else {
+            LogExit( "Rallyball time limit hit." );
+        }
     }
 }
 
@@ -123,7 +172,8 @@ static void G_RallyBall_GoalTouch( gentity_t *self, gentity_t *other, trace_t *t
         level.rallyball = NULL;
     }
     G_FreeEntity( other );
-    G_RallyBall_SpawnBall();
+    rbBallRespawnTime = level.time + 3000;
+    CalculateRanks();
 }
 
 /*QUAKED trigger_rallyball_goal (.5 .5 .5) ? RED_GOAL BLUE_GOAL GREEN_GOAL YELLOW_GOAL


### PR DESCRIPTION
## Summary
- Add round countdown, delayed ball respawn, and overtime handling for Rallyball
- Hook Rallyball into intermission exit and scoreboard rank calculation

## Testing
- `make -j2` *(fails: SDL_version.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b431316da08324b17261e75b516913