### PR TITLE
fix: parse boost_speed via string buffer

### DIFF
--- a/engine/code/cgame/cg_predict.c
+++ b/engine/code/cgame/cg_predict.c
@@ -679,6 +679,7 @@ void CG_PredictPlayerState( void ) {
 	centity_t	*cent;
 	int			i;
 	int			count, skipcount;
+	char			boostBuf[MAX_CVAR_VALUE_STRING];
 // END
 
 	cg.hyperspace = qfalse;	// will be set if touching a trigger_teleport
@@ -924,7 +925,6 @@ void CG_PredictPlayerState( void ) {
 	cg_pmove.car_air_cof = CP_AIR_COF;
 	cg_pmove.car_air_frac_to_df = CP_FRAC_TO_DF;
 	cg_pmove.car_friction_scale = 1.1f;
-	char boostBuf[MAX_CVAR_VALUE_STRING];
 	trap_Cvar_VariableStringBuffer("boost_speed", boostBuf, sizeof(boostBuf));
 	cg_pmove.boost_speed = atof(boostBuf);
 


### PR DESCRIPTION
## Summary
- declare `boostBuf` with other locals in `CG_PredictPlayerState`
- read `boost_speed` cvar via string buffer and convert using `atof`

## Testing
- `cd engine && make` *(fails: SDL_version.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b44f1a36488324937b9b2ac1223862