### PR TITLE
Add rallyball awareness to bot navigation and steering

### DIFF
--- a/engine/code/game/ai_dmnet.c
+++ b/engine/code/game/ai_dmnet.c
@@ -57,6 +57,11 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 // for the voice chats
 #include "../../ui/menudef.h"
 
+// Rallyball support
+qboolean BotGetRallyBallGoal(bot_state_t *bs, bot_goal_t *goal);
+qboolean BotRallyBallShot(bot_state_t *bs);
+void BotSteerToRallyBall(bot_state_t *bs);
+
 //goal flag, see ../botlib/be_ai_goal.h for the other GFL_*
 #define GFL_AIR			128
 
@@ -190,10 +195,15 @@ BotNearbyGoal
 ==================
 */
 int BotNearbyGoal(bot_state_t *bs, int tfl, bot_goal_t *ltg, float range) {
-	int ret;
+        int ret;
 
-	//check if the bot should go for air
-	if (BotGoForAir(bs, tfl, ltg, range)) return qtrue;
+        // rallyball has priority
+        if (BotGetRallyBallGoal(bs, ltg)) {
+                return qtrue;
+        }
+
+        //check if the bot should go for air
+        if (BotGoForAir(bs, tfl, ltg, range)) return qtrue;
 	// if the bot is carrying a flag or cubes
 	if (BotCTFCarryingFlag(bs)
 #ifdef MISSIONPACK
@@ -3145,4 +3155,75 @@ int AINode_MoveToNextCheckpoint( bot_state_t *bs )
 }
 // END
 
+/*
+==================
+BotGetRallyBallGoal
+==================
+*/
+qboolean BotGetRallyBallGoal(bot_state_t *bs, bot_goal_t *goal) {
+    if (g_gametype.integer != GT_RALLYBALL) {
+        return qfalse;
+    }
+    if (!level.rallyball) {
+        return qfalse;
+    }
+
+    VectorCopy(level.rallyball->r.currentOrigin, goal->origin);
+    goal->entitynum = level.rallyball->s.number;
+    goal->number = goal->entitynum;
+    goal->areanum = BotPointAreaNum(goal->origin);
+    if (!goal->areanum) {
+        return qfalse;
+    }
+    VectorSet(goal->mins, -8, -8, -8);
+    VectorSet(goal->maxs, 8, 8, 8);
+    goal->flags = 0;
+    return qtrue;
+}
+
+/*
+==================
+BotRallyBallShot
+==================
+*/
+qboolean BotRallyBallShot(bot_state_t *bs) {
+    gentity_t *goal = NULL;
+    vec3_t ballorg;
+
+    if (g_gametype.integer != GT_RALLYBALL || !level.rallyball) {
+        return qfalse;
+    }
+
+    VectorCopy(level.rallyball->r.currentOrigin, ballorg);
+    while ((goal = G_Find(goal, FOFS(classname), "trigger_rallyball_goal")) != NULL) {
+        vec3_t dir;
+        VectorSubtract(goal->s.origin, ballorg, dir);
+        if (VectorLength(dir) < 128) {
+            return qtrue;
+        }
+    }
+    return qfalse;
+}
+
+/*
+==================
+BotSteerToRallyBall
+==================
+*/
+void BotSteerToRallyBall(bot_state_t *bs) {
+    vec3_t dir;
+
+    if (g_gametype.integer != GT_RALLYBALL || !level.rallyball) {
+        return;
+    }
+
+    VectorSubtract(level.rallyball->r.currentOrigin, bs->origin, dir);
+    vectoangles(dir, bs->ideal_viewangles);
+    if (VectorLengthSquared(dir) > 1.0f) {
+        trap_EA_MoveForward(bs->client);
+    }
+    if (BotRallyBallShot(bs)) {
+        trap_EA_Attack(bs->client);
+    }
+}
 

--- a/engine/code/game/ai_dmnet.h
+++ b/engine/code/game/ai_dmnet.h
@@ -65,3 +65,8 @@ int AINode_MoveToNextCheckpoint(bot_state_t *bs);
 void BotResetNodeSwitches(void);
 void BotDumpNodeSwitches(bot_state_t *bs);
 
+// Rallyball helpers
+qboolean BotGetRallyBallGoal(bot_state_t *bs, bot_goal_t *goal);
+qboolean BotRallyBallShot(bot_state_t *bs);
+void BotSteerToRallyBall(bot_state_t *bs);
+

--- a/engine/code/game/ai_main.c
+++ b/engine/code/game/ai_main.c
@@ -1085,9 +1085,13 @@ int BotAI(int client, float thinktime) {
 	bs->eye[2] += bs->cur_ps.viewheight;
 	//get the area the bot is in
 	bs->areanum = BotPointAreaNum(bs->origin);
-	//the real AI
-	BotDeathmatchAI(bs, thinktime);
-	//set the weapon selection every AI frame
+        //the real AI
+        BotDeathmatchAI(bs, thinktime);
+
+        // rallyball steering adjustment
+        BotSteerToRallyBall(bs);
+
+        //set the weapon selection every AI frame
 	trap_EA_SelectWeapon(bs->client, bs->weaponnum);
 	//subtract the delta angles
 	for (j = 0; j < 3; j++) {


### PR DESCRIPTION
## Summary
- Prioritize rallyball as a nearby goal for bots
- Introduce helper routines to steer toward the ball and detect potential goal shots
- Invoke rallyball steering during main bot AI processing

## Testing
- `make -C engine/code/game/tests`
- `make -C engine/code/game/tests run`
- `make -C engine` *(fails: Interrupt)*
- `make -C engine BUILD_GAME_SO=1` *(fails: Interrupt)*

------
https://chatgpt.com/codex/tasks/task_e_68b43d9a94148324a8dbe7ed69e91f80