### PR TITLE
Add fuelcan item definition for Radiant

### DIFF
--- a/tools/radiant-config/radiant15-netradiant/q3rally.game/baseq3r/entities.def
+++ b/tools/radiant-config/radiant15-netradiant/q3rally.game/baseq3r/entities.def
@@ -2720,6 +2720,11 @@ disable_splash turns off splashes, improving framerates since there is not as mu
 /*QUAKED rally_item_quad (.3 .3 1) (-16 -16 -16) (16 16 16) suspended
 */
 
+/*QUAKED item_fuelcan (.3 .3 1) (-16 -16 -16) (16 16 16) suspended
+Refills vehicle fuel.
+model="models/items/fuelcan.md3"
+*/
+
 
 //ROADSIDE OBJECTS
 


### PR DESCRIPTION
## Summary
- Add `item_fuelcan` entity definition so Radiant exposes the vehicle fuel refill item.

## Testing
- `make -C engine` *(fails: SDL_version.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b8b147d4048324b767a55e9a89e77d