### PR TITLE
Add Rally Ball gametype to server menus

### DIFF
--- a/engine/code/q3_ui/ui_rally_startserver.c
+++ b/engine/code/q3_ui/ui_rally_startserver.c
@@ -97,12 +97,13 @@ static const char *gametype_items[] = {
 	"Capture the Flag",
 	"4-Team CTF",
     "Domination",
-	0
+    "Rally Ball",
+        0
 };
 
 // gametype_items[gametype_remap2[s_serveroptions.gametype]]
-static int gametype_remap[] = {GT_RACING, GT_RACING_DM, GT_DERBY, GT_LCS, GT_DEATHMATCH, GT_TEAM, GT_TEAM_RACING, GT_TEAM_RACING_DM, GT_CTF, GT_CTF4, GT_DOMINATION};
-static int gametype_remap2[] = {0, 1, 0, 2, 3, 4, 5, 6, 7, 8, 9, 10};
+static int gametype_remap[] = {GT_RACING, GT_RACING_DM, GT_DERBY, GT_LCS, GT_DEATHMATCH, GT_TEAM, GT_TEAM_RACING, GT_TEAM_RACING_DM, GT_CTF, GT_CTF4, GT_DOMINATION, GT_RALLYBALL};
+static int gametype_remap2[] = {0, 1, 0, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11};
 
 int		allowLength[3];
 int		reversable;

--- a/engine/code/q3_ui/ui_startserver.c
+++ b/engine/code/q3_ui/ui_startserver.c
@@ -95,18 +95,19 @@ typedef struct {
 static startserver_t s_startserver;
 
 static const char *gametype_items[] = {
-	"Free For All",
-	"Team Deathmatch",
-	"Tournament",
-	"Capture the Flag",
-	0
+        "Free For All",
+        "Team Deathmatch",
+        "Tournament",
+        "Capture the Flag",
+        "Rally Ball",
+        0
 };
 
 // STONELANCE - removed gametype
 // static int gametype_remap[] = {GT_FFA, GT_TEAM, GT_TOURNAMENT, GT_CTF};
-static int gametype_remap[] = {GT_RACING, GT_TEAM, GT_DERBY, GT_CTF};
+static int gametype_remap[] = {GT_RACING, GT_TEAM, GT_DERBY, GT_CTF, GT_RALLYBALL};
 // END
-static int gametype_remap2[] = {0, 2, 0, 1, 3};
+static int gametype_remap2[] = {0, 2, 0, 1, 3, 4};
 
 
 static void UI_ServerOptionsMenu( qboolean multiplayer );


### PR DESCRIPTION
## Summary
- add Rally Ball to start server gametype lists and remap arrays

## Testing
- `make` *(fails: SDL_version.h: No such file or directory)*
- `sudo apt-get update` *(fails: repository InRelease not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68b45af063188324bcc38b755d0056f8