### PR TITLE
Declare loop counter in CG_CustomSound

### DIFF
--- a/engine/code/cgame/cg_players.c
+++ b/engine/code/cgame/cg_players.c
@@ -63,6 +63,7 @@ CG_CustomSound
 */
 sfxHandle_t	CG_CustomSound( int clientNum, const char *soundName ) {
 	clientInfo_t *ci;
+	int i;
 
         if ( !soundName ) {
                 return 0;


### PR DESCRIPTION
## Summary
- Fix cgame custom sound lookup by declaring the missing loop counter `i` in `CG_CustomSound`.

## Testing
- `make` *(fails: SDL_version.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68bd7d94130c8324b1763133fc09c202