### PR TITLE
Remove redundant math.h includes

### DIFF
--- a/engine/code/cgame/cg_draw.c
+++ b/engine/code/cgame/cg_draw.c
@@ -25,7 +25,6 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 // active (after loading) gameplay
 
 #include "cg_local.h"
-#include <math.h>
 
 #ifdef MISSIONPACK
 #include "../ui/ui_shared.h"

--- a/engine/code/cgame/cg_scoreboard.c
+++ b/engine/code/cgame/cg_scoreboard.c
@@ -23,7 +23,6 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 
 /* cg_scoreboard.c -- Adaptive scoreboard design for Q3Rally */
 #include "cg_local.h"
-#include <math.h>
 
 /* Modern scoreboard layout constants */
 #define MODERN_SB_Y             120


### PR DESCRIPTION
## Summary
- Drop unused `<math.h>` includes from `cg_draw.c` and `cg_scoreboard.c` since math utilities are provided by internal headers.

## Testing
- `make BUILD_CLIENT=0 BUILD_SERVER=0 BUILD_GAME_SO=1 BUILD_GAME_QVM=0`

------
https://chatgpt.com/codex/tasks/task_e_68b448ef09e88324b79f3c11eee6e606