### PR TITLE
Remove redundant stdlib include in cg_predict

### DIFF
--- a/engine/code/cgame/cg_predict.c
+++ b/engine/code/cgame/cg_predict.c
@@ -27,7 +27,6 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 // It also handles local physics interaction, like fragments bouncing off walls
 
 #include "cg_local.h"
-#include <stdlib.h>
 
 static	pmove_t		cg_pmove;
 


### PR DESCRIPTION
## Summary
- drop unused `<stdlib.h>` include from `cg_predict.c`; `atof` is declared in existing headers

## Testing
- `make BUILD_CLIENT=0 BUILD_SERVER=0 BUILD_GAME_SO=1 BUILD_GAME_QVM=0`

------
https://chatgpt.com/codex/tasks/task_e_68b44b22b22083248acd82e79d9e7c87