### PR TITLE
Use string buffer to parse boost speed

### DIFF
--- a/engine/code/cgame/cg_predict.c
+++ b/engine/code/cgame/cg_predict.c
@@ -27,6 +27,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 // It also handles local physics interaction, like fragments bouncing off walls
 
 #include "cg_local.h"
+#include <stdlib.h>
 
 static	pmove_t		cg_pmove;
 
@@ -924,7 +925,9 @@ void CG_PredictPlayerState( void ) {
 	cg_pmove.car_air_cof = CP_AIR_COF;
 	cg_pmove.car_air_frac_to_df = CP_FRAC_TO_DF;
 	cg_pmove.car_friction_scale = 1.1f;
-	cg_pmove.boost_speed = trap_Cvar_VariableValue("boost_speed");
+	char boostBuf[MAX_CVAR_VALUE_STRING];
+	trap_Cvar_VariableStringBuffer("boost_speed", boostBuf, sizeof(boostBuf));
+	cg_pmove.boost_speed = atof(boostBuf);
 
 //	for ( cmdNum = current - CMD_BACKUP + 1 ; cmdNum <= current ; cmdNum++ ) {
 	count = 0;


### PR DESCRIPTION
## Summary
- safely fetch `boost_speed` cvar via string buffer and parse with `atof`
- include `<stdlib.h>` for `atof`

## Testing
- `make` *(fails: SDL_version.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b446f063908324935a6597a80ca870