### PR TITLE
Expose physics parameters via config cvars

### DIFF
--- a/baseq3r/physics.cfg
+++ b/baseq3r/physics.cfg
@@ -1,0 +1,3 @@
+// Physics tuning parameters for internal testing
+seta ball_mass "50"
+seta boost_speed "4.5"

--- a/engine/code/cgame/cg_predict.c
+++ b/engine/code/cgame/cg_predict.c
@@ -924,6 +924,7 @@ void CG_PredictPlayerState( void ) {
 	cg_pmove.car_air_cof = CP_AIR_COF;
 	cg_pmove.car_air_frac_to_df = CP_FRAC_TO_DF;
 	cg_pmove.car_friction_scale = 1.1f;
+	cg_pmove.boost_speed = trap_Cvar_VariableValue("boost_speed");
 
 //	for ( cmdNum = current - CMD_BACKUP + 1 ; cmdNum <= current ; cmdNum++ ) {
 	count = 0;

--- a/engine/code/game/bg_public.h
+++ b/engine/code/game/bg_public.h
@@ -299,6 +299,7 @@ typedef struct {
         float           car_air_cof;
         float           car_air_frac_to_df;
         float           car_friction_scale;
+        float           boost_speed;
 // END
 } pmove_t;
 

--- a/engine/code/game/bg_wheel_forces.c
+++ b/engine/code/game/bg_wheel_forces.c
@@ -444,7 +444,7 @@ static void PM_TireEngineForces( car_t *car, carPoint_t *points, int i, vec3_t f
 	torque += friction;
 
 	if (pm->ps->powerups[PW_TURBO] > 0){
-		torque *= 4.5f;
+		torque *= pm->boost_speed;
 //		car->sPoints[0].scof *= 2.0f; // need to be able to set this back to normal
 //		car->sPoints[0].kcof *= 2.0f;
 	}

--- a/engine/code/game/g_active.c
+++ b/engine/code/game/g_active.c
@@ -1325,7 +1325,8 @@ void ClientThink_real( gentity_t *ent ) {
 
 	pm.car_air_cof = car_air_cof.value;
 	pm.car_air_frac_to_df = car_air_frac_to_df.value;
-	pm.car_friction_scale = car_friction_scale.value;
+        pm.car_friction_scale = car_friction_scale.value;
+        pm.boost_speed = boost_speed.value;
 // END
 
 	VectorCopy( client->ps.origin, client->oldOrigin );

--- a/engine/code/game/g_local.h
+++ b/engine/code/game/g_local.h
@@ -1044,6 +1044,8 @@ extern	vmCvar_t	car_body_elasticity;
 extern	vmCvar_t	car_air_cof;
 extern	vmCvar_t	car_air_frac_to_df;
 extern	vmCvar_t	car_friction_scale;
+extern  vmCvar_t        ball_mass;
+extern  vmCvar_t        boost_speed;
 // END
 
 void	trap_Print( const char *text );

--- a/engine/code/game/g_main.c
+++ b/engine/code/game/g_main.c
@@ -140,6 +140,8 @@ vmCvar_t	car_body_elasticity;
 vmCvar_t	car_air_cof;
 vmCvar_t	car_air_frac_to_df;
 vmCvar_t	car_friction_scale;
+vmCvar_t	ball_mass;
+vmCvar_t	boost_speed;
 // END
 
 // bk001129 - made static to avoid aliasing
@@ -266,8 +268,10 @@ static cvarTable_t		gameCvarTable[] = {
 	{ &car_air_cof, "car_air_cof", "0.31", 0, 0, qfalse },
 	{ &car_air_frac_to_df, "car_air_frac_to_df", "0.5", 0, 0, qfalse },
 	{ &car_friction_scale, "car_friction_scale", "1.1", 0, 0, qfalse },
+	{ &ball_mass, "ball_mass", "50", 0, 0, qfalse },
+	{ &boost_speed, "boost_speed", "4.5", 0, 0, qfalse },
 
-        { &g_damageScale, "g_damageScale", "0.3", CVAR_ARCHIVE, 0, qfalse },
+	{ &g_damageScale, "g_damageScale", "0.3", CVAR_ARCHIVE, 0, qfalse },
         { &g_vehicleDamageScale, "g_vehicleDamageScale", "5.0", CVAR_ARCHIVE, 0, qfalse },
         { &g_vehicleDamageOffset, "g_vehicleDamageOffset", "0", CVAR_ARCHIVE, 0, qfalse },
         { &g_vehicleHealth, "g_vehicleHealth", "100", CVAR_ARCHIVE, 0, qfalse },

--- a/engine/code/game/g_rallyball_ball.c
+++ b/engine/code/game/g_rallyball_ball.c
@@ -38,10 +38,11 @@ gentity_t *G_SpawnRallyBall( vec3_t origin ) {
 	ball->classname = "rallyball";
 	ball->s.eType = ET_RALLYBALL;
 
-	ball->physicsObject = qtrue;
-	ball->physicsBounce = 0.6f;
-	ball->clipmask = MASK_SOLID;
-	ball->r.contents = CONTENTS_BODY;
+        ball->physicsObject = qtrue;
+        ball->physicsBounce = 0.6f;
+        ball->clipmask = MASK_SOLID;
+        ball->r.contents = CONTENTS_BODY;
+        ball->mass = ball_mass.integer;
 
 	ball->s.pos.trType = TR_GRAVITY;
 	ball->s.pos.trTime = level.time;


### PR DESCRIPTION
## Summary
- Add `ball_mass` and `boost_speed` cvars for tuning physics
- Allow rally ball mass and turbo boost multiplier to be configured
- Provide example `physics.cfg` for internal testing

## Testing
- `cd engine && make BUILD_GAME_SO=1 BUILD_CLIENT=1 BUILD_SERVER=0 BUILD_BASEGAME=1 -j8` *(failed: SDL_version.h: No such file or directory)*
- `apt-get update` *(failed: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68b440004fcc83249af5f140a29244ec