### PR TITLE
Offset dropped items to avoid immediate pickup

### DIFF
--- a/engine/code/game/g_items.c
+++ b/engine/code/game/g_items.c
@@ -718,10 +718,7 @@ gentity_t *Drop_Item( gentity_t *ent, gitem_t *item, float angle ) {
 	AngleVectors( angles, velocity, NULL, NULL );
 
 // STONELANCE
-	if (item->giType == IT_RFWEAPON)
-		VectorMA(ent->s.pos.trBase, 64, velocity, origin);
-	else
-		VectorCopy(ent->s.pos.trBase, origin);
+	VectorMA(ent->s.pos.trBase, 64, velocity, origin);
 // END
 
 	VectorScale( velocity, 150, velocity );


### PR DESCRIPTION
## Summary
- ensure Drop_Item spawns all items 64 units away from player
- keep G_DropHoldable using Drop_Item so holdables drop outside player bounding box

## Testing
- `make BUILD_CLIENT=0`
- `/tmp/test_drop_item`

------
https://chatgpt.com/codex/tasks/task_e_68bb53f1097c8324a92936d642b98178