### PR TITLE
Add trigger_fuel spawn prototype

### DIFF
--- a/engine/code/game/g_spawn.c
+++ b/engine/code/game/g_spawn.c
@@ -148,6 +148,7 @@ void SP_trigger_multiple (gentity_t *ent);
 void SP_trigger_push (gentity_t *ent);
 void SP_trigger_teleport (gentity_t *ent);
 void SP_trigger_hurt (gentity_t *ent);
+void SP_trigger_fuel (gentity_t *ent);
 
 void SP_target_remove_powerups( gentity_t *ent );
 void SP_target_give (gentity_t *ent);


### PR DESCRIPTION
## Summary
- add missing `SP_trigger_fuel` prototype to `g_spawn.c` so `trigger_fuel` can spawn correctly

## Testing
- `make BUILD_CLIENT=0`


------
https://chatgpt.com/codex/tasks/task_e_68b8a6afad1c8324b2616cd57b2bfc70