### PR TITLE
Add fuel gauge HUD element

### DIFF
--- a/engine/code/cgame/cg_draw.c
+++ b/engine/code/cgame/cg_draw.c
@@ -851,13 +851,16 @@ static void CG_DrawRallyStatusBar( void ) {
 	// health background
 	   CG_FillRect( 210, 476 - 30, 90, 24, bg_color );
 
-	// armor background
-	if ( ps->stats[ STAT_ARMOR ] )
+       // armor background
+       if ( ps->stats[ STAT_ARMOR ] )
 
-        CG_FillRect( 305, 476 - 30, 90, 24, bg_color );
+       CG_FillRect( 305, 476 - 30, 90, 24, bg_color );
 
-	// rearammo background
-	weapon = 0;
+       // fuel gauge
+       CG_DrawFuelGauge( 20, 476 - 42, 90, 8 );
+
+       // rearammo background
+       weapon = 0;
 	for (i = RWP_SMOKE; i < WP_NUM_WEAPONS; i++){
 		if (ps->stats[STAT_WEAPONS] & ( 1 << i )){
 			if (ps->ammo[ i ]){

--- a/engine/code/cgame/cg_local.h
+++ b/engine/code/cgame/cg_local.h
@@ -1891,6 +1891,7 @@ float CG_DrawLowerRightHUD( float y );
 float CG_DrawLowerLeftHUD( float y );
 void CG_DrawMMap( float x, float y, float w, float h );
 void CG_DrawHUD_DerbyList(float x, float y);
+void CG_DrawFuelGauge( float x, float y, float w, float h );
 
 
 //

--- a/engine/code/cgame/cg_rally_hud.c
+++ b/engine/code/cgame/cg_rally_hud.c
@@ -174,6 +174,45 @@ void CG_DrawMMap(float x, float y, float w, float h) {
 }
 
 /*
+====================
+CG_DrawFuelGauge
+====================
+*/
+void CG_DrawFuelGauge( float x, float y, float w, float h ) {
+       int     fuel;
+       float   frac;
+       vec4_t  backColor = {0.0f, 0.0f, 0.0f, 0.25f};
+       vec4_t  fuelColor = {0.0f, 0.8f, 0.0f, 0.8f};
+       vec4_t  warnColor = {1.0f, 0.0f, 0.0f, 0.8f};
+
+       if ( !cg.snap ) {
+               return;
+       }
+
+       fuel = cg.snap->ps.stats[STAT_FUEL];
+
+       if ( fuel < 0 ) {
+               fuel = 0;
+       }
+       if ( fuel > 100 ) {
+               fuel = 100;
+       }
+
+       frac = fuel / 100.0f;
+
+       CG_DrawRect( x, y, w, h, 1, colorWhite );
+       CG_FillRect( x + 1, y + 1, w - 2, h - 2, backColor );
+
+       if ( frac < 0.10f ) {
+               if ( (cg.time >> 8) & 1 ) {
+                       CG_FillRect( x + 1, y + 1, (w - 2) * frac, h - 2, warnColor );
+               }
+       } else {
+               CG_FillRect( x + 1, y + 1, (w - 2) * frac, h - 2, fuelColor );
+       }
+}
+
+/*
 ========================
 CG_DrawArrowToCheckpoint
 ========================


### PR DESCRIPTION
## Summary
- implement `CG_DrawFuelGauge` drawing a fuel bar with low-fuel blinking warning
- hook the new fuel gauge into the rally status bar

## Testing
- `make` *(fails: SDL_version.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b7c0c3130c8324ad2dd4a8dc64ddae