### PR TITLE
Add flame thrower projectile model and trail effect

### DIFF
--- a/baseq3r/scripts/weapons.shader
+++ b/baseq3r/scripts/weapons.shader
@@ -242,18 +242,18 @@ models/mapobjects/jets/jet_as
 }
 models/weapons2/flamethrower/trail2
 {
-	{
-		map models/weapons2/flamethrower/trail2.tga
-		tcMod scroll 3.1 1
-                rgbgen wave triangle 1 2 0 7
-		blendfunc GL_ONE GL_ONE
-	}
         {
-		map models/weapons2/flamethrower/trail2.tga
-		tcMod scroll -1.7 1
-                rgbgen wave triangle 1 1.1 0 5.1
-		blendfunc GL_ONE GL_ONE
-	}
+                map models/weapons2/flamethrower/trail2.tga
+                tcMod scroll 3.1 1
+                rgbGen const ( 1 0.75 0 )
+                blendfunc GL_ONE GL_ONE
+        }
+        {
+                map models/weapons2/flamethrower/trail2.tga
+                tcMod scroll -1.7 1
+                rgbGen const ( 1 0.75 0 )
+                blendfunc GL_ONE GL_ONE
+        }
 }
 models/mapobjects/console/centercon
 
@@ -1303,13 +1303,15 @@ models/rearfire/flametrail03
         {
 		clampmap models/mapobjects/barrel/barrel2fx.tga
 		blendFunc GL_ONE GL_ONE
-               // rgbgen wave triangle 1 1.4 0 9.5
+                rgbGen const ( 1 0.75 0 )
+                // rgbgen wave triangle 1 1.4 0 9.5
                 tcMod rotate 200
 	}	
         {
 		clampmap models/mapobjects/barrel/barrel2fx.tga
 		blendFunc GL_ONE GL_ONE
-               // rgbgen wave triangle 1 1 0 8.7
+                rgbGen const ( 1 0.75 0 )
+                // rgbgen wave triangle 1 1 0 8.7
                 tcMod rotate -100
 	}	
 	
@@ -1338,7 +1340,7 @@ models/rearfire/flametrail02
 	{
 		map textures/sfx/flameball.tga
 		blendFunc GL_ONE GL_ONE
-		rgbGen wave sin .6 .2 0 .6	
+                rgbGen const ( 1 0.75 0 )
 	}
 
 }
@@ -1366,7 +1368,7 @@ models/rearfire/flametrail01
 	{
 		map textures/sfx/flameball.tga
 		blendFunc GL_ONE GL_ONE
-		rgbGen wave sin .6 .2 0 .6	
+                rgbGen const ( 1 0.75 0 )
 	}
 
 }

--- a/engine/code/cgame/cg_ents.c
+++ b/engine/code/cgame/cg_ents.c
@@ -529,15 +529,6 @@ static void CG_Missile( centity_t *cent ) {
 		return;
 	}
 
-	if ( cent->currentState.weapon == WP_FLAME_THROWER ) {
-		ent.reType = RT_SPRITE;
-		ent.radius = 32;
-		ent.rotation = 0;
-		ent.customShader = cgs.media.flameBallShader;
-		trap_R_AddRefEntityToScene( &ent );
-		return;
-	}
-
 // Q3Rally Code Start
 	if (cent->currentState.weapon == RWP_MINE){
 		if (cgs.gametype >= GT_TEAM){

--- a/engine/code/cgame/cg_local.h
+++ b/engine/code/cgame/cg_local.h
@@ -1846,9 +1846,10 @@ void CG_DrawCheckpointLinks(void);
 void CG_Sparks( const vec3_t origin, const vec3_t normal, const vec3_t direction, const float speed );
 qboolean CG_FrictionCalc( const carPoint_t *point, float *sCOF, float *kCOF );
 void CG_Hazard( int barrel, vec3_t origin, int radius );
-localEntity_t *CreateFireEntity( vec3_t origin, vec3_t dir, 
-								qhandle_t hModel, qhandle_t shader,
-								int msec );
+void CG_FlameTrail( centity_t *cent, const weaponInfo_t *wi );
+localEntity_t *CreateFireEntity( vec3_t origin, vec3_t dir,
+                                                                qhandle_t hModel, qhandle_t shader,
+                                                                int msec );
 
 void CreateSmokeCloudEntity(vec3_t origin, vec3_t vel, float speed, int radius, int duration, float r, float g, float b, float a, qhandle_t hShader );
 team_t TeamCount( int ignoreClientNum, int team );

--- a/engine/code/cgame/cg_rally_tools.c
+++ b/engine/code/cgame/cg_rally_tools.c
@@ -432,6 +432,47 @@ void CG_GetTagPosition( const refEntity_t *parent, qhandle_t parentModel, char *
 
 /*
 ====================
+CG_FlameTrail
+
+Creates a short-lived flame effect along a projectile's path
+====================
+*/
+void CG_FlameTrail( centity_t *cent, const weaponInfo_t *wi ) {
+       static qboolean initialized = qfalse;
+       static qhandle_t shaders[3];
+       int              step;
+       vec3_t           origin;
+       int              t;
+       int              startTime;
+       entityState_t   *es;
+
+       if ( cg_noProjectileTrail.integer ) {
+               return;
+       }
+
+       if ( !initialized ) {
+               shaders[0] = trap_R_RegisterShader( "models/rearfire/flametrail01" );
+               shaders[1] = trap_R_RegisterShader( "models/rearfire/flametrail02" );
+               shaders[2] = trap_R_RegisterShader( "models/rearfire/flametrail03" );
+               initialized = qtrue;
+       }
+
+       step = 40;
+       es = &cent->currentState;
+       startTime = cent->trailTime;
+       t = step * ( ( startTime + step ) / step );
+
+       for ( ; t <= cg.time ; t += step ) {
+               BG_EvaluateTrajectory( &es->pos, t, origin );
+               CreateFireEntity( origin, vec3_origin, cgs.media.fireModel,
+                                 shaders[rand() % 3], 300 );
+       }
+
+       cent->trailTime = cg.time;
+}
+
+/*
+====================
 CreateFireEntity
 
   Creates fire localEntities

--- a/engine/code/cgame/cg_weapons.c
+++ b/engine/code/cgame/cg_weapons.c
@@ -702,14 +702,16 @@ void CG_RegisterWeapon( int weaponNum ) {
 
 		break;
 
-	case WP_FLAME_THROWER:
-        weaponInfo->readySound = trap_S_RegisterSound( "sound/weapons/flamer/fl_hum.wav", qfalse );
-		weaponInfo->missileSound = trap_S_RegisterSound( "sound/weapons/flamer/fl_fly.wav", qfalse );
-        MAKERGB( weaponInfo->missileDlightColor, 1, 0.75f, 0 );
-		MAKERGB( weaponInfo->flashDlightColor, 1, 0.75f, 0 );
-		weaponInfo->flashSound[0] = trap_S_RegisterSound( "sound/weapons/flamer/fl_fire.wav", qfalse );
-		cgs.media.flameExplosionShader = trap_R_RegisterShader( "rocketExplosion" );
-	break;
+        case WP_FLAME_THROWER:
+                weaponInfo->readySound = trap_S_RegisterSound( "sound/weapons/flamer/fl_hum.wav", qfalse );
+                weaponInfo->missileSound = trap_S_RegisterSound( "sound/weapons/flamer/fl_fly.wav", qfalse );
+                weaponInfo->missileModel = cgs.media.fireModel;
+                weaponInfo->missileTrailFunc = CG_FlameTrail;
+                MAKERGB( weaponInfo->missileDlightColor, 1, 0.75f, 0 );
+                MAKERGB( weaponInfo->flashDlightColor, 1, 0.75f, 0 );
+                weaponInfo->flashSound[0] = trap_S_RegisterSound( "sound/weapons/flamer/fl_fire.wav", qfalse );
+                cgs.media.flameExplosionShader = trap_R_RegisterShader( "rocketExplosion" );
+                break;
 
 #ifdef MISSIONPACK
 	case WP_CHAINGUN:


### PR DESCRIPTION
## Summary
- Render flame thrower projectile using dedicated model and CG_FlameTrail
- Remove old special-case sprite handling for flame thrower missiles
- Implement CG_FlameTrail to spawn animated fire entities and adjust flame shaders

## Testing
- `make -C engine -j4` *(fails: SDL_version.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b5f625ef30832481fde1532b7d4004