### PR TITLE
Add fuel gauge to digital speedometer

### DIFF
--- a/engine/code/cgame/cg_draw.c
+++ b/engine/code/cgame/cg_draw.c
@@ -857,7 +857,9 @@ static void CG_DrawRallyStatusBar( void ) {
        CG_FillRect( 305, 476 - 30, 90, 24, bg_color );
 
        // fuel gauge
-       CG_DrawFuelGauge( 20, 476 - 42, 90, 8 );
+	if ( !cg_speedometerMode.integer ) {
+		CG_DrawFuelGauge( 20, 476 - 42, 90, 8 );
+	}
 
        // rearammo background
        weapon = 0;

--- a/engine/code/cgame/cg_rally_hud.c
+++ b/engine/code/cgame/cg_rally_hud.c
@@ -778,6 +778,7 @@ static float CG_DrawSpeed( float y ) {
 		float	segmentWidth;
 		const float segmentHeight = 4.0f;
 		const float segmentGap = 2.0f;
+		const float gaugeHeight = 8.0f;
 		int		i;
 
 		Com_sprintf( speedStr, sizeof( speedStr ), "%i %s", vel_speed, cg_metricUnits.integer ? "KPH" : "MPH" );
@@ -806,7 +807,7 @@ static float CG_DrawSpeed( float y ) {
 		{
 			float rectX = x - 4, rectY = y - 4;
 			float rectW = maxLen * SMALLCHAR_WIDTH + 8;
-			float rectH = segmentHeight + 2 * SMALLCHAR_HEIGHT + 8;
+			float rectH = segmentHeight + 2 * SMALLCHAR_HEIGHT + gaugeHeight + 8;
 			CG_FillRect( rectX, rectY, rectW, rectH, bgColor );
 		}
 
@@ -825,9 +826,11 @@ static float CG_DrawSpeed( float y ) {
 		y += SMALLCHAR_HEIGHT;
 		CG_DrawSmallDigitalStringColor( x, y, gearStr, colorWhite );
 
+		y += SMALLCHAR_HEIGHT;
+		CG_DrawFuelGauge( x, y, maxLen * SMALLCHAR_WIDTH, gaugeHeight );
 		y = yorg;
 		y -= 44;
-		y -= segmentHeight + 2 * SMALLCHAR_HEIGHT;
+		y -= segmentHeight + 2 * SMALLCHAR_HEIGHT + gaugeHeight;
 		return y;
 	}
 /*


### PR DESCRIPTION
## Summary
- Draw fuel gauge within digital speedometer HUD and adjust layout
- Hide standalone fuel gauge when digital HUD is active

## Testing
- `make` *(fails: interrupted during build)*

------
https://chatgpt.com/codex/tasks/task_e_68bbcceb5cbc83248b9cec8735d47d6b