### PR TITLE
Add trigger fuel brush entity

### DIFF
--- a/engine/code/game/g_spawn.c
+++ b/engine/code/game/g_spawn.c
@@ -245,9 +245,10 @@ spawn_t	spawns[] = {
 	// could not be client side predicted (push and teleport).
 	{"trigger_always", SP_trigger_always},
 	{"trigger_multiple", SP_trigger_multiple},
-	{"trigger_push", SP_trigger_push},
-	{"trigger_teleport", SP_trigger_teleport},
-	{"trigger_hurt", SP_trigger_hurt},
+        {"trigger_push", SP_trigger_push},
+        {"trigger_teleport", SP_trigger_teleport},
+        {"trigger_hurt", SP_trigger_hurt},
+        {"trigger_fuel", SP_trigger_fuel},
 
 	// targets perform no action by themselves, but must be triggered
 	// by another entity

--- a/engine/code/game/g_trigger.c
+++ b/engine/code/game/g_trigger.c
@@ -124,7 +124,7 @@ void trigger_always_think( gentity_t *ent ) {
 }
 
 /*QUAKED trigger_always (.5 .5 .5) (-8 -8 -8) (8 8 8)
-This trigger will always fire.  It is activated by the world.
+This trigger will always fire.	It is activated by the world.
 */
 void SP_trigger_always (gentity_t *ent) {
 	// we must have some delay to make sure our use targets are present
@@ -292,7 +292,7 @@ void trigger_teleporter_touch (gentity_t *self, gentity_t *other, trace_t *trace
 	}
 
 
-	dest = 	G_PickTarget( self->target );
+	dest =	G_PickTarget( self->target );
 	if (!dest) {
 		G_Printf ("Couldn't find teleporter destination\n");
 		return;
@@ -412,6 +412,59 @@ void SP_trigger_hurt( gentity_t *self ) {
 
 /*
 ==============================================================================
+
+trigger_fuel
+
+==============================================================================
+*/
+
+void Touch_Fuel( gentity_t *self, gentity_t *other, trace_t *trace ) {
+    float max;
+
+    if ( !other->client ) {
+	return;
+    }
+
+    max = ( self->count > 0 ) ? self->count : other->client->car.maxFuel;
+
+    if ( other->client->car.fuel >= max ) {
+	return;
+    }
+
+    if ( self->speed <= 0 ) {
+	self->speed = 10;
+    }
+
+    other->client->car.fuel += self->speed * FRAMETIME / 1000.0f;
+
+    if ( other->client->car.fuel > max ) {
+	other->client->car.fuel = max;
+    }
+
+    other->client->ps.stats[STAT_FUEL] = (int)other->client->car.fuel;
+}
+
+/*QUAKED trigger_fuel (.5 .5 .5) ?
+Continuously refuels vehicles that touch it.
+"rate"	fuel units added per second (default 10)
+"max"	maximum fuel level to fill to (default vehicle max)
+*/
+void SP_trigger_fuel( gentity_t *self ) {
+    float max;
+
+    G_SpawnFloat( "rate", "10", &self->speed );
+    G_SpawnFloat( "max", "0", &max );
+    self->count = (int)max;
+
+    self->touch = Touch_Fuel;
+
+    InitTrigger( self );
+    trap_LinkEntity( self );
+}
+
+
+/*
+============================================================================== 
 
 timer
 

--- a/tools/radiant-config/radiant15-netradiant/q3rally.game/baseq3r/entities.def
+++ b/tools/radiant-config/radiant15-netradiant/q3rally.game/baseq3r/entities.def
@@ -2315,6 +2315,17 @@ To make a jump pad or launch ramp, place the target_position/info_notnull entity
 
 //=============================================================================
 
+/*QUAKED trigger_fuel (.5 .5 .5) ?
+Brush trigger that continuously refuels vehicles that touch it.
+-------- KEYS --------
+rate : fuel units added per second (default 10)
+max : maximum fuel level to fill to (default vehicle maximum)
+-------- NOTES --------
+Place this around pit stops or areas where cars should be refueled.
+*/
+
+//=============================================================================
+
 /*QUAKED trigger_rallyball_goal (.5 .5 .5) ? RED_GOAL BLUE_GOAL GREEN_GOAL YELLOW_GOAL
 A trigger volume that scores for the specified team when the rallyball touches it.
 -------- SPAWNFLAGS --------


### PR DESCRIPTION
## Summary
- add `trigger_fuel` entity that refuels vehicles touching the brush
- expose `trigger_fuel` in spawn table and Radiant entity definitions

## Testing
- `make` *(fails: SDL_version.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b7c430f894832487ec01938c8b1f86