### PR TITLE
Unwrap trail effects from missionpack guard

### DIFF
--- a/engine/code/cgame/cg_players.c
+++ b/engine/code/cgame/cg_players.c
@@ -2013,9 +2013,10 @@ static void CG_BreathPuffs( centity_t *cent, refEntity_t *head) {
 	VectorSet( up, 0, 0, 8 );
 	VectorMA(head->origin, 8, head->axis[0], origin);
 	VectorMA(origin, -4, head->axis[2], origin);
-	CG_SmokePuff( origin, up, 16, 1, 1, 1, 0.66f, 1500, cg.time, cg.time + 400, LEF_PUFF_DONT_SCALE, cgs.media.shotgunSmokePuffShader );
-	ci->breathPuffTime = cg.time + 2000;
+       CG_SmokePuff( origin, up, 16, 1, 1, 1, 0.66f, 1500, cg.time, cg.time + 400, LEF_PUFF_DONT_SCALE, cgs.media.shotgunSmokePuffShader );
+       ci->breathPuffTime = cg.time + 2000;
 }
+#endif
 
 /*
 ===============
@@ -2054,13 +2055,11 @@ static void CG_DustTrail( centity_t *cent ) {
 				  24,
 				  .8f, .8f, 0.7f, 0.33f,
 				  500,
-				  cg.time,
-				  0,
-				  0,
-				  cgs.media.dustPuffShader );
+                                  cg.time,
+                                  0,
+                                  0,
+                                  cgs.media.dustPuffShader );
 }
-
-// #endif
 
 /*
 ===============
@@ -2150,7 +2149,6 @@ static void CG_SandTrail( centity_t *cent ) {
                                   cgs.media.sandPuffShader );
 }
 
- #endif
 
 /*
 ===============


### PR DESCRIPTION
## Summary
- Limit `MISSIONPACK` conditional to `CG_BreathPuffs` so dust, snow, and sand trail effects are always compiled.
- Remove obsolete `// #endif` comment and trailing preprocessor guard.

## Testing
- `make` *(fails: SDL_version.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68bd6dcb107083249b522ae4d45a3836