### PR TITLE
Add fuel item grab logic

### DIFF
--- a/engine/code/cgame/cg_predict.c
+++ b/engine/code/cgame/cg_predict.c
@@ -472,7 +472,7 @@ static void CG_TouchItem( centity_t *cent ) {
 		return;
 	}
 
-	if ( !BG_CanItemBeGrabbed( cgs.gametype, &cent->currentState, &cg.predictedPlayerState ) ) {
+	if ( !BG_CanItemBeGrabbed( cgs.gametype, &cent->currentState, &cg.predictedPlayerState, cg.car.maxFuel ) ) {
 		return;		// can't hold it
 	}
 

--- a/engine/code/game/bg_misc.c
+++ b/engine/code/game/bg_misc.c
@@ -1422,7 +1422,7 @@ Returns false if the item should not be picked up.
 This needs to be the same for client side prediction and server use.
 ================
 */
-qboolean BG_CanItemBeGrabbed( int gametype, const entityState_t *ent, const playerState_t *ps ) {
+qboolean BG_CanItemBeGrabbed( int gametype, const entityState_t *ent, const playerState_t *ps, float maxFuel ) {
 	gitem_t	*item;
 #ifdef MISSIONPACK
 	int		upperBound;
@@ -1504,12 +1504,18 @@ qboolean BG_CanItemBeGrabbed( int gametype, const entityState_t *ent, const play
 			return qtrue;
 		}
 
-		if ( ps->stats[STAT_HEALTH] >= ps->stats[STAT_MAX_HEALTH] ) {
-			return qfalse;
-		}
-		return qtrue;
+                if ( ps->stats[STAT_HEALTH] >= ps->stats[STAT_MAX_HEALTH] ) {
+                        return qfalse;
+                }
+                return qtrue;
 
-	case IT_POWERUP:
+        case IT_FUEL:
+                if ( ps->stats[STAT_FUEL] < maxFuel ) {
+                        return qtrue;
+                }
+                return qfalse;
+
+        case IT_POWERUP:
 // STONELANCE
 //		return qtrue;	// powerups are always picked up
 

--- a/engine/code/game/bg_public.h
+++ b/engine/code/game/bg_public.h
@@ -844,7 +844,7 @@ gitem_t *BG_FindItemForPowerup( powerup_t pw );
 gitem_t *BG_FindItemForHoldable( holdable_t pw );
 #define ITEM_INDEX(x) ((x)-bg_itemlist)
 
-qboolean        BG_CanItemBeGrabbed( int gametype, const entityState_t *ent, const playerState_t *ps );
+qboolean        BG_CanItemBeGrabbed( int gametype, const entityState_t *ent, const playerState_t *ps, float maxFuel );
 
 
 // g_dmflags->integer flags

--- a/engine/code/game/g_items.c
+++ b/engine/code/game/g_items.c
@@ -497,9 +497,9 @@ void Touch_Item (gentity_t *ent, gentity_t *other, trace_t *trace) {
 // END
 
 	// the same pickup rules are used for client side and server side
-	if ( !BG_CanItemBeGrabbed( g_gametype.integer, &ent->s, &other->client->ps ) ) {
-		return;
-	}
+       if ( !BG_CanItemBeGrabbed( g_gametype.integer, &ent->s, &other->client->ps, other->client->car.maxFuel ) ) {
+               return;
+       }
 
 	G_LogPrintf( "Item: %i %s\n", other->s.number, ent->item->classname );
 


### PR DESCRIPTION
## Summary
- allow players to pick up fuel cans only when below their vehicle's max fuel
- thread max fuel through BG_CanItemBeGrabbed and update game and client calls

## Testing
- `make BUILD_CLIENT=0`
- `/tmp/test_fuel`

------
https://chatgpt.com/codex/tasks/task_e_68b90c0bbf1c8324b5b1b0d4c51e2f79