### PR TITLE
feat: add critical fuel warning

### DIFF
--- a/engine/code/cgame/cg_rally_hud.c
+++ b/engine/code/cgame/cg_rally_hud.c
@@ -227,6 +227,19 @@ void CG_DrawFuelGauge( float x, float y, float w, float h ) {
                if ( ( cg.time >> 8 ) & 1 ) {
                        CG_DrawPic( x - size - 4, y + ( h - size ) * 0.5f, size, size, icon );
                }
+
+               // draw centered critical fuel warning text
+               {
+                       int textWidth;
+                       float textX;
+
+                       textWidth = BIGCHAR_WIDTH * CG_DrawStrlen( "Fuel Critical \xE2\x80\x93 Refuel Now!" );
+                       textX = ( SCREEN_WIDTH - textWidth ) / 2;
+
+                       CG_SetScreenPlacement( PLACE_CENTER, PLACE_CENTER );
+                       CG_DrawStringExt( textX, SCREEN_HEIGHT * 0.30f, "Fuel Critical \xE2\x80\x93 Refuel Now!", warnColor, qfalse, qtrue, BIGCHAR_WIDTH, (int)(BIGCHAR_WIDTH * 1.5f), 0 );
+                       CG_PopScreenPlacement();
+               }
        } else {
                warned = qfalse;
                CG_FillRect( x + 1, y + 1, (w - 2) * frac, h - 2, fuelColor );


### PR DESCRIPTION
## Summary
- display a centered "Fuel Critical – Refuel Now!" message when fuel is low
- compute text width for centering and draw in warn color

## Testing
- `make` *(fails: SDL_version.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68bd1ffc76848324916093c9d8be2563