### PR TITLE
Expand transmission to six gears and lower idle rpm

### DIFF
--- a/engine/code/game/bg_physics.h
+++ b/engine/code/game/bg_physics.h
@@ -122,28 +122,18 @@ extern	float CP_GEAR_RATIOS[];
 #define	CP_AXLEGEAR			3.07f
 #define	CP_GEARR			-2.80f
 #define	CP_GEARN			0.00f
-/*
-#define	CP_GEAR1			2.82f
-#define	CP_GEAR2			1.78f
-#define	CP_GEAR3			1.27f
-#define	CP_GEAR4			0.92f
-#define	CP_GEAR5			0.60f
 
-#define	CP_GEAR1			3.02f
-#define	CP_GEAR2			2.01f
-#define	CP_GEAR3			1.34f
-#define	CP_GEAR4			0.89f
-#define	CP_GEAR5			0.60f
-*/
-#define	CP_GEAR1			2.75f
-#define	CP_GEAR2			1.67f
-#define	CP_GEAR3			1.19f
-#define	CP_GEAR4			0.82f
-#define	CP_GEAR5			0.49f
+// Six speed transmission gear ratios
+#define	CP_GEAR1			3.33f
+#define	CP_GEAR2			2.10f
+#define	CP_GEAR3			1.43f
+#define	CP_GEAR4			1.14f
+#define	CP_GEAR5			0.89f
+#define	CP_GEAR6			0.69f
 
 
 #define	CP_RPM_MAX	      6250
-#define	CP_RPM_MIN			  1000
+#define	CP_RPM_MIN			  750
 
 // #define	CP_HP_PEAK			191.0f
 // #define	CP_RPM_HP_PEAK		4600.0f

--- a/engine/code/game/bg_wheel_forces.c
+++ b/engine/code/game/bg_wheel_forces.c
@@ -32,7 +32,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 
 
 static float CP_TORQUE_SLOPE = (float)(CP_RPM_HP_PEAK * M_PI * CP_TORQUE_PEAK - 16500 * CP_HP_PEAK) / (float)(CP_RPM_HP_PEAK * M_PI * (CP_RPM_HP_PEAK*CP_RPM_HP_PEAK - 2 * CP_RPM_HP_PEAK * CP_RPM_TORQUE_PEAK + CP_RPM_TORQUE_PEAK*CP_RPM_TORQUE_PEAK));
-static float CP_GEAR_RATIOS[] = {CP_GEAR1, CP_GEAR2, CP_GEAR3, CP_GEAR4, CP_GEAR5};
+static float CP_GEAR_RATIOS[] = {CP_GEAR1, CP_GEAR2, CP_GEAR3, CP_GEAR4, CP_GEAR5, CP_GEAR6};
 
 
 #if 0
@@ -139,7 +139,7 @@ static void PM_UpdateRPM(car_t *car, carPoint_t *points){
 					break;
 			}
 
-			if (car->gear < 5){
+                if (car->gear < 6){
 				if ( points[2].onGround && points[3].onGround && !points[2].slipping && !points[3].slipping )
 					car->gear++;
 			}


### PR DESCRIPTION
## Summary
- upgrade car physics to six-speed gearbox with ratios up to 0.69 top gear
- drop engine idle from 1000 RPM to 750 RPM

## Testing
- `make -C engine BUILD_GAME_QVM=1` *(fails: SDL_version.h missing)*

------
https://chatgpt.com/codex/tasks/task_e_68bcb6cd0d3c8324b76f6b100f490a04