### PR TITLE
Add rallyball map entities and documentation

### DIFF
--- a/baseq3r/maps/rallyball_test.map
+++ b/baseq3r/maps/rallyball_test.map
@@ -1,0 +1,14 @@
+// entity 0
+{
+"classname" "worldspawn"
+}
+// entity 1
+{
+"classname" "rallyball_ball_spawn"
+"origin" "0 0 24"
+}
+// entity 2
+{
+"classname" "rallyball_goal"
+"origin" "128 0 24"
+}

--- a/engine/code/game/g_rally_mapobjects.c
+++ b/engine/code/game/g_rally_mapobjects.c
@@ -334,8 +334,40 @@ void SP_rally_misc_barreloil( gentity_t *ent ){
 //	ent->health = 1000;
 //	ent->takedamage = qtrue;
 
-	ent->s.origin[2] += 1;
-	DropToFloor(ent);
+        ent->s.origin[2] += 1;
+        DropToFloor(ent);
 
-	trap_LinkEntity (ent);
+        trap_LinkEntity (ent);
+}
+
+/*QUAKED rallyball_goal (0 0.5 0.5) (-16 -16 -16) (16 16 16)
+A static model marking a rallyball goal. Use in combination with a
+trigger_rallyball_goal brush. The optional "model" key specifies a
+different model.
+*/
+void SP_rallyball_goal( gentity_t *ent ) {
+    if ( !ent->model || !*ent->model ) {
+        ent->s.modelindex = G_ModelIndex( "models/mapobjects/rallyball/goal.md3" );
+    } else {
+        ent->s.modelindex = G_ModelIndex( ent->model );
+    }
+    ent->s.eType = ET_GENERAL;
+    trap_LinkEntity( ent );
+}
+
+/*QUAKED rallyball_ball_spawn (0 0.5 0.5) (-8 -8 -8) (8 8 8)
+Defines where the rallyball initially appears. Only one entity is needed.
+The optional "model" key sets a different model.
+*/
+void SP_rallyball_ball_spawn( gentity_t *ent ) {
+    // store spawn origin for rallyball game logic
+    VectorCopy( ent->s.origin, level.rallyballSpawn );
+
+    if ( !ent->model || !*ent->model ) {
+        ent->s.modelindex = G_ModelIndex( "models/mapobjects/rallyball/ball_spawn.md3" );
+    } else {
+        ent->s.modelindex = G_ModelIndex( ent->model );
+    }
+    ent->s.eType = ET_GENERAL;
+    trap_LinkEntity( ent );
 }

--- a/engine/code/game/g_spawn.c
+++ b/engine/code/game/g_spawn.c
@@ -211,6 +211,8 @@ void SP_rally_weather_snow( gentity_t *ent );
 
 // scripted map object
 void SP_rally_scripted_object( gentity_t *ent );
+void SP_rallyball_goal( gentity_t *ent );
+void SP_rallyball_ball_spawn( gentity_t *ent );
 // END
 
 spawn_t	spawns[] = {
@@ -312,10 +314,12 @@ spawn_t	spawns[] = {
 
 	{"rally_sun", SP_rally_sun},
 
-	{"rally_weather_rain", SP_rally_weather_rain},
-	{"rally_weather_snow", SP_rally_weather_snow},
+        {"rally_weather_rain", SP_rally_weather_rain},
+        {"rally_weather_snow", SP_rally_weather_snow},
 
-	{"rally_scripted_object", SP_rally_scripted_object},
+        {"rallyball_goal", SP_rallyball_goal},
+        {"rallyball_ball_spawn", SP_rallyball_ball_spawn},
+        {"rally_scripted_object", SP_rally_scripted_object},
 // END
 
 	{NULL, 0}

--- a/rally_scripted_objects_manual.txt
+++ b/rally_scripted_objects_manual.txt
@@ -1,7 +1,7 @@
 1.Scripted Objects in deiner Map einsetzen
 
 - Scriptdatei anlegen
-  Erstelle eine Datei *.script, in der du das Objekt beschreibst. Der Block rally_scripted_object definiert Eigenschaften wie Modell, zerstˆrtes Modell,
+  Erstelle eine Datei *.script, in der du das Objekt beschreibst. Der Block rally_scripted_object definiert Eigenschaften wie Modell, zerst√∂rtes Modell,
   Masse oder Sounds.
   
   Beispiel:
@@ -29,23 +29,23 @@ rally_scripted_object {
 
 2.Entity im Editor platzieren
 
-- In Radiant (oder einem kompatiblen Editor) w‰hlst du die Entity rally_scripted_object
+- In Radiant (oder einem kompatiblen Editor) w√§hlst du die Entity rally_scripted_object
   Setze die Key/Value-Paare:
 
   script ? Pfad zur oben erstellten Scriptdatei (ohne .script)
-  Optional: angle/angles f¸r Ausrichtung, targetname f¸r Trigger usw.
+  Optional: angle/angles f√ºr Ausrichtung, targetname f√ºr Trigger usw.
   Der Spawn-Code mappt das Feld script direkt auf das Entity ({ "script", FOFS(script), F_STRING }),
-  und die Entity-Klasse wird ¸ber rally_scripted_object gebunden
+  und die Entity-Klasse wird √ºber rally_scripted_object gebunden
         
 3.Im Spiel
 
-- Beim Laden der Map liest das Spiel den Pfad aus script und l‰dt die zugehˆrige Datei.
-  Ohne g¸ltige Scriptangabe wird das Objekt verworfen (No Script file specified).
+- Beim Laden der Map liest das Spiel den Pfad aus script und l√§dt die zugeh√∂rige Datei.
+  Ohne g√ºltige Scriptangabe wird das Objekt verworfen (No Script file specified).
   Steht moveable 1, unterliegt das Objekt der Physik.
-  Wird health auf >0 gesetzt, kann es zerstˆrt werden; deadmodel und gibs definieren das Aussehen und die Bruchst¸cke.
+  Wird health auf >0 gesetzt, kann es zerst√∂rt werden; deadmodel und gibs definieren das Aussehen und die Bruchst√ºcke.
   Die definierten Sounds (hitsound, presound, postsound, destroysound) werden automatisch abgespielt.
   
-  Mit diesen Schritten lassen sich in Q3Rally interaktive, zerstˆrbare oder bewegliche Objekte in die Map integrieren.
+  Mit diesen Schritten lassen sich in Q3Rally interaktive, zerst√∂rbare oder bewegliche Objekte in die Map integrieren.
   
 1. Use scripted objects in your map
 
@@ -95,5 +95,37 @@ rally_scripted_object {
   The defined sounds (hitsound, presound, postsound, destroysound) are played automatically.
 
   With these steps, interactive, destructible, or moving objects can be integrated into the map in Q3Rally.
+
+4. Rallyball-Entities
+
+- rallyball_ball_spawn: Startposition der Rallyball. Beispiel:
+
+{
+ "classname" "rallyball_ball_spawn"
+ "origin" "0 0 64"
+}
+
+- rallyball_goal: Sichtbares Torobjekt. Beispiel:
+
+{
+ "classname" "rallyball_goal"
+ "origin" "128 0 64"
+}
+
+4. Rallyball entities
+
+- rallyball_ball_spawn: Spawn location for the rallyball. Example:
+
+{
+ "classname" "rallyball_ball_spawn"
+ "origin" "0 0 64"
+}
+
+- rallyball_goal: Visible goal object. Example:
+
+{
+ "classname" "rallyball_goal"
+ "origin" "128 0 64"
+}
   
   


### PR DESCRIPTION
## Summary
- add `rallyball_goal` and `rallyball_ball_spawn` entity classes with default models
- document rallyball entities in scripting manual
- include a minimal test map using the new entities

## Testing
- `make -j2` *(fails: SDL_version.h: No such file or directory)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68b4366fa8f48324976e938958108505