### PR TITLE
Add kill fuel reward cvar

### DIFF
--- a/engine/code/game/g_combat.c
+++ b/engine/code/game/g_combat.c
@@ -607,12 +607,18 @@ void player_die( gentity_t *self, gentity_t *inflictor, gentity_t *attacker, int
 				attacker->client->ps.eFlags |= EF_AWARD_EXCELLENT;
 				attacker->client->rewardTime = level.time + REWARD_SPRITE_TIME;
 			}
-			attacker->client->lastKillTime = level.time;
+                        attacker->client->lastKillTime = level.time;
 
-		}
-	} else {
-		AddScore( self, self->r.currentOrigin, -1 );
-	}
+                        attacker->client->car.fuel += g_fuelKillReward.value;
+                        if ( attacker->client->car.fuel > attacker->client->car.maxFuel ) {
+                                attacker->client->car.fuel = attacker->client->car.maxFuel;
+                        }
+                        attacker->client->ps.stats[STAT_FUEL] = (int)attacker->client->car.fuel;
+
+                }
+        } else {
+                AddScore( self, self->r.currentOrigin, -1 );
+        }
 
 	// Add team bonuses
 	Team_FragBonuses(self, inflictor, attacker);

--- a/engine/code/game/g_local.h
+++ b/engine/code/game/g_local.h
@@ -1014,6 +1014,7 @@ extern  vmCvar_t        g_derbyRamRadius;
 extern  vmCvar_t        g_derbyRamDamage;
 extern  vmCvar_t        g_derbyRamDamageScale;
 extern  vmCvar_t        g_derbyRamDamageMax;
+extern  vmCvar_t        g_fuelKillReward;
 
 // car variables
 extern	vmCvar_t	car_spring;

--- a/engine/code/game/g_main.c
+++ b/engine/code/game/g_main.c
@@ -122,6 +122,7 @@ vmCvar_t        g_derbyRamDamage;
 vmCvar_t        g_derbyRamDamageScale;
 vmCvar_t        g_derbyRamDamageMax;
 vmCvar_t  g_humanplayers;
+vmCvar_t        g_fuelKillReward;
 
 // car variables
 vmCvar_t	car_spring;
@@ -247,6 +248,7 @@ static cvarTable_t		gameCvarTable[] = {
 
 	{ &g_developer, "developer", "0", 0, 0, qfalse },
 	{ &g_humanplayers, "g_humanplayers", "0", CVAR_ROM | CVAR_NORESTART, 0, qfalse },
+        { &g_fuelKillReward, "g_fuelKillReward", "10", CVAR_ARCHIVE, 0, qfalse },
 
 	// car variables
 	// FIXME: should really be serverinfo so there are no client prediction problems


### PR DESCRIPTION
## Summary
- grant configurable fuel bonus to killers in `player_die`
- register new `g_fuelKillReward` server cvar

## Testing
- `make` *(fails: SDL_version.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b9183d8f188324a9ecb4d817d8a0da