### PR TITLE
Offset dropped items to avoid immediate pickup

### DIFF
--- a/engine/code/game/g_items.c
+++ b/engine/code/game/g_items.c
@@ -718,10 +718,10 @@ gentity_t *Drop_Item( gentity_t *ent, gitem_t *item, float angle ) {
 	AngleVectors( angles, velocity, NULL, NULL );
 
 // STONELANCE
-	if (item->giType == IT_RFWEAPON)
-		VectorMA(ent->s.pos.trBase, 64, velocity, origin);
-	else
-		VectorCopy(ent->s.pos.trBase, origin);
+	if ( item->giType != IT_RFWEAPON ) {
+		VectorScale( velocity, -1, velocity );
+	}
+	VectorMA( ent->s.pos.trBase, 64, velocity, origin );
 // END
 
 	VectorScale( velocity, 150, velocity );


### PR DESCRIPTION
## Summary
- spawn dropped items 64 units behind player unless it's an RF weapon
- keep G_DropHoldable using Drop_Item so holdables drop outside player bounding box

## Testing
- `make -C engine BUILD_CLIENT=0`
- `/tmp/test_drop_item` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68bb53f1097c8324a92936d642b98178