### PR TITLE
Set rallyball collision bounds and origin

### DIFF
--- a/engine/code/game/g_rallyball_ball.c
+++ b/engine/code/game/g_rallyball_ball.c
@@ -23,6 +23,8 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 
 #include "g_local.h"
 
+#define RALLYBALL_RADIUS 8
+
 /*
  * Basic rally ball entity implementation. The ball uses the
  * generic item physics to move and bounce through the world.
@@ -50,9 +52,13 @@ gentity_t *G_SpawnRallyBall( vec3_t origin ) {
         VectorCopy( origin, ball->s.pos.trBase );
         VectorClear( ball->s.pos.trDelta );
 
-	ball->think = G_RallyBall_Think;
-	ball->nextthink = level.time + FRAMETIME;
+        ball->think = G_RallyBall_Think;
+        ball->nextthink = level.time + FRAMETIME;
 
-	trap_LinkEntity( ball );
-	return ball;
+        VectorSet( ball->r.mins, -RALLYBALL_RADIUS, -RALLYBALL_RADIUS, -RALLYBALL_RADIUS );
+        VectorSet( ball->r.maxs,  RALLYBALL_RADIUS,  RALLYBALL_RADIUS,  RALLYBALL_RADIUS );
+        G_SetOrigin( ball, origin );
+
+        trap_LinkEntity( ball );
+        return ball;
 }


### PR DESCRIPTION
## Summary
- define `RALLYBALL_RADIUS` and apply it to the rally ball entity's bounding box
- update rally ball spawn to set origin and link with collision bounds

## Testing
- `make BUILD_CLIENT=0 BUILD_SERVER=0 BUILD_GAME_SO=1`

------
https://chatgpt.com/codex/tasks/task_e_68b4a3f69db48324baee4af421162935