### PR TITLE
Initialize team chat buffer length

### DIFF
--- a/engine/code/cgame/cg_servercmds.c
+++ b/engine/code/cgame/cg_servercmds.c
@@ -460,7 +460,7 @@ CG_AddToTeamChat
 =======================
 */
 static void CG_AddToTeamChat( const char *str ) {
-	int len;
+	int len = 0;
 	char *p, *ls;
 	int lastcolor;
 	int chatHeight;


### PR DESCRIPTION
## Summary
- Initialize `len` in `CG_AddToTeamChat` so the team chat buffer starts with a defined length

## Testing
- `gcc -Wall -Werror=maybe-uninitialized -DARCH_STRING="linux" -Icode/cgame -Icode -Icode/game -Icode/qcommon -c code/cgame/cg_servercmds.c -o /tmp/cg_servercmds.o`
- `make BUILD_CLIENT=0 BUILD_SERVER=0 BUILD_GAME_SO=1` *(fails: code/cgame/cg_players.c:80:15: error: ‘i’ undeclared)*

------
https://chatgpt.com/codex/tasks/task_e_68bd7bd757c8832485238719b8866c96