### PR TITLE
Add header guard and refine bg_misc includes

### DIFF
--- a/engine/code/game/bg_misc.c
+++ b/engine/code/game/bg_misc.c
@@ -24,11 +24,15 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 // bg_misc.c -- both games misc functions, all completely stateless
 
 #include "../qcommon/q_shared.h"
-#include "bg_public.h"
-#if defined(QAGAME)
-#include "g_local.h"
-#elif defined(CGAME)
+
+#ifdef CGAME
 #include "../cgame/cg_local.h"
+#else
+#include "bg_public.h"
+#endif
+
+#ifdef QAGAME
+#include "g_local.h"
 #endif
 
 /*QUAKED item_***** ( 0 0 0 ) (-16 -16 -16) (16 16 16) suspended

--- a/engine/code/game/bg_public.h
+++ b/engine/code/game/bg_public.h
@@ -23,6 +23,9 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 //
 // bg_public.h -- definitions shared by both the server game and client game modules
 
+#ifndef BG_PUBLIC_H
+#define BG_PUBLIC_H
+
 // STONELANCE
 #include "bg_physics.h"
 // END
@@ -947,4 +950,6 @@ qboolean        BG_PlayerTouchesItem( playerState_t *ps, entityState_t *item, in
 #define KAMI_SHOCKWAVE_MAXRADIUS                1320
 #define KAMI_BOOMSPHERE_MAXRADIUS               720
 #define KAMI_SHOCKWAVE2_MAXRADIUS               704
+
+#endif // BG_PUBLIC_H
 


### PR DESCRIPTION
## Summary
- add BG_PUBLIC_H header guard to avoid multiple inclusion
- include cg_local.h only for CGAME and defer bg_public.h to non-CGAME builds

## Testing
- `make` *(fails: SDL_version.h: No such file or directory)*


------
https://chatgpt.com/codex/tasks/task_e_68b4b61406ac8324b6dca99cb6b25e16