### PR TITLE
Add drop command to key bindings

### DIFF
--- a/engine/code/ui/ui_shared.c
+++ b/engine/code/ui/ui_shared.c
@@ -3280,6 +3280,7 @@ static bind_t g_bindings[] =
 	{"tauntGauntlet", K_F5,			-1,		-1, -1},
 	{"scoresUp", K_KP_PGUP,			-1,		-1, -1},
 	{"scoresDown", K_KP_PGDN,			-1,		-1, -1},
+	{"drop", -1, -1, -1, -1},
 	{"messagemode",  -1,					-1,		-1, -1},
 	{"messagemode2", -1,						-1,		-1, -1},
 	{"messagemode3", -1,						-1,		-1, -1},


### PR DESCRIPTION
## Summary
- allow new `drop` command to be bound in UI

## Testing
- `make -C engine` (interrupted)

------
https://chatgpt.com/codex/tasks/task_e_68ba630c295c83249355172e8f2e7f84