### PR TITLE
Preserve rallyball gravity when resetting origin

### DIFF
--- a/engine/code/game/g_utils.c
+++ b/engine/code/game/g_utils.c
@@ -645,13 +645,20 @@ Sets the pos trajectory for a fixed position
 ================
 */
 void G_SetOrigin( gentity_t *ent, vec3_t origin ) {
-	VectorCopy( origin, ent->s.pos.trBase );
-	ent->s.pos.trType = TR_STATIONARY;
-	ent->s.pos.trTime = 0;
-	ent->s.pos.trDuration = 0;
-	VectorClear( ent->s.pos.trDelta );
+        VectorCopy( origin, ent->s.pos.trBase );
+        VectorCopy( origin, ent->r.currentOrigin );
 
-	VectorCopy( origin, ent->r.currentOrigin );
+        // Preserve gravity-driven motion for physics objects such as the rallyball
+        if ( ent->physicsObject || ent->s.eType == ET_RALLYBALL ) {
+                ent->s.pos.trType = TR_GRAVITY;
+                ent->s.pos.trTime = level.time;
+        } else {
+                ent->s.pos.trType = TR_STATIONARY;
+                ent->s.pos.trTime = 0;
+        }
+
+        ent->s.pos.trDuration = 0;
+        VectorClear( ent->s.pos.trDelta );
 }
 
 /*


### PR DESCRIPTION
## Summary
- keep physics-driven entities like the rallyball under gravity when `G_SetOrigin` is used

## Testing
- `make BUILD_GAME_SO=1` *(fails: SDL_version.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b4af4b0c888324a86be650eadb892a