### PR TITLE
Generalize holdable drop

### DIFF
--- a/engine/code/game/g_cmds.c
+++ b/engine/code/game/g_cmds.c
@@ -2197,14 +2197,12 @@ void ClientCommand( int clientNum ) {
 	else if (Q_stricmp (cmd, "dropWeapon") == 0){
 		G_DropRearWeapon( ent );
 	}
-	else if (Q_stricmp (cmd, "drop") == 0){
-		trap_Argv( 1, buffer, sizeof( buffer ) );
-                if ( !Q_stricmp( buffer, "fuelcan" ) ) {
-                        if ( ent->client->ps.stats[STAT_HOLDABLE_ITEM] == BG_FindItemForHoldable( HI_FUELCAN ) - bg_itemlist ) {
-                                G_DropFuelCan( ent );
-                        }
-                }
-	}
+       else if (Q_stricmp (cmd, "drop") == 0){
+               if ( ent->client->ps.stats[STAT_HOLDABLE_ITEM] != 0 ) {
+                       gitem_t *item = &bg_itemlist[ ent->client->ps.stats[STAT_HOLDABLE_ITEM] ];
+                       G_DropHoldable( ent, item );
+               }
+       }
 	else if (Q_stricmp (cmd, "mapstats") == 0){
 		trap_Argv( 1, buffer, sizeof( buffer ) );
 		trap_Argv( 2, name, sizeof( name ) );

--- a/engine/code/game/g_items.c
+++ b/engine/code/game/g_items.c
@@ -214,11 +214,17 @@ int Pickup_Holdable( gentity_t *ent, gentity_t *other ) {
 }
 
 
+void G_DropHoldable( gentity_t *ent, gitem_t *item ) {
+
+       Drop_Item( ent, item, 0 );
+
+       ent->client->ps.stats[STAT_HOLDABLE_ITEM] = 0;
+}
+
+
 void G_DropFuelCan( gentity_t *ent ) {
 
-	Drop_Item( ent, BG_FindItemForHoldable( HI_FUELCAN ), 0 );
-
-	ent->client->ps.stats[STAT_HOLDABLE_ITEM] = 0;
+       G_DropHoldable( ent, BG_FindItemForHoldable( HI_FUELCAN ) );
 }
 
 

--- a/engine/code/game/g_local.h
+++ b/engine/code/game/g_local.h
@@ -577,6 +577,7 @@ void RespawnItem( gentity_t *ent );
 void UseHoldableItem( gentity_t *ent );
 void PrecacheItem (gitem_t *it);
 gentity_t *Drop_Item( gentity_t *ent, gitem_t *item, float angle );
+void G_DropHoldable( gentity_t *ent, gitem_t *item );
 void G_DropFuelCan( gentity_t *ent );
 gentity_t *LaunchItem( gitem_t *item, vec3_t origin, vec3_t velocity );
 void SetRespawn (gentity_t *ent, float delay);


### PR DESCRIPTION
## Summary
- Generalize the `drop` command to release any holdable item
- Introduce `G_DropHoldable` for generic holdable item dropping
- Refactor fuel can drop to use the new helper

## Testing
- `make -C engine` *(fails: SDL_version.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68bb4f53301883249121481aa7e985e0