### PR TITLE
Use g_gametype for rallyball team spawns

### DIFF
--- a/engine/code/game/g_team.c
+++ b/engine/code/game/g_team.c
@@ -1348,7 +1348,7 @@ gentity_t *SelectRandomTeamSpawnPoint( int teamstate, team_t team ) {
 	char		*classname;
 
         if (teamstate == TEAM_BEGIN) {
-                if (level.gametype == GT_RALLYBALL) {
+               if (g_gametype.integer == GT_RALLYBALL) {
                         if (team == TEAM_RED)
                                 classname = "rallyball_redplayer";
                         else if (team == TEAM_BLUE)
@@ -1372,7 +1372,7 @@ gentity_t *SelectRandomTeamSpawnPoint( int teamstate, team_t team ) {
                                 return NULL;
                 }
         } else {
-                if (level.gametype == GT_RALLYBALL) {
+               if (g_gametype.integer == GT_RALLYBALL) {
                         if (team == TEAM_RED)
                                 classname = "rallyball_redspawn";
                         else if (team == TEAM_BLUE)


### PR DESCRIPTION
## Summary
- Fix rallyball spawn selection to rely on g_gametype instead of level.gametype for both initial and subsequent spawn checks

## Testing
- `make BUILD_CLIENT=0`

------
https://chatgpt.com/codex/tasks/task_e_68b46290470c8324a60812833568ac2d