### PR TITLE
Add low fuel warning with cvar control

### DIFF
--- a/engine/code/cgame/cg_local.h
+++ b/engine/code/cgame/cg_local.h
@@ -1466,6 +1466,7 @@ extern	vmCvar_t		cg_debugpredict;
 
 extern	vmCvar_t		cg_engineSounds;
 
+extern  vmCvar_t                cg_fuelWarningLevel;
 extern	vmCvar_t		cg_drawBotPaths;
 // Q3Rally Code END
 

--- a/engine/code/cgame/cg_main.c
+++ b/engine/code/cgame/cg_main.c
@@ -277,6 +277,7 @@ vmCvar_t	cg_debugpredict;
 
 vmCvar_t	cg_engineSounds;
 
+vmCvar_t        cg_fuelWarningLevel;
 vmCvar_t	cg_drawBotPaths;
 
 
@@ -389,6 +390,7 @@ static cvarTable_t cvarTable[] = {
 
        { &cg_engineSounds, "cg_engineSounds", "0", CVAR_ARCHIVE },
 
+        { &cg_fuelWarningLevel, "cg_fuelWarningLevel", "10", CVAR_ARCHIVE },
 	{ &cg_drawBotPaths, "cg_drawBotPaths", "0", 0 },
 // END
 	{ &cg_teamChatTime, "cg_teamChatTime", "3000", CVAR_ARCHIVE  },

--- a/engine/code/cgame/cg_rally_hud.c
+++ b/engine/code/cgame/cg_rally_hud.c
@@ -179,14 +179,22 @@ CG_DrawFuelGauge
 ====================
 */
 void CG_DrawFuelGauge( float x, float y, float w, float h ) {
-       int     fuel;
-       float   frac;
-       vec4_t  backColor = {0.0f, 0.0f, 0.0f, 0.25f};
-       vec4_t  fuelColor = {0.0f, 0.8f, 0.0f, 0.8f};
-       vec4_t  warnColor = {1.0f, 0.0f, 0.0f, 0.8f};
+       static qhandle_t      icon = 0;
+       static qboolean       warned = qfalse;
+       int                   fuel;
+       float                 frac;
+       float                 warnFrac;
+       float                 size;
+       vec4_t                backColor = {0.0f, 0.0f, 0.0f, 0.25f};
+       vec4_t                fuelColor = {0.0f, 0.8f, 0.0f, 0.8f};
+       vec4_t                warnColor = {1.0f, 0.0f, 0.0f, 0.8f};
 
        if ( !cg.snap ) {
                return;
+       }
+
+       if ( !icon ) {
+               icon = trap_R_RegisterShaderNoMip( "icons/fuelcan" );
        }
 
        fuel = cg.snap->ps.stats[STAT_FUEL];
@@ -199,15 +207,28 @@ void CG_DrawFuelGauge( float x, float y, float w, float h ) {
        }
 
        frac = fuel / 100.0f;
+       warnFrac = cg_fuelWarningLevel.value / 100.0f;
 
        CG_DrawRect( x, y, w, h, 1, colorWhite );
        CG_FillRect( x + 1, y + 1, w - 2, h - 2, backColor );
 
-       if ( frac < 0.10f ) {
-               if ( (cg.time >> 8) & 1 ) {
-                       CG_FillRect( x + 1, y + 1, (w - 2) * frac, h - 2, warnColor );
+       if ( frac < warnFrac ) {
+               // draw warning fuel level in red
+               CG_FillRect( x + 1, y + 1, (w - 2) * frac, h - 2, warnColor );
+
+               // play a warning beep once when entering the low fuel state
+               if ( !warned ) {
+                       trap_S_StartLocalSound( cgs.media.talkSound, CHAN_LOCAL_SOUND );
+                       warned = qtrue;
+               }
+
+               // blink the low fuel icon
+               if ( ( cg.time >> 8 ) & 1 ) {
+                       size = h * 2.0f;
+                       CG_DrawPic( x - size - 4, y + ( h - size ) * 0.5f, size, size, icon );
                }
        } else {
+               warned = qfalse;
                CG_FillRect( x + 1, y + 1, (w - 2) * frac, h - 2, fuelColor );
        }
 }


### PR DESCRIPTION
## Summary
- Blink fuel icon and play warning sound when fuel drops below configurable threshold
- Add `cg_fuelWarningLevel` cvar for adjustable low fuel warning level

## Testing
- `make` *(fails: SDL_version.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b90fedb9308324bfeef6f17c946acd