### PR TITLE
Send 32-bit STAT_WEAPONS mask

### DIFF
--- a/engine/code/cgame/cg_draw.c
+++ b/engine/code/cgame/cg_draw.c
@@ -863,8 +863,8 @@ static void CG_DrawRallyStatusBar( void ) {
 
        // rearammo background
        weapon = 0;
-	for (i = RWP_SMOKE; i < WP_NUM_WEAPONS; i++){
-		if (ps->stats[STAT_WEAPONS] & ( 1 << i )){
+for (i = RWP_SMOKE; i < WP_NUM_WEAPONS; i++){
+if (ps->stats[STAT_WEAPONS] & ( 1u << i )){
 			if (ps->ammo[ i ]){
 				weapon = i;
 				break;

--- a/engine/code/cgame/cg_playerstate.c
+++ b/engine/code/cgame/cg_playerstate.c
@@ -34,13 +34,13 @@ void CG_CheckAmmo( void ) {
 	int		i;
 	int		total;
 	int		previous;
-	int		weapons;
+	uint32_t	weapons;
 
 	// see about how many seconds of ammo we have remaining
 	weapons = cg.snap->ps.stats[ STAT_WEAPONS ];
 	total = 0;
 	for ( i = WP_MACHINEGUN ; i < WP_NUM_WEAPONS ; i++ ) {
-		if ( ! ( weapons & ( 1 << i ) ) ) {
+		if ( ! ( weapons & ( 1u << i ) ) ) {
 			continue;
 		}
 		if ( cg.snap->ps.ammo[i] < 0 ) {

--- a/engine/code/cgame/cg_predict.c
+++ b/engine/code/cgame/cg_predict.c
@@ -507,7 +507,7 @@ static void CG_TouchItem( centity_t *cent ) {
 
 	// if it's a weapon, give them some predicted ammo so the autoswitch will work
 	if ( item->giType == IT_WEAPON ) {
-		cg.predictedPlayerState.stats[ STAT_WEAPONS ] |= 1 << item->giTag;
+cg.predictedPlayerState.stats[ STAT_WEAPONS ] |= 1u << item->giTag;
 		if ( !cg.predictedPlayerState.ammo[ item->giTag ] ) {
 			cg.predictedPlayerState.ammo[ item->giTag ] = 1;
 		}

--- a/engine/code/cgame/cg_rally_hud.c
+++ b/engine/code/cgame/cg_rally_hud.c
@@ -1064,8 +1064,8 @@ float CG_DrawLowerLeftHUD( float y ) {
 	int		i;
 
 	y += 36;
-	for (i = RWP_SMOKE; i < WP_NUM_WEAPONS; i++){
-		if (cg.snap->ps.stats[STAT_WEAPONS] & ( 1 << i )){
+for (i = RWP_SMOKE; i < WP_NUM_WEAPONS; i++){
+if (cg.snap->ps.stats[STAT_WEAPONS] & ( 1u << i )){
 			if (cg.snap->ps.ammo[ i ]){
 				y -= 36;
 				break;

--- a/engine/code/cgame/cg_weapons.c
+++ b/engine/code/cgame/cg_weapons.c
@@ -1443,7 +1443,7 @@ CG_DrawWeaponSelect
 */
 void CG_DrawWeaponSelect( void ) {
 	int		i;
-	int		bits;
+	uint32_t	bits;
 	int		count;
 	int		x, y, w;
 	char	*name;
@@ -1471,7 +1471,7 @@ void CG_DrawWeaponSelect( void ) {
 	cg.itemPickupTime = 0;
 
 	// count the number of weapons owned
-	bits = cg.snap->ps.stats[ STAT_WEAPONS ];
+bits = cg.snap->ps.stats[ STAT_WEAPONS ];
 	count = 0;
 // Q3Rally Code Start
 //	for ( i = 1 ; i < MAX_WEAPONS ; i++ ) {
@@ -1480,7 +1480,7 @@ void CG_DrawWeaponSelect( void ) {
 		if ( i == WP_DERBY_RAM ) {
                        continue;
                }
-               if ( bits & ( 1 << i ) ) {
+if ( bits & ( 1u << i ) ) {
                        count++;
                }
        }
@@ -1504,7 +1504,7 @@ void CG_DrawWeaponSelect( void ) {
 		if ( i == WP_DERBY_RAM ) {
                        continue;
                }
-               if ( !( bits & ( 1 << i ) ) ) {
+if ( !( bits & ( 1u << i ) ) ) {
                        continue;
                }
 
@@ -1556,7 +1556,7 @@ static qboolean CG_WeaponSelectable( int i ) {
 	if ( !cg.snap->ps.ammo[i] ) {
                 return qfalse;
         }
-        if ( ! (cg.snap->ps.stats[ STAT_WEAPONS ] & ( 1 << i ) ) ) {
+if ( ! (cg.snap->ps.stats[ STAT_WEAPONS ] & ( 1u << i ) ) ) {
 		return qfalse;
 	}
 
@@ -1661,7 +1661,7 @@ void CG_Weapon_f( void ) {
 
 	cg.weaponSelectTime = cg.time;
 
-	if ( ! ( cg.snap->ps.stats[STAT_WEAPONS] & ( 1 << num ) ) ) {
+if ( ! ( cg.snap->ps.stats[STAT_WEAPONS] & ( 1u << num ) ) ) {
 		return;		// don't have the weapon
 	}
 

--- a/engine/code/game/ai_dmq3.c
+++ b/engine/code/game/ai_dmq3.c
@@ -1736,23 +1736,23 @@ void BotUpdateInventory(bot_state_t *bs) {
 	//armor
 	bs->inventory[INVENTORY_ARMOR] = bs->cur_ps.stats[STAT_ARMOR];
 	//weapons
-	bs->inventory[INVENTORY_GAUNTLET] = (bs->cur_ps.stats[STAT_WEAPONS] & (1 << WP_GAUNTLET)) != 0;
-	bs->inventory[INVENTORY_SHOTGUN] = (bs->cur_ps.stats[STAT_WEAPONS] & (1 << WP_SHOTGUN)) != 0;
-	bs->inventory[INVENTORY_MACHINEGUN] = (bs->cur_ps.stats[STAT_WEAPONS] & (1 << WP_MACHINEGUN)) != 0;
-	bs->inventory[INVENTORY_GRENADELAUNCHER] = (bs->cur_ps.stats[STAT_WEAPONS] & (1 << WP_GRENADE_LAUNCHER)) != 0;
-	bs->inventory[INVENTORY_ROCKETLAUNCHER] = (bs->cur_ps.stats[STAT_WEAPONS] & (1 << WP_ROCKET_LAUNCHER)) != 0;
-	bs->inventory[INVENTORY_LIGHTNING] = (bs->cur_ps.stats[STAT_WEAPONS] & (1 << WP_LIGHTNING)) != 0;
-	bs->inventory[INVENTORY_RAILGUN] = (bs->cur_ps.stats[STAT_WEAPONS] & (1 << WP_RAILGUN)) != 0;
-	bs->inventory[INVENTORY_PLASMAGUN] = (bs->cur_ps.stats[STAT_WEAPONS] & (1 << WP_PLASMAGUN)) != 0;
-	bs->inventory[INVENTORY_BFG10K] = (bs->cur_ps.stats[STAT_WEAPONS] & (1 << WP_BFG)) != 0;
-	bs->inventory[INVENTORY_FLAMETHROWER] = (bs->cur_ps.stats[STAT_WEAPONS] & (1 << WP_FLAME_THROWER)) !=0;
+	bs->inventory[INVENTORY_GAUNTLET] = (bs->cur_ps.stats[STAT_WEAPONS] & (1u << WP_GAUNTLET)) != 0;
+	bs->inventory[INVENTORY_SHOTGUN] = (bs->cur_ps.stats[STAT_WEAPONS] & (1u << WP_SHOTGUN)) != 0;
+	bs->inventory[INVENTORY_MACHINEGUN] = (bs->cur_ps.stats[STAT_WEAPONS] & (1u << WP_MACHINEGUN)) != 0;
+	bs->inventory[INVENTORY_GRENADELAUNCHER] = (bs->cur_ps.stats[STAT_WEAPONS] & (1u << WP_GRENADE_LAUNCHER)) != 0;
+	bs->inventory[INVENTORY_ROCKETLAUNCHER] = (bs->cur_ps.stats[STAT_WEAPONS] & (1u << WP_ROCKET_LAUNCHER)) != 0;
+	bs->inventory[INVENTORY_LIGHTNING] = (bs->cur_ps.stats[STAT_WEAPONS] & (1u << WP_LIGHTNING)) != 0;
+	bs->inventory[INVENTORY_RAILGUN] = (bs->cur_ps.stats[STAT_WEAPONS] & (1u << WP_RAILGUN)) != 0;
+	bs->inventory[INVENTORY_PLASMAGUN] = (bs->cur_ps.stats[STAT_WEAPONS] & (1u << WP_PLASMAGUN)) != 0;
+	bs->inventory[INVENTORY_BFG10K] = (bs->cur_ps.stats[STAT_WEAPONS] & (1u << WP_BFG)) != 0;
+	bs->inventory[INVENTORY_FLAMETHROWER] = (bs->cur_ps.stats[STAT_WEAPONS] & (1u << WP_FLAME_THROWER)) !=0;
 // STONELANCE
-//	bs->inventory[INVENTORY_GRAPPLINGHOOK] = (bs->cur_ps.stats[STAT_WEAPONS] & (1 << WP_GRAPPLING_HOOK)) != 0;
+//	bs->inventory[INVENTORY_GRAPPLINGHOOK] = (bs->cur_ps.stats[STAT_WEAPONS] & (1u << WP_GRAPPLING_HOOK)) != 0;
 // END
 #ifdef MISSIONPACK
-	bs->inventory[INVENTORY_NAILGUN] = (bs->cur_ps.stats[STAT_WEAPONS] & (1 << WP_NAILGUN)) != 0;;
-	bs->inventory[INVENTORY_PROXLAUNCHER] = (bs->cur_ps.stats[STAT_WEAPONS] & (1 << WP_PROX_LAUNCHER)) != 0;;
-	bs->inventory[INVENTORY_CHAINGUN] = (bs->cur_ps.stats[STAT_WEAPONS] & (1 << WP_CHAINGUN)) != 0;;
+	bs->inventory[INVENTORY_NAILGUN] = (bs->cur_ps.stats[STAT_WEAPONS] & (1u << WP_NAILGUN)) != 0;;
+	bs->inventory[INVENTORY_PROXLAUNCHER] = (bs->cur_ps.stats[STAT_WEAPONS] & (1u << WP_PROX_LAUNCHER)) != 0;;
+	bs->inventory[INVENTORY_CHAINGUN] = (bs->cur_ps.stats[STAT_WEAPONS] & (1u << WP_CHAINGUN)) != 0;;
 #endif
 	//ammo
 	bs->inventory[INVENTORY_SHELLS] = bs->cur_ps.ammo[WP_SHOTGUN];

--- a/engine/code/game/bg_misc.c
+++ b/engine/code/game/bg_misc.c
@@ -1448,13 +1448,13 @@ qboolean BG_CanItemBeGrabbed( int gametype, const entityState_t *ent, const play
 
 			// FIXME: need this?
 /*
-			if (ps->stats[STAT_WEAPONS] & ( 1 << i ) && !ps->ammo[ i ]){
-				ps->stats[STAT_WEAPONS] &= ~( 1 << i );
-			}
+if (ps->stats[STAT_WEAPONS] & ( 1u << i ) && !ps->ammo[ i ]){
+ps->stats[STAT_WEAPONS] &= ~( 1u << i );
+}
 */
 
-			if (ps->stats[STAT_WEAPONS] & ( 1 << i ))
-				return qfalse;
+if (ps->stats[STAT_WEAPONS] & ( 1u << i ))
+return qfalse;
 		}
 		return qtrue;
 // END

--- a/engine/code/game/bg_pmove.c
+++ b/engine/code/game/bg_pmove.c
@@ -1582,7 +1582,7 @@ static void PM_BeginWeaponChange( int weapon ) {
 		return;
 	}
 
-	if ( !( pm->ps->stats[STAT_WEAPONS] & ( 1 << weapon ) ) ) {
+if ( !( pm->ps->stats[STAT_WEAPONS] & ( 1u << weapon ) ) ) {
 		return;
 	}
 	
@@ -1610,7 +1610,7 @@ static void PM_FinishWeaponChange( void ) {
 		weapon = WP_NONE;
 	}
 
-	if ( !( pm->ps->stats[STAT_WEAPONS] & ( 1 << weapon ) ) ) {
+if ( !( pm->ps->stats[STAT_WEAPONS] & ( 1u << weapon ) ) ) {
 		weapon = WP_NONE;
 	}
 
@@ -2188,14 +2188,14 @@ void PM_RearWeapon( void ) {
 		return;
 	}
 
-	for (i = RWP_SMOKE; i < WP_NUM_WEAPONS; i++){
-		if (pm->ps->stats[STAT_WEAPONS] & ( 1 << i ) && !pm->ps->ammo[ i ]){
-			pm->ps->stats[STAT_WEAPONS] &= ~( 1 << i );
-		}
+for (i = RWP_SMOKE; i < WP_NUM_WEAPONS; i++){
+if (pm->ps->stats[STAT_WEAPONS] & ( 1u << i ) && !pm->ps->ammo[ i ]){
+pm->ps->stats[STAT_WEAPONS] &= ~( 1u << i );
+}
 
-		if (pm->ps->stats[STAT_WEAPONS] & ( 1 << i ) && pm->ps->ammo[ i ])
-			break;
-	}
+if (pm->ps->stats[STAT_WEAPONS] & ( 1u << i ) && pm->ps->ammo[ i ])
+break;
+}
 
 	if (i < WP_NUM_WEAPONS){
 		weapon = i;

--- a/engine/code/game/bg_public.h
+++ b/engine/code/game/bg_public.h
@@ -319,7 +319,7 @@ typedef enum {
 #ifdef MISSIONPACK
         STAT_PERSISTANT_POWERUP,
 #endif
-        STAT_WEAPONS,                                   // 16 bit fields
+        STAT_WEAPONS,                                   // 32 bit field
         STAT_ARMOR,                            
         STAT_DEAD_YAW,                                  // look this direction when dead (FIXME: get rid of?)
         STAT_CLIENTS_READY,                             // bit mask of clients wishing to exit the intermission (FIXME: configstring?)

--- a/engine/code/game/g_client.c
+++ b/engine/code/game/g_client.c
@@ -1525,7 +1525,7 @@ void ClientSpawn(gentity_t *ent) {
 
 // dont give machinegun on spawn in races
 	if (!isRallyRace() && g_gametype.integer != GT_DERBY ){
-		client->ps.stats[STAT_WEAPONS] = ( 1 << WP_MACHINEGUN );
+client->ps.stats[STAT_WEAPONS] = ( 1u << WP_MACHINEGUN );
 
 		if ( g_gametype.integer == GT_TEAM ) {
 			client->ps.ammo[WP_MACHINEGUN] = 50;
@@ -1535,16 +1535,16 @@ void ClientSpawn(gentity_t *ent) {
 	}
 
         if (!isRallyNonDMRace() && g_gametype.integer != GT_DERBY){
-                client->ps.stats[STAT_WEAPONS] |= ( 1 << WP_GAUNTLET );
+client->ps.stats[STAT_WEAPONS] |= ( 1u << WP_GAUNTLET );
         }
 	else {
-		client->ps.stats[STAT_WEAPONS] &= ~( 1 << WP_GAUNTLET );
+client->ps.stats[STAT_WEAPONS] &= ~( 1u << WP_GAUNTLET );
 	}
 
         client->ps.ammo[WP_GAUNTLET] = -1;
 
         if ( g_gametype.integer == GT_DERBY ) {
-                client->ps.stats[STAT_WEAPONS] = ( 1 << WP_DERBY_RAM );
+client->ps.stats[STAT_WEAPONS] = ( 1u << WP_DERBY_RAM );
                 client->ps.weapon = WP_DERBY_RAM;
                 client->ps.ammo[WP_DERBY_RAM] = -1;
         }
@@ -1703,8 +1703,8 @@ void ClientSpawn(gentity_t *ent) {
 			// select the highest weapon number available, after any spawn given items have fired
 			client->ps.weapon = WP_NONE;
 
-			for (i = WP_NUM_WEAPONS - 1 ; i > 0 ; i--) {
-				if (client->ps.stats[STAT_WEAPONS] & (1 << i)) {
+for (i = WP_NUM_WEAPONS - 1 ; i > 0 ; i--) {
+if (client->ps.stats[STAT_WEAPONS] & (1u << i)) {
 					client->ps.weapon = i;
 					break;
 				}

--- a/engine/code/game/g_cmds.c
+++ b/engine/code/game/g_cmds.c
@@ -319,9 +319,9 @@ void Cmd_Give_f (gentity_t *ent)
 // END
 	{
 // STONELANCE
-		ent->client->ps.stats[STAT_WEAPONS] = (1 << RWP_SMOKE) - 1 - 
-			- ( 1 << WP_NONE );
-//		ent->client->ps.stats[STAT_WEAPONS] = (1 << WP_NUM_WEAPONS) - 1 - 
+		ent->client->ps.stats[STAT_WEAPONS] = (1u << RWP_SMOKE) - 1 -
+			( 1u << WP_NONE );
+//		ent->client->ps.stats[STAT_WEAPONS] = (1u << WP_NUM_WEAPONS) - 1 - 
 //			( 1 << WP_GRAPPLING_HOOK ) - ( 1 << WP_NONE );
 // END
 		if (!give_all)

--- a/engine/code/game/g_combat.c
+++ b/engine/code/game/g_combat.c
@@ -107,7 +107,7 @@ void TossClientItems( gentity_t *self ) {
 		if ( self->client->ps.weaponstate == WEAPON_DROPPING ) {
 			weapon = self->client->pers.cmd.weapon;
 		}
-		if ( !( self->client->ps.stats[STAT_WEAPONS] & ( 1 << weapon ) ) ) {
+if ( !( self->client->ps.stats[STAT_WEAPONS] & ( 1u << weapon ) ) ) {
 			weapon = WP_NONE;
 		}
 	}

--- a/engine/code/game/g_items.c
+++ b/engine/code/game/g_items.c
@@ -287,7 +287,7 @@ int Pickup_Weapon (gentity_t *ent, gentity_t *other) {
 	}
 
 	// add the weapon
-	other->client->ps.stats[STAT_WEAPONS] |= ( 1 << ent->item->giTag );
+other->client->ps.stats[STAT_WEAPONS] |= ( 1u << ent->item->giTag );
 
 	Add_Ammo( other, ent->item->giTag, quantity );
 
@@ -484,18 +484,18 @@ void Touch_Item (gentity_t *ent, gentity_t *other, trace_t *trace) {
 	// autoDrop old weapon
 
 	if ( ent->item->giType == IT_RFWEAPON && other->client->pers.autoDrop ){
-		for (i = RWP_SMOKE; i < WP_NUM_WEAPONS; i++){
-			if (ent->item->giTag == i) continue;
+for (i = RWP_SMOKE; i < WP_NUM_WEAPONS; i++){
+if (ent->item->giTag == i) continue;
 
-			if (other->client->ps.stats[STAT_WEAPONS] & ( 1 << i ) && !other->client->ps.ammo[ i ]){
-				other->client->ps.stats[STAT_WEAPONS] &= ~( 1 << i );
-			}
+if (other->client->ps.stats[STAT_WEAPONS] & ( 1u << i ) && !other->client->ps.ammo[ i ]){
+other->client->ps.stats[STAT_WEAPONS] &= ~( 1u << i );
+}
 
-			if (other->client->ps.stats[STAT_WEAPONS] & ( 1 << i )){
-				G_DropRearWeapon( other );
-				break;
-			}
-		}
+if (other->client->ps.stats[STAT_WEAPONS] & ( 1u << i )){
+G_DropRearWeapon( other );
+break;
+}
+}
 	}
 
 // END

--- a/engine/code/game/g_rally_rearweapon.c
+++ b/engine/code/game/g_rally_rearweapon.c
@@ -232,14 +232,14 @@ Quadfactor-Test 16/03/2020   End
 	// set aiming directions
 	AngleVectors (ent->client->ps.viewangles, forward, right, up);
 
-	for (i = RWP_SMOKE; i < WP_NUM_WEAPONS; i++){
-		if (ent->client->ps.stats[STAT_WEAPONS] & ( 1 << i ) && !ent->client->ps.ammo[ i ]){
-			ent->client->ps.stats[STAT_WEAPONS] &= ~( 1 << i );
-		}
+for (i = RWP_SMOKE; i < WP_NUM_WEAPONS; i++){
+if (ent->client->ps.stats[STAT_WEAPONS] & ( 1u << i ) && !ent->client->ps.ammo[ i ]){
+ent->client->ps.stats[STAT_WEAPONS] &= ~( 1u << i );
+}
 
-		if (ent->client->ps.stats[STAT_WEAPONS] & ( 1 << i ) && ent->client->ps.ammo[ i ])
-			break;
-	}
+if (ent->client->ps.stats[STAT_WEAPONS] & ( 1u << i ) && ent->client->ps.ammo[ i ])
+break;
+}
 
 	if (i < WP_NUM_WEAPONS){
 		weapon = i;

--- a/engine/code/game/g_rally_tools.c
+++ b/engine/code/game/g_rally_tools.c
@@ -261,9 +261,9 @@ void G_DropRearWeapon( gentity_t *ent ) {
 	gitem_t		*item;
 	int			i;
 
-	for (i = RWP_SMOKE; i < WP_NUM_WEAPONS; i++){
-		if (ent->client->ps.stats[STAT_WEAPONS] & ( 1 << i )){
-			ent->client->ps.stats[STAT_WEAPONS] &= ~( 1 << i );
+for (i = RWP_SMOKE; i < WP_NUM_WEAPONS; i++){
+if (ent->client->ps.stats[STAT_WEAPONS] & ( 1u << i )){
+ent->client->ps.stats[STAT_WEAPONS] &= ~( 1u << i );
 
 			if (ent->client->ps.ammo[ i ]){
 				item = BG_FindItemForWeapon( i );

--- a/engine/code/qcommon/msg.c
+++ b/engine/code/qcommon/msg.c
@@ -21,6 +21,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 */
 #include "q_shared.h"
 #include "qcommon.h"
+#include "../game/bg_public.h"
 
 static huffman_t		msgHuff;
 
@@ -1221,9 +1222,15 @@ void MSG_WriteDeltaPlayerstate( msg_t *msg, struct playerState_s *from, struct p
 	if ( statsbits ) {
 		MSG_WriteBits( msg, 1, 1 );	// changed
 		MSG_WriteBits( msg, statsbits, MAX_STATS );
-		for (i=0 ; i<MAX_STATS ; i++)
-			if (statsbits & (1<<i) )
-				MSG_WriteShort (msg, to->stats[i]);
+		for (i=0 ; i<MAX_STATS ; i++) {
+			if (statsbits & (1<<i) ) {
+				if (i == STAT_WEAPONS) {
+					MSG_WriteLong (msg, to->stats[i]);
+				} else {
+					MSG_WriteShort (msg, to->stats[i]);
+				}
+			}
+		}
 	} else {
 		MSG_WriteBits( msg, 0, 1 );	// no change
 	}
@@ -1358,7 +1365,11 @@ void MSG_ReadDeltaPlayerstate (msg_t *msg, playerState_t *from, playerState_t *t
 			bits = MSG_ReadBits (msg, MAX_STATS);
 			for (i=0 ; i<MAX_STATS ; i++) {
 				if (bits & (1<<i) ) {
-					to->stats[i] = MSG_ReadShort(msg);
+					if (i == STAT_WEAPONS) {
+						to->stats[i] = MSG_ReadLong(msg);
+					} else {
+						to->stats[i] = MSG_ReadShort(msg);
+					}
 				}
 			}
 		}


### PR DESCRIPTION
## Summary
- Serialize STAT_WEAPONS using 32-bit longs so high-bit weapons replicate correctly
- Treat STAT_WEAPONS as a `uint32_t` across game and client code for masking
- Keep rear-ammo HUD logic intact with extended weapon mask

## Testing
- `make` *(fails: SDL_version.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68bc2c2b5658832494bbe547a8f87705