### PR TITLE
Fix fuel can holdable handling

### DIFF
--- a/engine/code/game/g_cmds.c
+++ b/engine/code/game/g_cmds.c
@@ -2199,11 +2199,11 @@ void ClientCommand( int clientNum ) {
 	}
 	else if (Q_stricmp (cmd, "drop") == 0){
 		trap_Argv( 1, buffer, sizeof( buffer ) );
-		if ( !Q_stricmp( buffer, "fuelcan" ) ) {
-			if ( ent->client->ps.stats[STAT_HOLDABLE_ITEM] == HI_FUELCAN ) {
-				G_DropFuelCan( ent );
-			}
-		}
+                if ( !Q_stricmp( buffer, "fuelcan" ) ) {
+                        if ( ent->client->ps.stats[STAT_HOLDABLE_ITEM] == BG_FindItemForHoldable( HI_FUELCAN ) - bg_itemlist ) {
+                                G_DropFuelCan( ent );
+                        }
+                }
 	}
 	else if (Q_stricmp (cmd, "mapstats") == 0){
 		trap_Argv( 1, buffer, sizeof( buffer ) );

--- a/engine/code/game/g_items.c
+++ b/engine/code/game/g_items.c
@@ -374,8 +374,8 @@ int Pickup_Armor( gentity_t *ent, gentity_t *other ) {
 }
 
 int Pickup_FuelCan( gentity_t *ent, gentity_t *other ) {
-       other->client->ps.stats[STAT_HOLDABLE_ITEM] = HI_FUELCAN;
-       return RESPAWN_HOLDABLE;
+    other->client->ps.stats[STAT_HOLDABLE_ITEM] = ent->item - bg_itemlist;
+    return RESPAWN_HOLDABLE;
 }
 
 //======================================================================


### PR DESCRIPTION
## Summary
- Store fuel can holdable item index instead of hard-coded tag
- Drop fuelcan command checks the holdable by item index

## Testing
- `make -C engine BUILD_GAME_SO=1 BUILD_CLIENT=0 BUILD_SERVER=0`

------
https://chatgpt.com/codex/tasks/task_e_68b9ffac6ea08324b69407b33af9bd8d