### PR TITLE
Include rally ball entities in G_RunItem processing

### DIFF
--- a/engine/code/game/g_main.c
+++ b/engine/code/game/g_main.c
@@ -2321,10 +2321,10 @@ void G_RunFrame( int levelTime ) {
 			continue;
 		}
 
-		if ( ent->s.eType == ET_ITEM || ent->physicsObject ) {
-			G_RunItem( ent );
-			continue;
-		}
+               if ( ent->s.eType == ET_ITEM || ent->physicsObject || ent->s.eType == ET_RALLYBALL ) {
+                       G_RunItem( ent );
+                       continue;
+               }
 
 		if ( ent->s.eType == ET_MOVER ) {
 			G_RunMover( ent );


### PR DESCRIPTION
## Summary
- Ensure rally ball entities are handled by `G_RunItem` so rally balls always run through item logic

## Testing
- `make` *(fails: SDL_version.h: No such file or directory)*
- `make BUILD_CLIENT=0`

------
https://chatgpt.com/codex/tasks/task_e_68b4b0ab7fbc8324b7831c2eb542c143