### PR TITLE
Implement fuel leak mechanics with repair options

### DIFF
--- a/engine/code/game/bg_physics.c
+++ b/engine/code/game/bg_physics.c
@@ -543,8 +543,9 @@ void PM_InitializeVehicle( car_t *car, vec3_t origin, vec3_t angles, vec3_t velo
 //	car->shockStrength = CP_SHOCK_STRENGTH;
 
 	car->gear = 1;
-        car->rpm = CP_RPM_MIN;
+	car->rpm = CP_RPM_MIN;
 	car->fuel = CP_MAX_FUEL;
+	car->fuelLeak = qfalse;
 	if ( pm->ps ) {
 		pm->ps->stats[STAT_FUEL] = (int)car->fuel;
 	}
@@ -2331,10 +2332,13 @@ void PM_DriveMove( car_t *car, float time, qboolean includeBodies )
 	// calculate forces
 	PM_CalculateForces(car, &car->sBody, car->sPoints, time);
     
-    if ( car->fuel > 0.0f ) {
+	if ( car->fuel > 0.0f ) {
 		float fuelUse;
 		fuelUse = fabs(car->throttle) * (fabs(car->rpm) / CP_RPM_MAX) * CP_FUEL_CONSUMPTION * time;
 		car->fuel -= fuelUse;
+		if ( car->fuelLeak ) {
+			car->fuel -= CP_FUEL_LEAK_RATE * time;
+		}
 		if (car->fuel < 0.0f) {
 			car->fuel = 0.0f;
 		}

--- a/engine/code/game/bg_physics.h
+++ b/engine/code/game/bg_physics.h
@@ -62,6 +62,7 @@ extern	float CP_M_2_QU;
 #define	CP_CAR_MASS			( CP_FRAME_MASS * 4 + CP_WHEEL_MASS * 4 )
 #define CP_MAX_FUEL             100.0f
 #define CP_FUEL_CONSUMPTION     1.0f
+#define CP_FUEL_LEAK_RATE       1.0f
 
 #define	CP_BODY_ELASTICITY	0.05f
 #define	CP_WHEEL_ELASTICITY	0.05f
@@ -326,6 +327,7 @@ typedef struct {
 
     float	fuel;
 	float	maxFuel;
+	qboolean	fuelLeak;
 
 	qboolean	initializeOnNextMove;
 

--- a/engine/code/game/g_client.c
+++ b/engine/code/game/g_client.c
@@ -1571,9 +1571,10 @@ void ClientSpawn(gentity_t *ent) {
 	if ( client->sess.sessionTeam != TEAM_SPECTATOR && !isRaceObserver( ent->s.number ) ) {
        client->car.initializeOnNextMove = qtrue;
 
-       client->car.maxFuel = CP_MAX_FUEL;
-       client->car.fuel = client->car.maxFuel;
-       client->ps.stats[STAT_FUEL] = client->car.maxFuel;
+	client->car.maxFuel = CP_MAX_FUEL;
+	client->car.fuel = client->car.maxFuel;
+	client->car.fuelLeak = qfalse;
+	client->ps.stats[STAT_FUEL] = client->car.maxFuel;
 
 	if ( !ent->frontBounds )
 		ent->frontBounds = G_Spawn();

--- a/engine/code/game/g_combat.c
+++ b/engine/code/game/g_combat.c
@@ -1168,7 +1168,13 @@ void G_Damage( gentity_t *targ, gentity_t *inflictor, gentity_t *attacker,
 		targ->health = targ->health - take;
 		if ( targ->client ) {
 			targ->client->ps.stats[STAT_HEALTH] = targ->health;
-		}
+			if ( !targ->client->car.fuelLeak ) {
+				int leakThreshold = g_vehicleHealth.integer / 4;
+				if ( targ->health > 0 && targ->health <= leakThreshold ) {
+					targ->client->car.fuelLeak = qtrue;
+				}
+			}
+}
 			
 		if ( targ->health <= 0 ) {
 // STONELANCE

--- a/engine/code/game/g_items.c
+++ b/engine/code/game/g_items.c
@@ -324,6 +324,10 @@ int Pickup_Health (gentity_t *ent, gentity_t *other) {
 		other->health = max;
 	}
 	other->client->ps.stats[STAT_HEALTH] = other->health;
+	if ( other->client->car.fuelLeak ) {
+		other->client->car.fuelLeak = qfalse;
+	}
+
 
 	if ( ent->item->quantity == 100 ) {		// mega health respawns slow
 		return RESPAWN_MEGAHEALTH;
@@ -376,6 +380,9 @@ int Pickup_FuelCan( gentity_t *ent, gentity_t *other ) {
                 other->client->car.fuel = max;
         }
         other->client->ps.stats[STAT_FUEL] = (int)other->client->car.fuel;
+	if ( other->client->car.fuelLeak ) {
+		other->client->car.fuelLeak = qfalse;
+	}
 
         return RESPAWN_HEALTH;
 }

--- a/engine/code/game/g_trigger.c
+++ b/engine/code/game/g_trigger.c
@@ -419,29 +419,36 @@ trigger_fuel
 */
 
 void Touch_Fuel( gentity_t *self, gentity_t *other, trace_t *trace ) {
-    float max;
+	float max;
 
-    if ( !other->client ) {
-	return;
-    }
+	if ( !other->client ) {
+		return;
+	}
 
-   max = ( self->count > 0 ) ? self->count : ( other->client->car.maxFuel > 0 ? other->client->car.maxFuel : CP_MAX_FUEL );
+	max = ( self->count > 0 ) ? self->count : ( other->client->car.maxFuel > 0 ? other->client->car.maxFuel : CP_MAX_FUEL );
 
-    if ( other->client->car.fuel >= max ) {
-	return;
-    }
+	if ( other->client->car.fuel >= max ) {
+		if ( other->client->car.fuelLeak ) {
+			other->client->car.fuelLeak = qfalse;
+		}
+		return;
+	}
 
-    if ( self->speed <= 0 ) {
-	self->speed = 10;
-    }
+	if ( other->client->car.fuelLeak ) {
+		other->client->car.fuelLeak = qfalse;
+	}
 
-    other->client->car.fuel += self->speed * FRAMETIME / 1000.0f;
+	if ( self->speed <= 0 ) {
+		self->speed = 10;
+	}
 
-    if ( other->client->car.fuel > max ) {
-	other->client->car.fuel = max;
-    }
+	other->client->car.fuel += self->speed * FRAMETIME / 1000.0f;
 
-    other->client->ps.stats[STAT_FUEL] = (int)other->client->car.fuel;
+	if ( other->client->car.fuel > max ) {
+		other->client->car.fuel = max;
+	}
+
+	other->client->ps.stats[STAT_FUEL] = (int)other->client->car.fuel;
 }
 
 /*QUAKED trigger_fuel (.5 .5 .5) ?


### PR DESCRIPTION
## Summary
- Introduce `fuelLeak` flag and leak rate constant for vehicles
- Trigger fuel leak at low health and consume extra fuel while leaking
- Allow triggers and pickups to repair fuel leaks and reset flag

## Testing
- `make` *(fails: SDL_version.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b9bc3042448324869138a9ad3961ae