### PR TITLE
Add fuel can as holdable item

### DIFF
--- a/engine/code/cgame/cg_event.c
+++ b/engine/code/cgame/cg_event.c
@@ -546,10 +546,12 @@ static void CG_UseItem( centity_t *cent ) {
 		break;
 #endif
 // Q3Rally Code Start
-	case HI_TURBO:
-		break;
+        case HI_TURBO:
+                break;
+        case HI_FUELCAN:
+                break;
 // Q3Rally Code END
-	}
+        }
 
 }
 

--- a/engine/code/game/bg_misc.c
+++ b/engine/code/game/bg_misc.c
@@ -250,9 +250,9 @@ Refills vehicle fuel.
         { "models/items/fuelcan.md3", NULL, NULL, NULL },
 /* icon */              "icons/fuelcan",
 /* pickup */    "Fuel Can",
-                25,
-                IT_FUEL,
-                0,
+               25,
+               IT_HOLDABLE,
+               HI_FUELCAN,
 /* precache */ "",
 /* sounds */ ""
         },
@@ -1509,13 +1509,7 @@ qboolean BG_CanItemBeGrabbed( int gametype, const entityState_t *ent, const play
                 }
                 return qtrue;
 
-        case IT_FUEL:
-                if ( ps->stats[STAT_FUEL] < maxFuel ) {
-                        return qtrue;
-                }
-                return qfalse;
-
-        case IT_POWERUP:
+       case IT_POWERUP:
 // STONELANCE
 //		return qtrue;	// powerups are always picked up
 
@@ -1642,12 +1636,18 @@ qboolean BG_CanItemBeGrabbed( int gametype, const entityState_t *ent, const play
 	     return qtrue;
 // Q3Rally Code END
 
-	case IT_HOLDABLE:
-		// can only hold one item at a time
-		if ( ps->stats[STAT_HOLDABLE_ITEM] ) {
-			return qfalse;
-		}
-		return qtrue;
+       case IT_HOLDABLE:
+               if ( item->giTag == HI_FUELCAN ) {
+                       if ( ps->stats[STAT_HOLDABLE_ITEM] ) {
+                               return qfalse;
+                       }
+                       return qtrue;
+               }
+               // can only hold one item at a time
+               if ( ps->stats[STAT_HOLDABLE_ITEM] ) {
+                       return qfalse;
+               }
+               return qtrue;
 
         case IT_BAD:
             Com_Error( ERR_DROP, "BG_CanItemBeGrabbed: IT_BAD" );

--- a/engine/code/game/bg_public.h
+++ b/engine/code/game/bg_public.h
@@ -412,6 +412,7 @@ typedef enum {
 // STONELANCE
         HI_TURBO,
 // END
+        HI_FUELCAN,
         HI_NUM_HOLDABLE
 } holdable_t;
 
@@ -793,7 +794,6 @@ typedef enum {
 // Q3Rally Code Start
         IT_RFWEAPON,
         IT_SIGIL,
-        IT_FUEL
 // Q3Rally Code END
 } itemType_t;
 

--- a/engine/code/game/g_active.c
+++ b/engine/code/game/g_active.c
@@ -871,6 +871,11 @@ void ClientEvents( gentity_t *ent, int oldEventSequence ) {
 			break;
 #endif
 
+		case EV_USE_ITEM7:		      // fuel can
+			ent->client->car.fuel = ent->client->car.maxFuel;
+			ent->client->ps.stats[STAT_FUEL] = (int)ent->client->car.fuel;
+			break;
+
 		default:
 			break;
 		}

--- a/engine/code/game/g_items.c
+++ b/engine/code/game/g_items.c
@@ -366,23 +366,8 @@ int Pickup_Armor( gentity_t *ent, gentity_t *other ) {
 }
 
 int Pickup_FuelCan( gentity_t *ent, gentity_t *other ) {
-        float amount;
-        float max;
-
-        if ( ent->count ) {
-                amount = ent->count;
-        } else {
-                amount = ent->item->quantity;
-        }
-
-        max = other->client->car.maxFuel;
-        other->client->car.fuel += amount;
-        if ( other->client->car.fuel > max ) {
-                other->client->car.fuel = max;
-        }
-        other->client->ps.stats[STAT_FUEL] = (int)other->client->car.fuel;
-
-        return RESPAWN_HEALTH;
+       other->client->ps.stats[STAT_HOLDABLE_ITEM] = HI_FUELCAN;
+       return RESPAWN_HOLDABLE;
 }
 
 //======================================================================
@@ -529,13 +514,10 @@ void Touch_Item (gentity_t *ent, gentity_t *other, trace_t *trace) {
         case IT_HEALTH:
                 respawn = Pickup_Health(ent, other);
                 break;
-       case IT_FUEL:
-               respawn = Pickup_FuelCan(ent, other);
+       case IT_POWERUP:
+               respawn = Pickup_Powerup(ent, other);
+               predict = qfalse;
                break;
-        case IT_POWERUP:
-                respawn = Pickup_Powerup(ent, other);
-                predict = qfalse;
-                break;
 #ifdef MISSIONPACK
 	case IT_PERSISTANT_POWERUP:
 		respawn = Pickup_PersistantPowerup(ent, other);
@@ -549,9 +531,13 @@ void Touch_Item (gentity_t *ent, gentity_t *other, trace_t *trace) {
         respawn = Sigil_Touch(ent, other);
         break;
 // Q3Rally Code END
-	case IT_HOLDABLE:
-		respawn = Pickup_Holdable(ent, other);
-		break;
+       case IT_HOLDABLE:
+               if ( ent->item->giTag == HI_FUELCAN ) {
+                       respawn = Pickup_FuelCan(ent, other);
+               } else {
+                       respawn = Pickup_Holdable(ent, other);
+               }
+               break;
 	default:
 		return;
 	}
@@ -742,12 +728,7 @@ Respawn the item
 ================
 */
 void Use_Item( gentity_t *ent, gentity_t *other, gentity_t *activator ) {
-        if ( ent->item->giType == IT_FUEL ) {
-                RespawnItem( ent );
-                return;
-        }
-
-        RespawnItem( ent );
+       RespawnItem( ent );
 }
 
 //======================================================================


### PR DESCRIPTION
## Summary
- Introduce `HI_FUELCAN` holdable and remove obsolete `IT_FUEL` type
- Treat fuel can as a holdable item and allow pickup only when the holdable slot is free
- Allow using the fuel can to refill vehicle fuel tanks

## Testing
- `make` *(fails: SDL_version.h missing)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68b9f80678a48324a17f5dcaec811e35