### PR TITLE
Draw UI backgrounds with resolution scaling

### DIFF
--- a/engine/code/q3_ui/ui_atoms.c
+++ b/engine/code/q3_ui/ui_atoms.c
@@ -1439,7 +1439,17 @@ void UI_DrawHandlePic( float x, float y, float w, float h, qhandle_t hShader ) {
 	}
 	
 	UI_AdjustFrom640( &x, &y, &w, &h );
-	trap_R_DrawStretchPic( x, y, w, h, s0, t0, s1, t1, hShader );
+        trap_R_DrawStretchPic( x, y, w, h, s0, t0, s1, t1, hShader );
+}
+
+void UI_DrawBackground( qhandle_t shader ) {
+        float sw = uis.glconfig.vidWidth;
+        float sh = uis.glconfig.vidHeight;
+        float pw = SCREEN_WIDTH, ph = SCREEN_HEIGHT;
+        float scale = (sw / pw > sh / ph) ? sw / pw : sh / ph;
+        float w = pw * scale, h = ph * scale;
+        float x = (sw - w) * 0.5f, y = (sh - h) * 0.5f;
+        trap_R_DrawStretchPic( x, y, w, h, 0, 0, 1, 1, shader );
 }
 
 /*

--- a/engine/code/q3_ui/ui_connect.c
+++ b/engine/code/q3_ui/ui_connect.c
@@ -165,9 +165,9 @@ void UI_DrawConnectScreen( qboolean overlay ) {
 
 	if ( !overlay ) {
 		// draw the dialog background
-		UI_SetColor( color_white );
-		UI_DrawHandlePic( 0, 0, SCREEN_WIDTH, SCREEN_HEIGHT, uis.menuBackShader );
-	}
+               UI_SetColor( color_white );
+               UI_DrawBackground( uis.menuBackShader );
+        }
 
 	// see what information we should display
 	trap_GetClientState( &cstate );

--- a/engine/code/q3_ui/ui_local.h
+++ b/engine/code/q3_ui/ui_local.h
@@ -789,6 +789,7 @@ extern qboolean		UI_ConsoleCommand( int realTime );
 extern float		UI_ClampCvar( float min, float max, float value );
 extern void			UI_DrawNamedPic( float x, float y, float width, float height, const char *picname );
 extern void			UI_DrawHandlePic( float x, float y, float w, float h, qhandle_t hShader ); 
+extern void			UI_DrawBackground( qhandle_t shader );
 extern void			UI_FillRect( float x, float y, float width, float height, const float *color );
 extern void			UI_DrawRect( float x, float y, float width, float height, const float *color );
 extern void			UI_UpdateScreen( void );

--- a/engine/code/ui/ui_atoms.c
+++ b/engine/code/ui/ui_atoms.c
@@ -461,7 +461,17 @@ void UI_DrawHandlePic( float x, float y, float w, float h, qhandle_t hShader ) {
 	}
 	
 	UI_AdjustFrom640( &x, &y, &w, &h );
-	trap_R_DrawStretchPic( x, y, w, h, s0, t0, s1, t1, hShader );
+        trap_R_DrawStretchPic( x, y, w, h, s0, t0, s1, t1, hShader );
+}
+
+void UI_DrawBackground( qhandle_t shader ) {
+        float sw = uiInfo.uiDC.glconfig.vidWidth;
+        float sh = uiInfo.uiDC.glconfig.vidHeight;
+        float pw = SCREEN_WIDTH, ph = SCREEN_HEIGHT;
+        float scale = (sw / pw > sh / ph) ? sw / pw : sh / ph;
+        float w = pw * scale, h = ph * scale;
+        float x = (sw - w) * 0.5f, y = (sh - h) * 0.5f;
+        trap_R_DrawStretchPic( x, y, w, h, 0, 0, 1, 1, shader );
 }
 
 /*

--- a/engine/code/ui/ui_local.h
+++ b/engine/code/ui/ui_local.h
@@ -862,6 +862,7 @@ extern qboolean		UI_ConsoleCommand( int realTime );
 extern float		UI_ClampCvar( float min, float max, float value );
 extern void			UI_DrawNamedPic( float x, float y, float width, float height, const char *picname );
 extern void			UI_DrawHandlePic( float x, float y, float w, float h, qhandle_t hShader ); 
+extern void			UI_DrawBackground( qhandle_t shader );
 extern void			UI_FillRect( float x, float y, float width, float height, const float *color );
 extern void			UI_DrawRect( float x, float y, float width, float height, const float *color );
 extern void     UI_DrawTopBottom(float x, float y, float w, float h);

--- a/engine/code/ui/ui_shared.c
+++ b/engine/code/ui/ui_shared.c
@@ -4344,8 +4344,8 @@ void Menu_Paint(menuDef_t *menu, qboolean forcePaint) {
 	if (menu->fullScreen) {
 		// implies a background shader
 		// FIXME: make sure we have a default shader if fullscreen is set with no background
-		DC->drawHandlePic( 0, 0, SCREEN_WIDTH, SCREEN_HEIGHT, menu->window.background );
-	} else if (menu->window.background) {
+               UI_DrawBackground( menu->window.background );
+        } else if (menu->window.background) {
 		// this allows a background shader without being full screen
 		//UI_DrawHandlePic(menu->window.rect.x, menu->window.rect.y, menu->window.rect.w, menu->window.rect.h, menu->backgroundShader);
 	}


### PR DESCRIPTION
## Summary
- add UI_DrawBackground helper to scale background images to the current video resolution
- use UI_DrawBackground in menu painting and connect screen instead of direct draw calls

## Testing
- `make -C engine` *(fails: SDL_version.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b60398c8588324bfd4f3877829e45c