### PR TITLE
Write config before clearing client state on shutdown

### DIFF
--- a/engine/code/client/cl_main.c
+++ b/engine/code/client/cl_main.c
@@ -3776,6 +3776,9 @@ void CL_Shutdown(char *finalmsg, qboolean disconnect, qboolean quit)
 
 	if(disconnect)
 		CL_Disconnect(qtrue);
+
+	// write config before we start clearing state
+	Com_WriteConfiguration();
 	
 	CL_ClearMemory(qtrue);
 	CL_Snd_Shutdown();


### PR DESCRIPTION
## Summary
- ensure client shutdown writes configuration before clearing state

## Testing
- `make -j4` *(fails: SDL_version.h: No such file or directory)*
- `sudo apt-get install -y libsdl2-dev` *(fails: Unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_68bb55b6e8588324bfcf10f10b08e1b0