### PR TITLE
Fix digital speedometer alignment

### DIFF
--- a/engine/code/cgame/cg_rally_hud.c
+++ b/engine/code/cgame/cg_rally_hud.c
@@ -803,12 +803,12 @@ static float CG_DrawSpeed( float y ) {
                rpm = cg.predictedPlayerState.stats[STAT_RPM];
                segments = (CP_RPM_MAX + 999) / 1000;
 
-               // determine total block dimensions
-               blockWidth = iconOffset + maxLen * GIANTCHAR_WIDTH;
+               // determine total block dimensions and shrink width by 15px
+               blockWidth = iconOffset + maxLen * GIANTCHAR_WIDTH - 15;
                blockHeight = segmentHeight + 2 * GIANTCHAR_HEIGHT + gaugeHeight;
 
                // anchor to bottom-right reference
-               x -= blockWidth;
+               x = 640 - blockWidth - 8;
                y -= blockHeight;
 
                {
@@ -834,7 +834,7 @@ static float CG_DrawSpeed( float y ) {
 		CG_DrawGiantDigitalStringColor( x, y, gearStr, colorWhite );
 
                y += GIANTCHAR_HEIGHT;
-               CG_DrawFuelGauge( x + iconOffset, y, maxLen * GIANTCHAR_WIDTH, gaugeHeight );
+               CG_DrawFuelGauge( x + iconOffset, y, blockWidth - iconOffset, gaugeHeight );
                y = yorg;
                y -= 44;
                y -= blockHeight;


### PR DESCRIPTION
## Summary
- anchor digital speedometer to 632px from the right by precomputing block width
- feed fuel gauge and background using the precomputed block width
- shrink digital speedometer block width by 15px

## Testing
- `cd engine && make` *(fails: SDL_version.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68bbd5f64d788324a018d7df648ab59e