### PR TITLE
Use integer math for RPM segment count

### DIFF
--- a/engine/code/cgame/cg_rally_hud.c
+++ b/engine/code/cgame/cg_rally_hud.c
@@ -22,7 +22,6 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 */
 
 #include "cg_local.h"
-#include <math.h>
 
 float colors[4][4] = { 
 //		{ 0.2, 1.0, 0.2, 1.0 } , { 1.0, 0.2, 0.2, 1.0 }, {0.5, 0.5, 0.5, 1} };
@@ -798,8 +797,8 @@ static float CG_DrawSpeed( float y ) {
 			maxLen = len;
 		}
 
-		rpm = cg.predictedPlayerState.stats[STAT_RPM];
-		segments = (int)ceil( CP_RPM_MAX / 1000.0f );
+                rpm = cg.predictedPlayerState.stats[STAT_RPM];
+                segments = (CP_RPM_MAX + 999) / 1000;
 
 		x -= 38 + ( maxLen * SMALLCHAR_WIDTH ) / 2;
 


### PR DESCRIPTION
## Summary
- compute RPM gauge segment count using integer math instead of `ceil`
- drop unused `<math.h>` include from rally HUD

## Testing
- `make BUILD_CLIENT=0 BUILD_SERVER=0 BUILD_GAME_SO=1 BUILD_GAME_QVM=0 BUILD_BASEGAME=1`


------
https://chatgpt.com/codex/tasks/task_e_68bbcb07ea048324aea7a63f1bc5cb0b