### PR TITLE
Preserve custom rallyball spawn

### DIFF
--- a/engine/code/game/g_rallyball.c
+++ b/engine/code/game/g_rallyball.c
@@ -43,8 +43,7 @@ Called when the level is initialized for the rallyball gametype.
 =================
 */
 void G_RallyBall_Init( void ) {
-    // default spawn origin at world origin; maps can override via rallyball_spawn entity
-    VectorClear( level.rallyballSpawn );
+    // level.rallyballSpawn defaults to vec3_origin; maps can override via rallyball_spawn entity
     level.rallyball = NULL;
     rbRoundActive = qfalse;
     rbLastCountdown = -1;


### PR DESCRIPTION
## Summary
- avoid clearing `level.rallyballSpawn` during rallyball initialization so map-defined spawn points persist

## Testing
- `make` *(fails: SDL_version.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b49d6c76bc8324ab0ed4923f324b4e