### PR TITLE
Handle fuel leak repair based on health

### DIFF
--- a/engine/code/game/g_items.c
+++ b/engine/code/game/g_items.c
@@ -318,15 +318,16 @@ int Pickup_Health (gentity_t *ent, gentity_t *other) {
 		quantity = ent->item->quantity;
 	}
 
-	other->health += quantity;
+        other->health += quantity;
 
-	if (other->health > max ) {
-		other->health = max;
-	}
-	other->client->ps.stats[STAT_HEALTH] = other->health;
-	if ( other->client->car.fuelLeak ) {
-		other->client->car.fuelLeak = qfalse;
-	}
+        if (other->health > max ) {
+                other->health = max;
+        }
+        other->client->ps.stats[STAT_HEALTH] = other->health;
+        if ( other->client->car.fuelLeak &&
+                other->health > g_vehicleHealth.integer / 2 ) {
+                other->client->car.fuelLeak = qfalse;
+        }
 
 
 	if ( ent->item->quantity == 100 ) {		// mega health respawns slow
@@ -380,9 +381,6 @@ int Pickup_FuelCan( gentity_t *ent, gentity_t *other ) {
                 other->client->car.fuel = max;
         }
         other->client->ps.stats[STAT_FUEL] = (int)other->client->car.fuel;
-	if ( other->client->car.fuelLeak ) {
-		other->client->car.fuelLeak = qfalse;
-	}
 
         return RESPAWN_HEALTH;
 }

--- a/engine/code/game/g_trigger.c
+++ b/engine/code/game/g_trigger.c
@@ -427,16 +427,9 @@ void Touch_Fuel( gentity_t *self, gentity_t *other, trace_t *trace ) {
 
 	max = ( self->count > 0 ) ? self->count : ( other->client->car.maxFuel > 0 ? other->client->car.maxFuel : CP_MAX_FUEL );
 
-	if ( other->client->car.fuel >= max ) {
-		if ( other->client->car.fuelLeak ) {
-			other->client->car.fuelLeak = qfalse;
-		}
-		return;
-	}
-
-	if ( other->client->car.fuelLeak ) {
-		other->client->car.fuelLeak = qfalse;
-	}
+        if ( other->client->car.fuel >= max ) {
+                return;
+        }
 
 	if ( self->speed <= 0 ) {
 		self->speed = 10;


### PR DESCRIPTION
## Summary
- Only clear `fuelLeak` on health pickup when vehicle health exceeds half of `g_vehicleHealth`
- Stop fuel pickups and fuel triggers from clearing `fuelLeak`
- Searched for other healing routines and found no additional `fuelLeak` resets

## Testing
- `make` *(fails: SDL_version.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b9c11ac6b48324ba1fe3a42d9f9525