### PR TITLE
Set flame stream to use white vertex color

### DIFF
--- a/engine/code/cgame/cg_weapons.c
+++ b/engine/code/cgame/cg_weapons.c
@@ -1129,6 +1129,11 @@ void CG_FlameStream( centity_t *cent, vec3_t origin ) {
        beam.reType = RT_LIGHTNING;
        beam.customShader = cgs.media.flameStreamShader;
 
+       beam.shaderRGBA[0] = 0xff;
+       beam.shaderRGBA[1] = 0xff;
+       beam.shaderRGBA[2] = 0xff;
+       beam.shaderRGBA[3] = 0xff;
+
        trap_R_AddRefEntityToScene( &beam );
 }
 


### PR DESCRIPTION
## Summary
- ensure flame stream uses a white, fully opaque vertex color for its custom shader

## Testing
- `cd engine && make` *(fails: SDL_version.h not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b5eddab1348324ba3bfb832073f960