### PR TITLE
Declare Com_WriteConfiguration in qcommon.h

### DIFF
--- a/engine/code/qcommon/qcommon.h
+++ b/engine/code/qcommon/qcommon.h
@@ -847,7 +847,9 @@ void		Com_StartupVariable( const char *match );
 // if match is NULL, all set commands will be executed, otherwise
 // only a set with the exact name.  Only used during startup.
 
-qboolean		Com_PlayerNameToFieldString( char *str, int length, const char *name );
+void            Com_WriteConfiguration( void );
+
+qboolean                Com_PlayerNameToFieldString( char *str, int length, const char *name );
 qboolean		Com_FieldStringToPlayerName( char *name, int length, const char *rawname );
 int QDECL	Com_strCompare( const void *a, const void *b );
 


### PR DESCRIPTION
## Summary
- declare `Com_WriteConfiguration` so callers can access configuration write routine

## Testing
- `make -C engine -j4` *(fails: SDL_version.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68bb581ada64832487632b8017eed1c2