### PR TITLE
Ensure rallyball snapshots and event messaging

### DIFF
--- a/engine/code/client/cl_parse.c
+++ b/engine/code/client/cl_parse.c
@@ -30,12 +30,13 @@ char *svc_strings[256] = {
 	"svc_gamestate",
 	"svc_configstring",
 	"svc_baseline",	
-	"svc_serverCommand",
-	"svc_download",
-	"svc_snapshot",
-	"svc_EOF",
-	"svc_voipSpeex",
-	"svc_voipOpus",
+        "svc_serverCommand",
+        "svc_download",
+        "svc_snapshot",
+        "svc_rallyballEvent",
+        "svc_EOF",
+        "svc_voipSpeex",
+        "svc_voipOpus",
 };
 
 void SHOWNET( msg_t *msg, char *s) {
@@ -651,6 +652,28 @@ void CL_ParseDownload ( msg_t *msg ) {
 	}
 }
 
+/*
+=====================
+CL_ParseRallyballEvent
+
+Parse rallyball specific events from the server.
+=====================
+*/
+static void CL_ParseRallyballEvent( msg_t *msg ) {
+        int ev = MSG_ReadByte( msg );
+        switch ( ev ) {
+        case 0:
+                Com_Printf( "Rallyball: round start\n" );
+                break;
+        case 1:
+                Com_Printf( "Rallyball: goal scored\n" );
+                break;
+        default:
+                Com_Printf( "Rallyball: unknown event %d\n", ev );
+                break;
+        }
+}
+
 #ifdef USE_VOIP
 static
 qboolean CL_ShouldIgnoreVoipSender(int sender)
@@ -910,12 +933,15 @@ void CL_ParseServerMessage( msg_t *msg ) {
 		case svc_gamestate:
 			CL_ParseGamestate( msg );
 			break;
-		case svc_snapshot:
-			CL_ParseSnapshot( msg );
-			break;
-		case svc_download:
-			CL_ParseDownload( msg );
-			break;
+                case svc_snapshot:
+                        CL_ParseSnapshot( msg );
+                        break;
+                case svc_rallyballEvent:
+                        CL_ParseRallyballEvent( msg );
+                        break;
+                case svc_download:
+                        CL_ParseDownload( msg );
+                        break;
 		case svc_voipSpeex:
 #ifdef USE_VOIP
 			CL_ParseVoip( msg, qtrue );

--- a/engine/code/game/g_svcmds.c
+++ b/engine/code/game/g_svcmds.c
@@ -460,6 +460,37 @@ void	Svcmd_ForceTeam_f( void ) {
 char	*ConcatArgs( int start );
 
 /*
+===================
+Svcmd_SpawnRallyBall_f
+
+spawnrallyball <x> <y> <z>
+
+Allows spawning a rallyball entity from the server console for
+testing snapshot visibility.
+===================
+*/
+static void Svcmd_SpawnRallyBall_f( void ) {
+	vec3_t origin;
+	char   arg[MAX_TOKEN_CHARS];
+	int    i;
+
+	// default to predefined spawn location
+	VectorCopy( level.rallyballSpawn, origin );
+
+	if ( trap_Argc() >= 4 ) {
+		for ( i = 0; i < 3; i++ ) {
+			trap_Argv( i + 1, arg, sizeof( arg ) );
+			origin[i] = atof( arg );
+		}
+	}
+
+	if ( level.rallyball ) {
+		G_FreeEntity( level.rallyball );
+	}
+	level.rallyball = G_SpawnRallyBall( origin );
+}
+
+/*
 =================
 ConsoleCommand
 
@@ -490,15 +521,20 @@ qboolean	ConsoleCommand( void ) {
 		return qtrue;
 	}
 
-	if (Q_stricmp (cmd, "botlist") == 0) {
-		Svcmd_BotList_f();
-		return qtrue;
-	}
+        if (Q_stricmp (cmd, "botlist") == 0) {
+                Svcmd_BotList_f();
+                return qtrue;
+        }
 
-	if (Q_stricmp (cmd, "abort_podium") == 0) {
-		Svcmd_AbortPodium_f();
-		return qtrue;
-	}
+        if (Q_stricmp (cmd, "spawnrallyball") == 0) {
+                Svcmd_SpawnRallyBall_f();
+                return qtrue;
+        }
+
+        if (Q_stricmp (cmd, "abort_podium") == 0) {
+                Svcmd_AbortPodium_f();
+                return qtrue;
+        }
 
 	if (Q_stricmp (cmd, "addip") == 0) {
 		Svcmd_AddIP_f();

--- a/engine/code/qcommon/qcommon.h
+++ b/engine/code/qcommon/qcommon.h
@@ -297,6 +297,7 @@ enum svc_ops_e {
 	svc_serverCommand,			// [string] to be executed by client game module
 	svc_download,				// [short] size [size bytes]
 	svc_snapshot,
+	svc_rallyballEvent,		// rallyball-specific events (goal, start)
 	svc_EOF,
 
 // new commands, supported only by ioquake3 protocol but not legacy

--- a/engine/code/server/sv_snapshot.c
+++ b/engine/code/server/sv_snapshot.c
@@ -357,15 +357,21 @@ static void SV_AddEntitiesVisibleFromPoint( vec3_t origin, clientSnapshot_t *fra
 		svEnt = SV_SvEntityForGentity( ent );
 
 		// don't double add an entity through portals
-		if ( svEnt->snapshotCounter == sv.snapshotCounter ) {
-			continue;
-		}
+                if ( svEnt->snapshotCounter == sv.snapshotCounter ) {
+                        continue;
+                }
 
-		// broadcast entities are always sent
-		if ( ent->r.svFlags & SVF_BROADCAST ) {
-			SV_AddEntToSnapshot( svEnt, ent, eNums );
-			continue;
-		}
+                // broadcast entities are always sent
+                if ( ent->r.svFlags & SVF_BROADCAST ) {
+                        SV_AddEntToSnapshot( svEnt, ent, eNums );
+                        continue;
+                }
+
+                // rallyball must always be sent so clients can track the ball
+                if ( ent->s.eType == ET_RALLYBALL ) {
+                        SV_AddEntToSnapshot( svEnt, ent, eNums );
+                        continue;
+                }
 
 		// ignore if not touching a PV leaf
 		// check area


### PR DESCRIPTION
## Summary
- Always include rallyball entities in server snapshots
- Add `spawnrallyball` server command to spawn the ball for testing
- Introduce `svc_rallyballEvent` protocol message and client-side parser for rallyball events

## Testing
- `make -C engine/code/game/tests`
- `make -C engine/code/game/tests run`
- `gcc -Iengine/code/client -Iengine/code/qcommon -Iengine/code/game -DARCH_STRING="x86_64" -Wall -Wextra -std=c99 -c engine/code/client/cl_parse.c -o /tmp/cl_parse.o`
- `gcc -Iengine/code/server -Iengine/code/qcommon -Iengine/code/game -DARCH_STRING="x86_64" -Wall -Wextra -std=c99 -c engine/code/server/sv_snapshot.c -o /tmp/sv_snapshot.o`
- `gcc -Iengine/code/game -Iengine/code/qcommon -DARCH_STRING="x86_64" -Wall -Wextra -std=c99 -c engine/code/game/g_svcmds.c -o /tmp/g_svcmds.o`


------
https://chatgpt.com/codex/tasks/task_e_68b43bb0201c8324a2d6d4f14b1b5560