### PR TITLE
Add Rallyball team spawn entity aliases

### DIFF
--- a/baseq3r/maps/rallyball_test.map
+++ b/baseq3r/maps/rallyball_test.map
@@ -12,3 +12,24 @@
 "classname" "rallyball_goal"
 "origin" "128 0 24"
 }
+
+// entity 3
+{
+"classname" "rallyball_redplayer"
+"origin" "-128 0 24"
+}
+// entity 4
+{
+"classname" "rallyball_redspawn"
+"origin" "-128 0 24"
+}
+// entity 5
+{
+"classname" "rallyball_blueplayer"
+"origin" "128 0 24"
+}
+// entity 6
+{
+"classname" "rallyball_bluespawn"
+"origin" "128 0 24"
+}

--- a/engine/code/game/g_local.h
+++ b/engine/code/game/g_local.h
@@ -557,6 +557,16 @@ extern void SP_team_CTF_bluespawn( gentity_t *ent );
 extern void SP_team_CTF_greenspawn( gentity_t *ent );
 extern void SP_team_CTF_yellowspawn( gentity_t *ent );
 
+extern void SP_rallyball_redplayer( gentity_t *ent );
+extern void SP_rallyball_blueplayer( gentity_t *ent );
+extern void SP_rallyball_greenplayer( gentity_t *ent );
+extern void SP_rallyball_yellowplayer( gentity_t *ent );
+
+extern void SP_rallyball_redspawn( gentity_t *ent );
+extern void SP_rallyball_bluespawn( gentity_t *ent );
+extern void SP_rallyball_greenspawn( gentity_t *ent );
+extern void SP_rallyball_yellowspawn( gentity_t *ent );
+
 extern void SP_team_CTF_redflag( gentity_t *ent );
 extern void SP_team_CTF_blueflag( gentity_t *ent );
 extern void SP_team_CTF_greenflag( gentity_t *ent );

--- a/engine/code/game/g_spawn.c
+++ b/engine/code/game/g_spawn.c
@@ -286,14 +286,24 @@ spawn_t	spawns[] = {
 	{"team_CTF_greenplayer", SP_team_CTF_greenplayer},
 	{"team_CTF_yellowplayer", SP_team_CTF_yellowplayer},
 
-	{"team_CTF_redspawn", SP_team_CTF_redspawn},
-	{"team_CTF_bluespawn", SP_team_CTF_bluespawn},
-	{"team_CTF_greenspawn", SP_team_CTF_greenspawn},
-	{"team_CTF_yellowspawn", SP_team_CTF_yellowspawn},
+        {"team_CTF_redspawn", SP_team_CTF_redspawn},
+        {"team_CTF_bluespawn", SP_team_CTF_bluespawn},
+        {"team_CTF_greenspawn", SP_team_CTF_greenspawn},
+        {"team_CTF_yellowspawn", SP_team_CTF_yellowspawn},
+
+        {"rallyball_redplayer", SP_rallyball_redplayer},
+        {"rallyball_blueplayer", SP_rallyball_blueplayer},
+        {"rallyball_greenplayer", SP_rallyball_greenplayer},
+        {"rallyball_yellowplayer", SP_rallyball_yellowplayer},
+
+        {"rallyball_redspawn", SP_rallyball_redspawn},
+        {"rallyball_bluespawn", SP_rallyball_bluespawn},
+        {"rallyball_greenspawn", SP_rallyball_greenspawn},
+        {"rallyball_yellowspawn", SP_rallyball_yellowspawn},
 
     {"team_CTF_redflag", SP_team_CTF_redflag},
     {"team_CTF_blueflag", SP_team_CTF_blueflag},
-	{"team_CTF_greenflag", SP_team_CTF_greenflag},
+        {"team_CTF_greenflag", SP_team_CTF_greenflag},
 	{"team_CTF_yellowflag", SP_team_CTF_yellowflag},
 
 	{"func_door_rotating", SP_func_door_rotating},	// Rotating Doors

--- a/engine/code/game/g_team.c
+++ b/engine/code/game/g_team.c
@@ -1347,29 +1347,55 @@ gentity_t *SelectRandomTeamSpawnPoint( int teamstate, team_t team ) {
 	gentity_t	*spots[MAX_TEAM_SPAWN_POINTS];
 	char		*classname;
 
-	if (teamstate == TEAM_BEGIN) {
-		if (team == TEAM_RED)
-			classname = "team_CTF_redplayer";
-		else if (team == TEAM_BLUE)
-			classname = "team_CTF_blueplayer";
-		else if (team == TEAM_GREEN)
-			classname = "team_CTF_greenplayer";
-		else if (team == TEAM_YELLOW)
-			classname = "team_CTF_yellowplayer";
-		else
-			return NULL;
-	} else {
-		if (team == TEAM_RED)
-			classname = "team_CTF_redspawn";
-		else if (team == TEAM_BLUE)
-			classname = "team_CTF_bluespawn";
-		else if (team == TEAM_GREEN)
-			classname = "team_CTF_greenspawn";
-		else if (team == TEAM_YELLOW)
-			classname = "team_CTF_yellowspawn";
-		else
-			return NULL;
-	}
+        if (teamstate == TEAM_BEGIN) {
+                if (level.gametype == GT_RALLYBALL) {
+                        if (team == TEAM_RED)
+                                classname = "rallyball_redplayer";
+                        else if (team == TEAM_BLUE)
+                                classname = "rallyball_blueplayer";
+                        else if (team == TEAM_GREEN)
+                                classname = "rallyball_greenplayer";
+                        else if (team == TEAM_YELLOW)
+                                classname = "rallyball_yellowplayer";
+                        else
+                                return NULL;
+                } else {
+                        if (team == TEAM_RED)
+                                classname = "team_CTF_redplayer";
+                        else if (team == TEAM_BLUE)
+                                classname = "team_CTF_blueplayer";
+                        else if (team == TEAM_GREEN)
+                                classname = "team_CTF_greenplayer";
+                        else if (team == TEAM_YELLOW)
+                                classname = "team_CTF_yellowplayer";
+                        else
+                                return NULL;
+                }
+        } else {
+                if (level.gametype == GT_RALLYBALL) {
+                        if (team == TEAM_RED)
+                                classname = "rallyball_redspawn";
+                        else if (team == TEAM_BLUE)
+                                classname = "rallyball_bluespawn";
+                        else if (team == TEAM_GREEN)
+                                classname = "rallyball_greenspawn";
+                        else if (team == TEAM_YELLOW)
+                                classname = "rallyball_yellowspawn";
+                        else
+                                return NULL;
+                } else {
+                        if (team == TEAM_RED)
+                                classname = "team_CTF_redspawn";
+                        else if (team == TEAM_BLUE)
+                                classname = "team_CTF_bluespawn";
+                        else if (team == TEAM_GREEN)
+                                classname = "team_CTF_greenspawn";
+                        else if (team == TEAM_YELLOW)
+                                classname = "team_CTF_yellowspawn";
+                        else
+                                return NULL;
+                }
+        }
 	count = 0;
 
 	spot = NULL;
@@ -1610,7 +1636,67 @@ potential spawning position for yellow team in CTF games.
 Targets will be fired when someone spawns in on them.
 */
 void SP_team_CTF_yellowspawn(gentity_t *ent) {
-	(void)ent;
+        (void)ent;
+}
+
+/*QUAKED rallyball_redplayer (1 0 0) (-16 -16 -16) (16 16 32)
+Only in Rallyball games.  Red players spawn here at game start.
+*/
+void SP_rallyball_redplayer( gentity_t *ent ) {
+        SP_team_CTF_redplayer( ent );
+}
+
+/*QUAKED rallyball_blueplayer (0 0 1) (-16 -16 -16) (16 16 32)
+Only in Rallyball games.  Blue players spawn here at game start.
+*/
+void SP_rallyball_blueplayer( gentity_t *ent ) {
+        SP_team_CTF_blueplayer( ent );
+}
+
+/*QUAKED rallyball_greenplayer (0 1 0) (-16 -16 -16) (16 16 32)
+Only in Rallyball games.  Green players spawn here at game start.
+*/
+void SP_rallyball_greenplayer( gentity_t *ent ) {
+        SP_team_CTF_greenplayer( ent );
+}
+
+/*QUAKED rallyball_yellowplayer (1 1 0) (-16 -16 -16) (16 16 32)
+Only in Rallyball games.  Yellow players spawn here at game start.
+*/
+void SP_rallyball_yellowplayer( gentity_t *ent ) {
+        SP_team_CTF_yellowplayer( ent );
+}
+
+/*QUAKED rallyball_redspawn (1 0 0) (-16 -16 -24) (16 16 32)
+potential spawning position for red team in Rallyball games.
+Targets will be fired when someone spawns in on them.
+*/
+void SP_rallyball_redspawn(gentity_t *ent) {
+        SP_team_CTF_redspawn( ent );
+}
+
+/*QUAKED rallyball_bluespawn (0 0 1) (-16 -16 -24) (16 16 32)
+potential spawning position for blue team in Rallyball games.
+Targets will be fired when someone spawns in on them.
+*/
+void SP_rallyball_bluespawn(gentity_t *ent) {
+        SP_team_CTF_bluespawn( ent );
+}
+
+/*QUAKED rallyball_greenspawn (0 1 0) (-16 -16 -24) (16 16 32)
+potential spawning position for green team in Rallyball games.
+Targets will be fired when someone spawns in on them.
+*/
+void SP_rallyball_greenspawn(gentity_t *ent) {
+        SP_team_CTF_greenspawn( ent );
+}
+
+/*QUAKED rallyball_yellowspawn (1 1 0) (-16 -16 -24) (16 16 32)
+potential spawning position for yellow team in Rallyball games.
+Targets will be fired when someone spawns in on them.
+*/
+void SP_rallyball_yellowspawn(gentity_t *ent) {
+        SP_team_CTF_yellowspawn( ent );
 }
 
 /*QUAKED team_CTF_redflag (1 0 0) (-16 -16 -16) (16 16 16)

--- a/tools/radiant-config/radiant15-netradiant/q3rally.game/baseq3r/entities.def
+++ b/tools/radiant-config/radiant15-netradiant/q3rally.game/baseq3r/entities.def
@@ -2091,6 +2091,78 @@ count : number of times this spawnpoint can be used to spawn a player. Omit or s
 
 //=============================================================================
 
+/*QUAKED rallyball_redplayer (1 .2 0) (-52 -26 -16) (52 26 16)
+Initial Red team spawning position for Rallyball games. This is where players spawn when they join the Red team.
+-------- KEYS --------
+target : this can point at a target_give entity for respawn freebies.
+target2 : this can point at a target_give entity for respawn freebies.
+count : number of times this spawnpoint can be used to spawn a player. Omit or set to 0 to set no limit.*/
+
+//=============================================================================
+
+/*QUAKED rallyball_redspawn (1 .2 0) (-52 -26 -16) (52 26 16)
+Red team respawning position for Rallyball games. This is where Red team players respawn after they get fragged.
+-------- KEYS --------
+target : this can point at a target_give entity for respawn freebies.
+target2 : this can point at a target_give entity for respawn freebies.
+count : number of times this spawnpoint can be used to spawn a player. Omit or set to 0 to set no limit.*/
+
+//=============================================================================
+
+/*QUAKED rallyball_blueplayer (0 .2 1) (-52 -26 -16) (52 26 16)
+Initial Blue team spawning position for Rallyball games. This is where players spawn when they join the Blue team.
+-------- KEYS --------
+target : this can point at a target_give entity for respawn freebies.
+target2 : this can point at a target_give entity for respawn freebies.
+count : number of times this spawnpoint can be used to spawn a player. Omit or set to 0 to set no limit.*/
+
+//=============================================================================
+
+/*QUAKED rallyball_bluespawn (0 .2 1) (-52 -26 -16) (52 26 16)
+Blue team respawning position for Rallyball games. This is where Blue team players respawn after they get fragged.
+-------- KEYS --------
+target : this can point at a target_give entity for respawn freebies.
+target2 : this can point at a target_give entity for respawn freebies.
+count : number of times this spawnpoint can be used to spawn a player. Omit or set to 0 to set no limit.*/
+
+//=============================================================================
+
+/*QUAKED rallyball_greenplayer (0 1 0) (-52 -26 -16) (52 26 16)
+Initial Green team spawning position for Rallyball games. This is where players spawn when they join the Green team.
+-------- KEYS --------
+target : this can point at a target_give entity for respawn freebies.
+target2 : this can point at a target_give entity for respawn freebies.
+count : number of times this spawnpoint can be used to spawn a player. Omit or set to 0 to set no limit.*/
+
+//=============================================================================
+
+/*QUAKED rallyball_greenspawn (0 1 0) (-52 -26 -16) (52 26 16)
+Green team respawning position for Rallyball games. This is where Green team players respawn after they get fragged.
+-------- KEYS --------
+target : this can point at a target_give entity for respawn freebies.
+target2 : this can point at a target_give entity for respawn freebies.
+count : number of times this spawnpoint can be used to spawn a player. Omit or set to 0 to set no limit.*/
+
+//=============================================================================
+
+/*QUAKED rallyball_yellowplayer (1 1 0) (-52 -26 -16) (52 26 16)
+Initial Yellow team spawning position for Rallyball games. This is where players spawn when they join the Yellow team.
+-------- KEYS --------
+target : this can point at a target_give entity for respawn freebies.
+target2 : this can point at a target_give entity for respawn freebies.
+count : number of times this spawnpoint can be used to spawn a player. Omit or set to 0 to set no limit.*/
+
+//=============================================================================
+
+/*QUAKED rallyball_yellowspawn (1 1 0) (-52 -26 -16) (52 26 16)
+Yellow team respawning position for Rallyball games. This is where Yellow team players respawn after they get fragged.
+-------- KEYS --------
+target : this can point at a target_give entity for respawn freebies.
+target2 : this can point at a target_give entity for respawn freebies.
+count : number of times this spawnpoint can be used to spawn a player. Omit or set to 0 to set no limit.*/
+
+//=============================================================================
+
 TRIGGER_* ENTITIES
 
 //=============================================================================


### PR DESCRIPTION
## Summary
- Introduce Rallyball-specific spawn entity wrappers in g_team and use them when selecting spawn points
- Extend spawn table and headers for new Rallyball team classes
- Document and demonstrate Rallyball spawns in Radiant entities.def and sample map

## Testing
- `make -C engine/code/game/tests`
- `./engine/code/game/tests/test_g_frictioncalc`
- `make -C engine` *(fails: SDL_version.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b45f9de650832491cd0796a49bc8d4