### PR TITLE
Add flame stream beam weapon

### DIFF
--- a/baseq3r/scripts/flamestream.shader
+++ b/baseq3r/scripts/flamestream.shader
@@ -1,0 +1,9 @@
+flamestream
+{
+    cull disable
+    {
+        map gfx/2d/white
+        blendfunc add
+        rgbGen vertex
+    }
+}

--- a/engine/code/cgame/cg_ents.c
+++ b/engine/code/cgame/cg_ents.c
@@ -520,23 +520,19 @@ static void CG_Missile( centity_t *cent ) {
 	VectorCopy( cent->lerpOrigin, ent.origin);
 	VectorCopy( cent->lerpOrigin, ent.oldorigin);
 
-	if ( cent->currentState.weapon == WP_PLASMAGUN ) {
-		ent.reType = RT_SPRITE;
-		ent.radius = 16;
-		ent.rotation = 0;
-		ent.customShader = cgs.media.plasmaBallShader;
-		trap_R_AddRefEntityToScene( &ent );
-		return;
-	}
+       if ( cent->currentState.weapon == WP_PLASMAGUN ) {
+               ent.reType = RT_SPRITE;
+               ent.radius = 16;
+               ent.rotation = 0;
+               ent.customShader = cgs.media.plasmaBallShader;
+               trap_R_AddRefEntityToScene( &ent );
+               return;
+       }
 
-	if ( cent->currentState.weapon == WP_FLAME_THROWER ) {
-		ent.reType = RT_SPRITE;
-		ent.radius = 32;
-		ent.rotation = 0;
-		ent.customShader = cgs.media.flameBallShader;
-		trap_R_AddRefEntityToScene( &ent );
-		return;
-	}
+       if ( cent->currentState.weapon == WP_FLAME_THROWER ) {
+               CG_FlameStream( cent, cent->lerpOrigin );
+               return;
+       }
 
 // Q3Rally Code Start
 	if (cent->currentState.weapon == RWP_MINE){

--- a/engine/code/cgame/cg_local.h
+++ b/engine/code/cgame/cg_local.h
@@ -810,6 +810,7 @@ typedef struct {
 	qhandle_t	whiteShader;
 	qhandle_t	flameBallShader;
 	qhandle_t	flameExplosionShader;
+	qhandle_t	flameStreamShader;
 
 	qhandle_t	redFlagModel;
 	qhandle_t	blueFlagModel;
@@ -1742,6 +1743,7 @@ void CG_InvulnerabilityJuiced( vec3_t org );
 #endif
 void CG_LightningBoltBeam( vec3_t start, vec3_t end );
 void CG_LightningArc( vec3_t start, vec3_t end );
+void CG_FlameStream( centity_t *cent, vec3_t origin );
 void CG_ScorePlum( int client, vec3_t org, int score );
 void CG_ShowDebris( vec3_t srcOrigin, int count, int evType );
 void CG_StartEarthquake(int intensity, int duration);

--- a/engine/code/cgame/cg_main.c
+++ b/engine/code/cgame/cg_main.c
@@ -1046,7 +1046,8 @@ static void CG_RegisterGraphics( void ) {
 	cgs.media.smokePuffShader = trap_R_RegisterShader( "smokePuff" );
 	cgs.media.smokePuffRageProShader = trap_R_RegisterShader( "smokePuffRagePro" );
 	cgs.media.shotgunSmokePuffShader = trap_R_RegisterShader( "shotgunSmokePuff" );
-	cgs.media.flameBallShader = trap_R_RegisterShader( "sprites/flameball" );
+       cgs.media.flameBallShader = trap_R_RegisterShader( "sprites/flameball" );
+       cgs.media.flameStreamShader = trap_R_RegisterShader( "flamestream" );
 #ifdef MISSIONPACK
 	cgs.media.nailPuffShader = trap_R_RegisterShader( "nailtrail" );
 	cgs.media.blueProxMine = trap_R_RegisterModel( "models/weaphits/proxmineb.md3" );

--- a/engine/code/cgame/cg_weapons.c
+++ b/engine/code/cgame/cg_weapons.c
@@ -1096,6 +1096,42 @@ static void CG_LightningBolt( centity_t *cent, vec3_t origin ) {
         }
 }
 
+void CG_FlameStream( centity_t *cent, vec3_t origin ) {
+       trace_t  trace;
+       refEntity_t  beam;
+       vec3_t   forward;
+       vec3_t   muzzlePoint, endPoint;
+       vec3_t   up;
+
+       if (cent->currentState.weapon != WP_FLAME_THROWER) {
+               return;
+       }
+
+       memset( &beam, 0, sizeof( beam ) );
+
+       AngleVectors( cent->lerpAngles, forward, NULL, up );
+
+       VectorCopy( cent->lerpOrigin, muzzlePoint );
+
+       VectorMA( muzzlePoint, CAR_HEIGHT/2, up, muzzlePoint );
+
+       VectorMA( muzzlePoint, 14, forward, muzzlePoint );
+
+       VectorMA( muzzlePoint, FLAME_STREAM_RANGE, forward, endPoint );
+
+       CG_Trace( &trace, muzzlePoint, vec3_origin, vec3_origin, endPoint,
+               cent->currentState.number, MASK_SHOT );
+
+       VectorCopy( trace.endpos, beam.oldorigin );
+
+       VectorCopy( origin, beam.origin );
+
+       beam.reType = RT_LIGHTNING;
+       beam.customShader = cgs.media.flameStreamShader;
+
+       trap_R_AddRefEntityToScene( &beam );
+}
+
 /*
 ================
 CG_LightningArc
@@ -1326,16 +1362,19 @@ void CG_AddPlayerWeapon( refEntity_t *parent, playerState_t *ps, centity_t *cent
 	CG_PositionRotatedEntityOnTag( &flash, &gun, weapon->weaponModel, "tag_flash");
 	trap_R_AddRefEntityToScene( &flash );
 
-	if ( ps || cg.renderingThirdPerson ||
-		cent->currentState.number != cg.predictedPlayerState.clientNum ) {
-		// add lightning bolt
-		CG_LightningBolt( nonPredictedCent, flash.origin );
+       if ( ps || cg.renderingThirdPerson ||
+               cent->currentState.number != cg.predictedPlayerState.clientNum ) {
+               if ( weaponNum == WP_LIGHTNING ) {
+                       CG_LightningBolt( nonPredictedCent, flash.origin );
+               } else if ( weaponNum == WP_FLAME_THROWER ) {
+                       CG_FlameStream( nonPredictedCent, flash.origin );
+               }
 
-		if ( weapon->flashDlightColor[0] || weapon->flashDlightColor[1] || weapon->flashDlightColor[2] ) {
-			trap_R_AddLightToScene( flash.origin, 300 + (rand()&31), weapon->flashDlightColor[0],
-				weapon->flashDlightColor[1], weapon->flashDlightColor[2] );
-		}
-	}
+               if ( weapon->flashDlightColor[0] || weapon->flashDlightColor[1] || weapon->flashDlightColor[2] ) {
+                       trap_R_AddLightToScene( flash.origin, 300 + (rand()&31), weapon->flashDlightColor[0],
+                               weapon->flashDlightColor[1], weapon->flashDlightColor[2] );
+               }
+       }
 }
 
 /*

--- a/engine/code/game/bg_public.h
+++ b/engine/code/game/bg_public.h
@@ -46,6 +46,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #define	ITEM_RADIUS			15		// item sizes are needed for client side pickup detection
 
 #define LIGHTNING_RANGE         768
+#define FLAME_STREAM_RANGE      256
 
 #define SCORE_NOT_PRESENT       -9999   // for the CS_SCORES[12] when only one player is present
 

--- a/engine/code/game/g_local.h
+++ b/engine/code/game/g_local.h
@@ -675,6 +675,7 @@ gentity_t *fire_bfg (gentity_t *self, vec3_t start, vec3_t dir);
 // Q3Rally Code Start
 // gentity_t *fire_grapple (gentity_t *self, vec3_t start, vec3_t dir);
 gentity_t *fire_flame (gentity_t *self, vec3_t start, vec3_t aimdir);
+void fire_flame_stream (gentity_t *self, vec3_t start, vec3_t dir, int damage);
 gentity_t *fire_cluster_flame (gentity_t *self, vec3_t start, vec3_t aimdir); //TBB - just an idea atm
 //gentity_t *fire_cluster_flame2 (gentity_t *self, vec3_t start, vec3_t aimdir); //TBB - just an idea atm
 gentity_t *fire_mine( gentity_t *self, vec3_t start, vec3_t dir);

--- a/engine/code/game/g_missile.c
+++ b/engine/code/game/g_missile.c
@@ -210,6 +210,42 @@ gentity_t *fire_flame (gentity_t *self, vec3_t start, vec3_t dir) {
 	return bolt;
 }
 
+/*
+=================
+fire_flame_stream
+=================
+*/
+void fire_flame_stream (gentity_t *self, vec3_t start, vec3_t dir, int damage) {
+        trace_t         tr;
+        vec3_t          end;
+        gentity_t       *traceEnt, *tent;
+
+        VectorNormalize(dir);
+        VectorMA(start, FLAME_STREAM_RANGE, dir, end);
+
+        trap_Trace(&tr, start, NULL, NULL, end, self->s.number, MASK_SHOT);
+
+        if (tr.entityNum == ENTITYNUM_NONE) {
+                return;
+        }
+
+        if (g_entities[ tr.entityNum ].flags & FL_EXTRA_BBOX)
+                traceEnt = &g_entities[ g_entities[ tr.entityNum ].r.ownerNum ];
+        else
+                traceEnt = &g_entities[ tr.entityNum ];
+
+        if ( traceEnt->takedamage ) {
+                G_Damage(traceEnt, self, self, dir, tr.endpos, damage, DAMAGE_WEAPON, MOD_FLAME_THROWER);
+                tent = G_TempEntity( tr.endpos, EV_MISSILE_HIT );
+                tent->s.otherEntityNum = traceEnt->s.number;
+                tent->s.eventParm = DirToByte( tr.plane.normal );
+                tent->s.weapon = self->s.weapon;
+        } else if ( !( tr.surfaceFlags & SURF_NOIMPACT ) ) {
+                tent = G_TempEntity( tr.endpos, EV_MISSILE_MISS );
+                tent->s.eventParm = DirToByte( tr.plane.normal );
+        }
+}
+
 //TBB
 
 /*

--- a/engine/code/game/g_weapon.c
+++ b/engine/code/game/g_weapon.c
@@ -138,11 +138,10 @@ FLAME THROWER
 =======================================================================
 */
 void Weapon_fire_flame (gentity_t *ent ) {
-	gentity_t *m;
+        int damage;
 
-	m = fire_flame(ent, muzzle, forward);
-	m->damage *= s_quadFactor;
-	m->splashDamage *= s_quadFactor;
+        damage = 30 * s_quadFactor;
+        fire_flame_stream(ent, muzzle, forward, damage);
 }
 
 /*


### PR DESCRIPTION
## Summary
- add instant-hit flame stream using traces instead of projectiles
- render flame stream beam with new shader and client routine
- register `flamestream` shader asset

## Testing
- `make` *(fails: SDL_version.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b5e5a5ba4c83248a626ad7b21d1477