### PR TITLE
Adjust center print for team scores

### DIFF
--- a/engine/code/cgame/cg_event.c
+++ b/engine/code/cgame/cg_event.c
@@ -1367,15 +1367,17 @@ void CG_EntityEvent( centity_t *cent, vec3_t position ) {
                                         CG_AddBufferedSound(cgs.media.redScoredSound);
                                         cg.rallyballGoalTime = cg.time;
                                         cg.rallyballLastGoalTeam = es->otherEntityNum;
-                                        CG_CenterPrint(va("%s scores!", CG_GetTeamNameWithColor(es->otherEntityNum)),
-                                                       BIGCHAR_WIDTH * 2);
+                                        CG_CenterPrint(
+                                               va("%s scores!", CG_GetTeamNameWithColor(es->otherEntityNum)),
+                                               SCREEN_HEIGHT * 0.30, BIGCHAR_WIDTH * 2);
                                         break;
                                 case GTS_BLUETEAM_SCORED:
                                         CG_AddBufferedSound(cgs.media.blueScoredSound);
                                         cg.rallyballGoalTime = cg.time;
                                         cg.rallyballLastGoalTeam = es->otherEntityNum;
-                                        CG_CenterPrint(va("%s scores!", CG_GetTeamNameWithColor(es->otherEntityNum)),
-                                                       BIGCHAR_WIDTH * 2);
+                                        CG_CenterPrint(
+                                               va("%s scores!", CG_GetTeamNameWithColor(es->otherEntityNum)),
+                                               SCREEN_HEIGHT * 0.30, BIGCHAR_WIDTH * 2);
                                         break;
 				case GTS_REDTEAM_TOOK_LEAD:
 					CG_AddBufferedSound(cgs.media.redLeadsSound);


### PR DESCRIPTION
## Summary
- set centerprint position based on screen height when a team scores

## Testing
- `make -C engine release BUILD_CLIENT=0 BUILD_SERVER=0 BUILD_GAME_SO=0` *(fails: code/cgame/cg_draw.c:28 Could not find include file <math.h>)*

------
https://chatgpt.com/codex/tasks/task_e_68b4457a0e548324b2517eb3c27781f7