### PR TITLE
Preserve vehicle fuel on teleport

### DIFF
--- a/engine/code/game/bg_physics.c
+++ b/engine/code/game/bg_physics.c
@@ -433,6 +433,10 @@ void PM_InitializeVehicle( car_t *car, vec3_t origin, vec3_t angles, vec3_t velo
 	float	halfWidth, halfLength, halfHeight;
 	float	forwardScale, rightScale, upScale;
 
+	qboolean keep = car->preserveFuel;
+	float fuel = car->fuel;
+	qboolean leak = car->fuelLeak;
+
 	// UPDATE: use memset?
 
 	VectorCopy(origin, car->sBody.r);
@@ -544,11 +548,10 @@ void PM_InitializeVehicle( car_t *car, vec3_t origin, vec3_t angles, vec3_t velo
 
 	car->gear = 1;
 	car->rpm = CP_RPM_MIN;
-	car->fuel = CP_MAX_FUEL;
-	car->fuelLeak = qfalse;
-	if ( pm->ps ) {
-		pm->ps->stats[STAT_FUEL] = (int)car->fuel;
-	}
+	car->fuel = keep ? fuel : CP_MAX_FUEL;
+	car->fuelLeak = keep ? leak : qfalse;
+	if ( pm->ps ) pm->ps->stats[STAT_FUEL] = (int)car->fuel;
+	car->preserveFuel = qfalse;
 
 //	car->aCOF = CP_AIR_COF;
 //	car->dfCOF = CP_FRAC_TO_DF;

--- a/engine/code/game/bg_physics.h
+++ b/engine/code/game/bg_physics.h
@@ -329,6 +329,8 @@ typedef struct {
 	float	maxFuel;
 	qboolean	fuelLeak;
 
+	qboolean	preserveFuel;
+
 	qboolean	initializeOnNextMove;
 
 //	float	aCOF;

--- a/engine/code/game/g_misc.c
+++ b/engine/code/game/g_misc.c
@@ -115,6 +115,7 @@ void TeleportPlayer( gentity_t *player, vec3_t origin, vec3_t angles ) {
 	if (!noAngles) {
 		VectorCopy( angles, player->client->ps.viewangles );
 	}
+	player->client->car.preserveFuel = qtrue;
 	player->client->car.initializeOnNextMove = qtrue;
 // END
 


### PR DESCRIPTION
## Summary
- keep vehicle fuel levels across teleports using a new `preserveFuel` flag
- mark teleports to preserve fuel when initializing vehicles
- reset `preserveFuel` after initialization

## Testing
- `make` *(fails: SDL_version.h missing)*

------
https://chatgpt.com/codex/tasks/task_e_68ba607c17408324af4bad6200930097