### PR TITLE
Remove unused cent pointers in checkpoint drawing

### DIFF
--- a/engine/code/cgame/cg_rally_tools.c
+++ b/engine/code/cgame/cg_rally_tools.c
@@ -28,7 +28,6 @@ void CG_DrawCheckpointLinks(void)
 {
 	int			i, j;
 	centity_t	*cents[100];
-    centity_t	*cent, *cent2 = NULL, *cent3 = NULL;
 	qboolean	checkpointFound;
 	int			numCheckpoints = 0;
 	vec3_t		handle;


### PR DESCRIPTION
## Summary
- drop unused `cent`, `cent2`, and `cent3` pointer declarations in `CG_DrawCheckpointLinks`

## Testing
- `make -k BUILD_CLIENT=0 BUILD_SERVER=0` *(fails: cg_rally_hud2.c incompatible pointer type, but `cg_rally_tools.c` builds without unused variable warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68bd7a0011e08324967d51c6bbe8b757