### PR TITLE
Add sand trail effect and enable snow/sand trails

### DIFF
--- a/engine/code/cgame/cg_local.h
+++ b/engine/code/cgame/cg_local.h
@@ -1025,6 +1025,7 @@ typedef struct {
 	qhandle_t	teleportEffectShader;
     qhandle_t	dustPuffShader;
     qhandle_t   snowPuffShader;
+    qhandle_t   sandPuffShader;
 
 
 	// scoreboard headers

--- a/engine/code/cgame/cg_main.c
+++ b/engine/code/cgame/cg_main.c
@@ -1183,7 +1183,7 @@ static void CG_RegisterGraphics( void ) {
 #endif
 	cgs.media.dustPuffShader = trap_R_RegisterShader("hasteSmokePuff" );
     cgs.media.snowPuffShader = trap_R_RegisterShader("snowPuff" );
-// FIX THIS !!!    cgs.media.sandPuffShader = trap_R_RegisterShader("sandPuff" );
+    cgs.media.sandPuffShader = trap_R_RegisterShader("sandPuff" );
 //#endif
 // Q3Rally Code END
 

--- a/engine/code/cgame/cg_players.c
+++ b/engine/code/cgame/cg_players.c
@@ -2140,15 +2140,14 @@ static void CG_SandTrail( centity_t *cent ) {
 	end[2] -= 16;
 
 	VectorSet(vel, 0, 0, -30);
-	CG_SmokePuff( end, vel,
-				  24,
-				  .8f, .8f, 0.7f, 0.33f,
-				  500,
-				  cg.time,
-				  0,
-				  0,
-// FIX THIS !!!   cgs.media.sandPuffShader );
-				  cgs.media.snowPuffShader );
+        CG_SmokePuff( end, vel,
+                                  24,
+                                  .8f, .8f, 0.7f, 0.33f,
+                                  500,
+                                  cg.time,
+                                  0,
+                                  0,
+                                  cgs.media.sandPuffShader );
 }
 
  #endif
@@ -4170,13 +4169,12 @@ VectorCopy( cent->lerpOrigin, backlight.lightingOrigin );
 	}
     
  
-/*
-#ifdef MISSIONPACK
-	CG_BreathPuffs(cent, &head);
-
-	CG_DustTrail(cent);
-#endif
-*/
+        if ( cg_enableSnow.integer ) {
+                CG_SnowTrail( cent );
+        }
+        if ( cg_enableSand.integer ) {
+                CG_SandTrail( cent );
+        }
 // END
 
 	//


### PR DESCRIPTION
## Summary
- register and store a `sandPuff` shader handle
- render sand puff in `CG_SandTrail`
- call snow and sand trail routines during player updates

## Testing
- `make` *(fails: SDL_version.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68bd2cbad57483248b7f0759dfafaf82