### PR TITLE
Assign rallyball model directly

### DIFF
--- a/engine/code/game/g_rallyball_ball.c
+++ b/engine/code/game/g_rallyball_ball.c
@@ -43,11 +43,12 @@ gentity_t *G_SpawnRallyBall( vec3_t origin ) {
         ball->clipmask = MASK_SOLID;
         ball->r.contents = CONTENTS_BODY;
         ball->mass = ball_mass.integer;
+        ball->s.modelindex = G_ModelIndex("models/mapobjects/rallyball/ball.md3");
 
-	ball->s.pos.trType = TR_GRAVITY;
-	ball->s.pos.trTime = level.time;
-	VectorCopy( origin, ball->s.pos.trBase );
-	VectorClear( ball->s.pos.trDelta );
+        ball->s.pos.trType = TR_GRAVITY;
+        ball->s.pos.trTime = level.time;
+        VectorCopy( origin, ball->s.pos.trBase );
+        VectorClear( ball->s.pos.trDelta );
 
 	ball->think = G_RallyBall_Think;
 	ball->nextthink = level.time + FRAMETIME;


### PR DESCRIPTION
## Summary
- Initialize rallyball entities with a direct model index instead of `G_SetModel`

## Testing
- `make` *(fails: SDL_version.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b45726c99c8324b6a0a44a9b14eee8