### PR TITLE
Add fuel can pickup item

### DIFF
--- a/engine/code/game/bg_misc.c
+++ b/engine/code/game/bg_misc.c
@@ -239,12 +239,28 @@ Only in CTF games
 		0,
 /* precache */ "",
 /* sounds */ ""
-	},
+        },
+
+/*QUAKED item_fuelcan (.3 .3 1) (-16 -16 -16) (16 16 16) suspended
+Refills vehicle fuel.
+*/
+        {
+                "item_fuelcan",
+                "sound/items/n_health.wav",
+        { "models/items/fuelcan.md3", NULL, NULL, NULL },
+/* icon */              "icons/fuelcan",
+/* pickup */    "Fuel Can",
+                25,
+                IT_FUEL,
+                0,
+/* precache */ "",
+/* sounds */ ""
+        },
 
 
-	//
-	// WEAPONS 
-	//
+        //
+        // WEAPONS
+        //
 
 /*QUAKED weapon_gauntlet (.3 .3 1) (-16 -16 -16) (16 16 16) suspended
 */

--- a/engine/code/game/bg_public.h
+++ b/engine/code/game/bg_public.h
@@ -792,7 +792,8 @@ typedef enum {
         IT_TEAM,
 // Q3Rally Code Start
         IT_RFWEAPON,
-        IT_SIGIL
+        IT_SIGIL,
+        IT_FUEL
 // Q3Rally Code END
 } itemType_t;
 

--- a/engine/code/game/g_items.c
+++ b/engine/code/game/g_items.c
@@ -352,12 +352,32 @@ int Pickup_Armor( gentity_t *ent, gentity_t *other ) {
 	}
 #else
 	other->client->ps.stats[STAT_ARMOR] += ent->item->quantity;
-	if ( other->client->ps.stats[STAT_ARMOR] > other->client->ps.stats[STAT_MAX_HEALTH] * 2 ) {
-		other->client->ps.stats[STAT_ARMOR] = other->client->ps.stats[STAT_MAX_HEALTH] * 2;
-	}
+        if ( other->client->ps.stats[STAT_ARMOR] > other->client->ps.stats[STAT_MAX_HEALTH] * 2 ) {
+                other->client->ps.stats[STAT_ARMOR] = other->client->ps.stats[STAT_MAX_HEALTH] * 2;
+        }
 #endif
 
-	return RESPAWN_ARMOR;
+        return RESPAWN_ARMOR;
+}
+
+int Pickup_FuelCan( gentity_t *ent, gentity_t *other ) {
+        float amount;
+        float max;
+
+        if ( ent->count ) {
+                amount = ent->count;
+        } else {
+                amount = ent->item->quantity;
+        }
+
+        max = other->client->car.maxFuel;
+        other->client->car.fuel += amount;
+        if ( other->client->car.fuel > max ) {
+                other->client->car.fuel = max;
+        }
+        other->client->ps.stats[STAT_FUEL] = (int)other->client->car.fuel;
+
+        return RESPAWN_HEALTH;
 }
 
 //======================================================================
@@ -501,13 +521,16 @@ void Touch_Item (gentity_t *ent, gentity_t *other, trace_t *trace) {
 	case IT_ARMOR:
 		respawn = Pickup_Armor(ent, other);
 		break;
-	case IT_HEALTH:
-		respawn = Pickup_Health(ent, other);
-		break;
-	case IT_POWERUP:
-		respawn = Pickup_Powerup(ent, other);
-		predict = qfalse;
-		break;
+        case IT_HEALTH:
+                respawn = Pickup_Health(ent, other);
+                break;
+       case IT_FUEL:
+               respawn = Pickup_FuelCan(ent, other);
+               break;
+        case IT_POWERUP:
+                respawn = Pickup_Powerup(ent, other);
+                predict = qfalse;
+                break;
 #ifdef MISSIONPACK
 	case IT_PERSISTANT_POWERUP:
 		respawn = Pickup_PersistantPowerup(ent, other);
@@ -714,7 +737,12 @@ Respawn the item
 ================
 */
 void Use_Item( gentity_t *ent, gentity_t *other, gentity_t *activator ) {
-	RespawnItem( ent );
+        if ( ent->item->giType == IT_FUEL ) {
+                RespawnItem( ent );
+                return;
+        }
+
+        RespawnItem( ent );
 }
 
 //======================================================================


### PR DESCRIPTION
## Summary
- add new item type `IT_FUEL`
- introduce `item_fuelcan` and corresponding pickup logic
- allow fuel cans to respawn when triggered

## Testing
- `make` *(fails: SDL_version.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b8aabdde1c8324b7d7706e3f795d50