### PR TITLE
Add rallyball scoreboard and HUD indicators

### DIFF
--- a/engine/code/cgame/cg_draw.c
+++ b/engine/code/cgame/cg_draw.c
@@ -25,6 +25,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 // active (after loading) gameplay
 
 #include "cg_local.h"
+#include <math.h>
 
 #ifdef MISSIONPACK
 #include "../ui/ui_shared.h"
@@ -3151,6 +3152,47 @@ static void CG_DrawSigilLocations( void ) {
     }
   }
 //==================================================================================
+
+static void CG_DrawRallyBallIndicator(void) {
+    int i;
+    centity_t *cent = NULL;
+    entityState_t *es;
+    vec3_t dir;
+    float yaw, relYaw, angle, x, y;
+    vec4_t color = {1,1,0,1};
+
+    if (!cg.snap) {
+        return;
+    }
+
+    for (i = 0; i < cg.snap->numEntities; i++) {
+        es = &cg.snap->entities[i];
+        if (es->eType == ET_RALLYBALL) {
+            cent = &cg_entities[es->number];
+            break;
+        }
+    }
+
+    if (!cent) {
+        return;
+    }
+
+    VectorSubtract(cent->lerpOrigin, cg.refdef.vieworg, dir);
+    if (VectorNormalize(dir) <= 0) {
+        return;
+    }
+
+    yaw = atan2(dir[1], dir[0]) * 180.0f / M_PI;
+    relYaw = AngleSubtract(yaw, cg.refdefViewAngles[YAW]);
+    angle = relYaw * (M_PI / 180.0f);
+    x = SCREEN_WIDTH / 2 + sin(angle) * 100.0f;
+    y = SCREEN_HEIGHT / 2 - cos(angle) * 100.0f;
+
+    trap_R_SetColor(color);
+    CG_DrawPic(x - 8, y - 8, 16, 16, cgs.media.whiteShader);
+    trap_R_SetColor(NULL);
+}
+
 #ifdef MISSIONPACK
 /* 
 =================
@@ -3235,9 +3277,12 @@ static void CG_Draw2D(stereoFrame_t stereoFrame)
 #else
 	
 #endif
-			CG_DrawReward();
-		}
-	}
+                        CG_DrawReward();
+                        if (cgs.gametype == GT_RALLYBALL) {
+                                CG_DrawRallyBallIndicator();
+                        }
+                }
+        }
 
 	if ( cgs.gametype >= GT_TEAM ) {
 #ifndef MISSIONPACK

--- a/engine/code/cgame/cg_event.c
+++ b/engine/code/cgame/cg_event.c
@@ -1363,12 +1363,20 @@ void CG_EntityEvent( centity_t *cent, vec3_t position ) {
 					break;
 #endif
 
-				case GTS_REDTEAM_SCORED:
-					CG_AddBufferedSound(cgs.media.redScoredSound);
-					break;
-				case GTS_BLUETEAM_SCORED:
-					CG_AddBufferedSound(cgs.media.blueScoredSound);
-					break;
+                                case GTS_REDTEAM_SCORED:
+                                        CG_AddBufferedSound(cgs.media.redScoredSound);
+                                        cg.rallyballGoalTime = cg.time;
+                                        cg.rallyballLastGoalTeam = es->otherEntityNum;
+                                        CG_CenterPrint(va("%s scores!", CG_GetTeamNameWithColor(es->otherEntityNum)),
+                                                       BIGCHAR_WIDTH * 2);
+                                        break;
+                                case GTS_BLUETEAM_SCORED:
+                                        CG_AddBufferedSound(cgs.media.blueScoredSound);
+                                        cg.rallyballGoalTime = cg.time;
+                                        cg.rallyballLastGoalTeam = es->otherEntityNum;
+                                        CG_CenterPrint(va("%s scores!", CG_GetTeamNameWithColor(es->otherEntityNum)),
+                                                       BIGCHAR_WIDTH * 2);
+                                        break;
 				case GTS_REDTEAM_TOOK_LEAD:
 					CG_AddBufferedSound(cgs.media.redLeadsSound);
 					break;

--- a/engine/code/cgame/cg_local.h
+++ b/engine/code/cgame/cg_local.h
@@ -690,6 +690,8 @@ typedef struct {
 	int			selectedScore;
 	int			teamScores[4];
 	int			teamTimes[4];
+        int     rallyballGoalTime;
+        team_t  rallyballLastGoalTeam;
 	score_t		scores[MAX_CLIENTS];
 	qboolean	showScores;
 	qboolean	scoreBoardShowing;

--- a/engine/code/cgame/cg_scoreboard.c
+++ b/engine/code/cgame/cg_scoreboard.c
@@ -23,6 +23,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 
 /* cg_scoreboard.c -- Adaptive scoreboard design for Q3Rally */
 #include "cg_local.h"
+#include <math.h>
 
 /* Modern scoreboard layout constants */
 #define MODERN_SB_Y             120
@@ -741,6 +742,40 @@ static void CG_DrawModernGameInfo(int y, float fade) {
     CG_DrawBigStringColor(x, y, gameInfo, titleColor);
 }
 
+static void CG_DrawRallyballTeamScores(int y) {
+    int xLeft, xRight, yTop, yBottom;
+    vec4_t color;
+
+    xLeft = SCREEN_WIDTH / 2 - 160;
+    xRight = SCREEN_WIDTH / 2 + 20;
+    yTop = y;
+    yBottom = y + BIGCHAR_HEIGHT + 4;
+
+    CG_GetModernTeamColor(TEAM_RED, color);
+    if (cg.rallyballLastGoalTeam == TEAM_RED && cg.time - cg.rallyballGoalTime < 2000) {
+        color[3] = 0.5f + 0.5f * sin((cg.time - cg.rallyballGoalTime) / 100.0f);
+    }
+    CG_DrawBigStringColor(xLeft, yTop, va("Red: %i", cg.teamScores[TEAM_RED - TEAM_RED]), color);
+
+    CG_GetModernTeamColor(TEAM_BLUE, color);
+    if (cg.rallyballLastGoalTeam == TEAM_BLUE && cg.time - cg.rallyballGoalTime < 2000) {
+        color[3] = 0.5f + 0.5f * sin((cg.time - cg.rallyballGoalTime) / 100.0f);
+    }
+    CG_DrawBigStringColor(xRight, yTop, va("Blue: %i", cg.teamScores[TEAM_BLUE - TEAM_RED]), color);
+
+    CG_GetModernTeamColor(TEAM_GREEN, color);
+    if (cg.rallyballLastGoalTeam == TEAM_GREEN && cg.time - cg.rallyballGoalTime < 2000) {
+        color[3] = 0.5f + 0.5f * sin((cg.time - cg.rallyballGoalTime) / 100.0f);
+    }
+    CG_DrawBigStringColor(xLeft, yBottom, va("Green: %i", cg.teamScores[TEAM_GREEN - TEAM_RED]), color);
+
+    CG_GetModernTeamColor(TEAM_YELLOW, color);
+    if (cg.rallyballLastGoalTeam == TEAM_YELLOW && cg.time - cg.rallyballGoalTime < 2000) {
+        color[3] = 0.5f + 0.5f * sin((cg.time - cg.rallyballGoalTime) / 100.0f);
+    }
+    CG_DrawBigStringColor(xRight, yBottom, va("Yellow: %i", cg.teamScores[TEAM_YELLOW - TEAM_RED]), color);
+}
+
 /*
 =================
 CG_DrawModernScoreboard
@@ -825,7 +860,12 @@ qboolean CG_DrawModernScoreboard(void) {
         CG_DrawBigStringColor(x, y, fragMsg, fragColor);
         y += BIGCHAR_HEIGHT + 16;
     }
-    
+
+    if (cgs.gametype == GT_RALLYBALL) {
+        CG_DrawRallyballTeamScores(y);
+        y += BIGCHAR_HEIGHT * 2 + 24;
+    }
+
     /* Draw game info */
     CG_DrawModernGameInfo(y, fade);
     y += BIGCHAR_HEIGHT + 24;

--- a/engine/code/game/g_rallyball.c
+++ b/engine/code/game/g_rallyball.c
@@ -165,6 +165,17 @@ static void G_RallyBall_GoalTouch( gentity_t *self, gentity_t *other, trace_t *t
                 trap_SetConfigstring( CS_SCORES4, va("%i", level.teamScores[TEAM_YELLOW]) );
                 break;
         }
+
+        {
+            gentity_t *te = G_TempEntity(other->s.pos.trBase, EV_GLOBAL_TEAM_SOUND);
+            te->r.svFlags |= SVF_BROADCAST;
+            te->s.otherEntityNum = team;
+            if (team == TEAM_RED || team == TEAM_GREEN) {
+                te->s.eventParm = GTS_REDTEAM_SCORED;
+            } else {
+                te->s.eventParm = GTS_BLUETEAM_SCORED;
+            }
+        }
     }
 
     // remove old ball and spawn a new one


### PR DESCRIPTION
## Summary
- Highlight rallyball scores with a new scoreboard layout and goal flash
- Show ball direction via HUD indicator and announce team goals
- Broadcast rallyball goal events from server for client notifications

## Testing
- `make` *(fails: SDL_version.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b43879a1f88324a2b8ea02a790855b