### PR TITLE
Add fuelcan drop command and helper

### DIFF
--- a/engine/code/game/g_cmds.c
+++ b/engine/code/game/g_cmds.c
@@ -89,7 +89,7 @@ void DeathmatchScoreboardMessage( gentity_t *ent ) {
 			cl->ps.persistant[PERS_SCORE], ping, time,
 			scoreFlags, g_entities[level.sortedClients[i]].s.powerups, accuracy, 
 			cl->ps.persistant[PERS_IMPRESSIVE_COUNT],
-            cl->ps.persistant[PERS_IMPRESSIVETELEFRAG_COUNT],
+	    cl->ps.persistant[PERS_IMPRESSIVETELEFRAG_COUNT],
 			cl->ps.persistant[PERS_EXCELLENT_COUNT],
 			cl->ps.persistant[PERS_GAUNTLET_FRAG_COUNT], 
 			cl->ps.persistant[PERS_DEFEND_COUNT], 
@@ -482,7 +482,7 @@ void Cmd_Noclip_f( gentity_t *ent ) {
 Cmd_LevelShot_f
 
 This is just to help generate the level pictures
-for the menus.  It goes to the intermission immediately
+for the menus.	It goes to the intermission immediately
 and sends over a command to the client to resize the view,
 hide the scoreboard, and take a special screenshot
 ==================
@@ -616,7 +616,7 @@ void SetTeam( gentity_t *ent, const char *s ) {
 	specWilling = qtrue;
 // END
 
-	if ( !Q_stricmp( s, "scoreboard" ) || !Q_stricmp( s, "score" )  ) {
+	if ( !Q_stricmp( s, "scoreboard" ) || !Q_stricmp( s, "score" )	) {
 		team = TEAM_SPECTATOR;
 		specState = SPECTATOR_SCOREBOARD;
 	} else if ( !Q_stricmp( s, "follow1" ) ) {
@@ -1378,7 +1378,7 @@ static void Cmd_VoiceTaunt_f( gentity_t *ent ) {
 			G_Voice( ent, ent->enemy, SAY_TELL, VOICECHAT_DEATHINSULT, qfalse );
 		}
 		if (!(ent->r.svFlags & SVF_BOT)) {
-			G_Voice( ent, ent,        SAY_TELL, VOICECHAT_DEATHINSULT, qfalse );
+			G_Voice( ent, ent,	  SAY_TELL, VOICECHAT_DEATHINSULT, qfalse );
 		}
 		ent->enemy = NULL;
 		return;
@@ -2026,26 +2026,26 @@ void Cmd_MoveBHandle_f( gentity_t *other )
 
 	Com_Printf( "Moving Checkpoint %i by (%f %f %f)\n", curCheckpoint, delta[0], delta[1], delta[2] );
 
-        while ((ent = G_Find (ent, FOFS(classname), "rally_checkpoint")) != NULL) {
-                if ( ent->number == curCheckpoint )
-                {
-                        VectorAdd( ent->s.angles2, delta, ent->s.angles2 );
+	while ((ent = G_Find (ent, FOFS(classname), "rally_checkpoint")) != NULL) {
+		if ( ent->number == curCheckpoint )
+		{
+			VectorAdd( ent->s.angles2, delta, ent->s.angles2 );
 
-                        break;
-                }
-        }
+			break;
+		}
+	}
 }
 
 void Cmd_Headlight_Toggle_f( gentity_t *ent ) {
        if ( !ent->client ) {
-               return;
+	       return;
        }
 
        ent->client->ps.extra_eFlags ^= CF_HEADLIGHTS;
        if ( ent->client->ps.extra_eFlags & CF_HEADLIGHTS ) {
-               ent->s.eFlags |= EF_HEADLIGHTS;
+	       ent->s.eFlags |= EF_HEADLIGHTS;
        } else {
-               ent->s.eFlags &= ~EF_HEADLIGHTS;
+	       ent->s.eFlags &= ~EF_HEADLIGHTS;
        }
        ent->client->sess.headlights = (ent->client->ps.extra_eFlags & CF_HEADLIGHTS) ? qtrue : qfalse;
 }
@@ -2197,24 +2197,32 @@ void ClientCommand( int clientNum ) {
 	else if (Q_stricmp (cmd, "dropWeapon") == 0){
 		G_DropRearWeapon( ent );
 	}
+	else if (Q_stricmp (cmd, "drop") == 0){
+		trap_Argv( 1, buffer, sizeof( buffer ) );
+		if ( !Q_stricmp( buffer, "fuelcan" ) ) {
+			if ( ent->client->ps.stats[STAT_HOLDABLE_ITEM] == HI_FUELCAN ) {
+				G_DropFuelCan( ent );
+			}
+		}
+	}
 	else if (Q_stricmp (cmd, "mapstats") == 0){
 		trap_Argv( 1, buffer, sizeof( buffer ) );
 		trap_Argv( 2, name, sizeof( name ) );
 
 		G_PrintMapStats( ent, atoi(buffer), name );
 	}
-        else if (Q_stricmp (cmd, "times") == 0) {
-                Cmd_Times_f (ent);
-                return;
-        }
-        else if (Q_stricmp (cmd, "headlights") == 0) {
-                Cmd_Headlight_Toggle_f (ent);
-                return;
-        }
-        else if (Q_stricmp (cmd, "saveBPoints") == 0) {
-                Cmd_SaveBPoints_f (ent);
-                return;
-        }
+	else if (Q_stricmp (cmd, "times") == 0) {
+		Cmd_Times_f (ent);
+		return;
+	}
+	else if (Q_stricmp (cmd, "headlights") == 0) {
+		Cmd_Headlight_Toggle_f (ent);
+		return;
+	}
+	else if (Q_stricmp (cmd, "saveBPoints") == 0) {
+		Cmd_SaveBPoints_f (ent);
+		return;
+	}
 	else if (Q_stricmp (cmd, "moveBPoint") == 0) {
 		Cmd_MoveBPoint_f (ent);
 		return;

--- a/engine/code/game/g_items.c
+++ b/engine/code/game/g_items.c
@@ -32,7 +32,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
   all items should pop when dropped in lava or slime
 
   Respawnable items don't actually go away when picked up, they are
-  just made invisible and untouchable.  This allows them to ride
+  just made invisible and untouchable.	This allows them to ride
   movers and respawn appropriately.
 */
 
@@ -96,7 +96,7 @@ int Pickup_Powerup( gentity_t *ent, gentity_t *other ) {
 
     // if same team in team game, no sound
     // cannot use OnSameTeam as it expects to g_entities, not clients
-  	if ( g_gametype.integer >= GT_TEAM && other->client->sess.sessionTeam == client->sess.sessionTeam  ) {
+	if ( g_gametype.integer >= GT_TEAM && other->client->sess.sessionTeam == client->sess.sessionTeam  ) {
       continue;
     }
 
@@ -145,7 +145,7 @@ int Pickup_PersistantPowerup( gentity_t *ent, gentity_t *other ) {
 		if( handicap<=0.0f || handicap>100.0f) {
 			handicap = 100.0f;
 		}
-		max = (int)(2 *  handicap);
+		max = (int)(2 *	 handicap);
 
 		other->health = max;
 		other->client->ps.stats[STAT_HEALTH] = max;
@@ -211,6 +211,14 @@ int Pickup_Holdable( gentity_t *ent, gentity_t *other ) {
 	}
 
 	return RESPAWN_HOLDABLE;
+}
+
+
+void G_DropFuelCan( gentity_t *ent ) {
+
+	Drop_Item( ent, BG_FindItemForHoldable( HI_FUELCAN ), 0 );
+
+	ent->client->ps.stats[STAT_HOLDABLE_ITEM] = 0;
 }
 
 
@@ -318,16 +326,16 @@ int Pickup_Health (gentity_t *ent, gentity_t *other) {
 		quantity = ent->item->quantity;
 	}
 
-        other->health += quantity;
+	other->health += quantity;
 
-        if (other->health > max ) {
-                other->health = max;
-        }
-        other->client->ps.stats[STAT_HEALTH] = other->health;
-        if ( other->client->car.fuelLeak &&
-                other->health > g_vehicleHealth.integer / 2 ) {
-                other->client->car.fuelLeak = qfalse;
-        }
+	if (other->health > max ) {
+		other->health = max;
+	}
+	other->client->ps.stats[STAT_HEALTH] = other->health;
+	if ( other->client->car.fuelLeak &&
+		other->health > g_vehicleHealth.integer / 2 ) {
+		other->client->car.fuelLeak = qfalse;
+	}
 
 
 	if ( ent->item->quantity == 100 ) {		// mega health respawns slow
@@ -357,12 +365,12 @@ int Pickup_Armor( gentity_t *ent, gentity_t *other ) {
 	}
 #else
 	other->client->ps.stats[STAT_ARMOR] += ent->item->quantity;
-        if ( other->client->ps.stats[STAT_ARMOR] > other->client->ps.stats[STAT_MAX_HEALTH] * 2 ) {
-                other->client->ps.stats[STAT_ARMOR] = other->client->ps.stats[STAT_MAX_HEALTH] * 2;
-        }
+	if ( other->client->ps.stats[STAT_ARMOR] > other->client->ps.stats[STAT_MAX_HEALTH] * 2 ) {
+		other->client->ps.stats[STAT_ARMOR] = other->client->ps.stats[STAT_MAX_HEALTH] * 2;
+	}
 #endif
 
-        return RESPAWN_ARMOR;
+	return RESPAWN_ARMOR;
 }
 
 int Pickup_FuelCan( gentity_t *ent, gentity_t *other ) {
@@ -488,7 +496,7 @@ void Touch_Item (gentity_t *ent, gentity_t *other, trace_t *trace) {
 
 	// the same pickup rules are used for client side and server side
        if ( !BG_CanItemBeGrabbed( g_gametype.integer, &ent->s, &other->client->ps, other->client->car.maxFuel ) ) {
-               return;
+	       return;
        }
 
 	G_LogPrintf( "Item: %i %s\n", other->s.number, ent->item->classname );
@@ -511,13 +519,13 @@ void Touch_Item (gentity_t *ent, gentity_t *other, trace_t *trace) {
 	case IT_ARMOR:
 		respawn = Pickup_Armor(ent, other);
 		break;
-        case IT_HEALTH:
-                respawn = Pickup_Health(ent, other);
-                break;
+	case IT_HEALTH:
+		respawn = Pickup_Health(ent, other);
+		break;
        case IT_POWERUP:
-               respawn = Pickup_Powerup(ent, other);
-               predict = qfalse;
-               break;
+	       respawn = Pickup_Powerup(ent, other);
+	       predict = qfalse;
+	       break;
 #ifdef MISSIONPACK
 	case IT_PERSISTANT_POWERUP:
 		respawn = Pickup_PersistantPowerup(ent, other);
@@ -528,16 +536,16 @@ void Touch_Item (gentity_t *ent, gentity_t *other, trace_t *trace) {
 		break;
 // Q3Rally Code Start
     case IT_SIGIL:
-        respawn = Sigil_Touch(ent, other);
-        break;
+	respawn = Sigil_Touch(ent, other);
+	break;
 // Q3Rally Code END
        case IT_HOLDABLE:
-               if ( ent->item->giTag == HI_FUELCAN ) {
-                       respawn = Pickup_FuelCan(ent, other);
-               } else {
-                       respawn = Pickup_Holdable(ent, other);
-               }
-               break;
+	       if ( ent->item->giTag == HI_FUELCAN ) {
+		       respawn = Pickup_FuelCan(ent, other);
+	       } else {
+		       respawn = Pickup_Holdable(ent, other);
+	       }
+	       break;
 	default:
 		return;
 	}
@@ -612,7 +620,7 @@ void Touch_Item (gentity_t *ent, gentity_t *other, trace_t *trace) {
 
 	// ZOID
 	// A negative respawn times means to never respawn this item (but don't 
-	// delete it).  This is used by items that are respawned by third party 
+	// delete it).	This is used by items that are respawned by third party 
 	// events such as ctf flags
 	if ( respawn <= 0 ) {
 		ent->nextthink = 0;
@@ -796,8 +804,8 @@ void FinishSpawningItem( gentity_t *ent ) {
        }
 
        if ( g_gametype.integer == GT_DERBY && ent->item->giType == IT_WEAPON ) {
-               G_FreeEntity( ent );
-               return;
+	       G_FreeEntity( ent );
+	       return;
        }
 
        trap_LinkEntity (ent);
@@ -913,12 +921,12 @@ void ClearRegisteredItems( void ) {
 
 	// players always start with the base weapon
 // STONELANCE dont start with machinegun in race
-        if (!isRallyRace() && g_gametype.integer != GT_DERBY){
-                RegisterItem( BG_FindItemForWeapon( WP_MACHINEGUN ) );
-        }
-        if (!isRallyNonDMRace() && g_gametype.integer != GT_DERBY){
-                RegisterItem( BG_FindItemForWeapon( WP_GAUNTLET ) );
-        }
+	if (!isRallyRace() && g_gametype.integer != GT_DERBY){
+		RegisterItem( BG_FindItemForWeapon( WP_MACHINEGUN ) );
+	}
+	if (!isRallyNonDMRace() && g_gametype.integer != GT_DERBY){
+		RegisterItem( BG_FindItemForWeapon( WP_GAUNTLET ) );
+	}
 //	RegisterItem( BG_FindItemForWeapon( WP_MACHINEGUN ) );
 //	RegisterItem( BG_FindItemForWeapon( WP_GAUNTLET ) );
 // END

--- a/engine/code/game/g_local.h
+++ b/engine/code/game/g_local.h
@@ -577,6 +577,7 @@ void RespawnItem( gentity_t *ent );
 void UseHoldableItem( gentity_t *ent );
 void PrecacheItem (gitem_t *it);
 gentity_t *Drop_Item( gentity_t *ent, gitem_t *item, float angle );
+void G_DropFuelCan( gentity_t *ent );
 gentity_t *LaunchItem( gitem_t *item, vec3_t origin, vec3_t velocity );
 void SetRespawn (gentity_t *ent, float delay);
 void G_SpawnItem (gentity_t *ent, gitem_t *item);


### PR DESCRIPTION
## Summary
- Allow players to drop held fuel cans via new `drop fuelcan` console command
- Implement `G_DropFuelCan` to spawn a fuel can and clear the player's holdable slot
- Expose helper in `g_local.h` for use by commands

## Testing
- `make` *(fails: SDL_version.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b9fb5a8a988324971a44ff261cc4a6