### PR TITLE
Initialize car max fuel and add trigger fuel fallback

### DIFF
--- a/engine/code/game/g_client.c
+++ b/engine/code/game/g_client.c
@@ -1569,10 +1569,11 @@ void ClientSpawn(gentity_t *ent) {
 
 //	PM_InitializeVehicle(&client->car, client->ps.origin, spawn_angles /*client->ps.viewangles*/, vec3_origin, car_frontweight_dist.value );
 	if ( client->sess.sessionTeam != TEAM_SPECTATOR && !isRaceObserver( ent->s.number ) ) {
-	client->car.initializeOnNextMove = qtrue;
+       client->car.initializeOnNextMove = qtrue;
 
-    client->car.fuel = client->car.maxFuel;
-	client->ps.stats[STAT_FUEL] = client->car.maxFuel;
+       client->car.maxFuel = CP_MAX_FUEL;
+       client->car.fuel = client->car.maxFuel;
+       client->ps.stats[STAT_FUEL] = client->car.maxFuel;
 
 	if ( !ent->frontBounds )
 		ent->frontBounds = G_Spawn();

--- a/engine/code/game/g_trigger.c
+++ b/engine/code/game/g_trigger.c
@@ -425,7 +425,7 @@ void Touch_Fuel( gentity_t *self, gentity_t *other, trace_t *trace ) {
 	return;
     }
 
-    max = ( self->count > 0 ) ? self->count : other->client->car.maxFuel;
+   max = ( self->count > 0 ) ? self->count : ( other->client->car.maxFuel > 0 ? other->client->car.maxFuel : CP_MAX_FUEL );
 
     if ( other->client->car.fuel >= max ) {
 	return;


### PR DESCRIPTION
## Summary
- Ensure client cars start with a defined max fuel value
- Trigger fuel now falls back to default max fuel when unset

## Testing
- `make` *(fails: SDL_version.h: No such file or directory)*
- `gcc engine/code/game/tests/test_touch_fuel.c -o engine/code/game/tests/test_touch_fuel && engine/code/game/tests/test_touch_fuel`

------
https://chatgpt.com/codex/tasks/task_e_68b8a34ec4bc8324bd4d82af6d65c26d