### PR TITLE
Increase machinegun burst damage and cooldown

### DIFF
--- a/engine/code/game/g_weapon.c
+++ b/engine/code/game/g_weapon.c
@@ -331,13 +331,15 @@ void weapon_machinegun_burst_fire( gentity_t *ent ) {
                 damage = MACHINEGUN_TEAM_DAMAGE;
         }
 
+        damage *= 2;
+
         spread = MACHINEGUN_SPREAD / 2;
 
         Bullet_Fire( ent, spread, damage, MOD_MACHINEGUN );
         Bullet_Fire( ent, spread, damage, MOD_MACHINEGUN );
         Bullet_Fire( ent, spread, damage, MOD_MACHINEGUN );
 
-        ent->client->ps.weaponTime += (300 & NORMAL_WEAPON_TIME_MASK);
+        ent->client->ps.weaponTime += (900 & NORMAL_WEAPON_TIME_MASK);
 }
 
 


### PR DESCRIPTION
## Summary
- Double machinegun burst fire damage to boost effectiveness
- Increase machinegun burst weapon cooldown to 900ms

## Testing
- `make` *(fails: SDL_version.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b5fdba8c4c8324ad74a0e3a6e4d209