### PR TITLE
Add sand, snow, and ice surface effects

### DIFF
--- a/engine/code/cgame/cg_local.h
+++ b/engine/code/cgame/cg_local.h
@@ -1000,6 +1000,9 @@ typedef struct {
 	qhandle_t	SMDirtShader;
 	qhandle_t	SMGrassShader;
 	qhandle_t	SMFleshShader;
+	qhandle_t	SMSandShader;
+	qhandle_t	SMSnowShader;
+	qhandle_t	SMIceShader;
 	qhandle_t	checkpointArrow;
 
 

--- a/engine/code/cgame/cg_main.c
+++ b/engine/code/cgame/cg_main.c
@@ -1079,6 +1079,9 @@ static void CG_RegisterGraphics( void ) {
 	cgs.media.SMDirtShader = trap_R_RegisterShader("gfx/skidmarks/dirt" );
 	cgs.media.SMGrassShader = trap_R_RegisterShader("gfx/skidmarks/grass" );
 	cgs.media.SMFleshShader = trap_R_RegisterShader("gfx/skidmarks/flesh" );
+	cgs.media.SMSandShader = trap_R_RegisterShader("gfx/skidmarks/sand" );
+	cgs.media.SMSnowShader = trap_R_RegisterShader("gfx/skidmarks/snow" );
+	cgs.media.SMIceShader = trap_R_RegisterShader("gfx/skidmarks/ice" );
 
 	cgs.media.checkpointArrow = trap_R_RegisterModel("gfx/hud/arrow.md3");
     cgs.media.gaugeImperial = trap_R_RegisterShaderNoMip("gfx/hud/gauge01" );

--- a/engine/code/cgame/cg_players.c
+++ b/engine/code/cgame/cg_players.c
@@ -3008,13 +3008,21 @@ static void CG_SurfaceEffects( centity_t *cent, vec3_t curOrigin, vec3_t up, int
 			shader = cgs.media.SMGrassShader;
 			colorIndex = 0;
 		}
+		else if (tr.surfaceFlags & SURF_SAND){
+			shader = cgs.media.SMSandShader;
+			colorIndex = 1;
+		}
 		else if (tr.surfaceFlags & SURF_DUST){
 			shader = cgs.media.SMDirtShader;
 			colorIndex = 1;
 		}
-        else if (tr.surfaceFlags & SURF_SNOW){
-			shader = cgs.media.SMDirtShader;
-			colorIndex = 1;
+		else if (tr.surfaceFlags & SURF_SNOW){
+			shader = cgs.media.SMSnowShader;
+			colorIndex = 2;
+		}
+		else if (tr.surfaceFlags & SURF_ICE){
+			shader = cgs.media.SMIceShader;
+			colorIndex = 2;
 		}
 		else if (tr.surfaceFlags & SURF_DIRT) {
 			shader = cgs.media.SMDirtShader;
@@ -3039,10 +3047,12 @@ static void CG_SurfaceEffects( centity_t *cent, vec3_t curOrigin, vec3_t up, int
 
 			// create smoke even if we arent moving because the car is being stopped from moving
 			if (cent->smokeTime[tireNum] < cg.time){
-				if (tr.surfaceFlags & SURF_DUST)
-					CreateSmokeCloudEntity(tr.endpos, up, 20, 48, 2000, surfaceColors[colorIndex][0], surfaceColors[colorIndex][1], surfaceColors[colorIndex][2], surfaceColors[colorIndex][3], cgs.media.smokePuffShader);
-				else
-					CreateSmokeCloudEntity(tr.endpos, up, 20, 12, 1000, surfaceColors[colorIndex][0], surfaceColors[colorIndex][1], surfaceColors[colorIndex][2], surfaceColors[colorIndex][3], cgs.media.smokePuffShader);
+			if (tr.surfaceFlags & SURF_DUST)
+				CreateSmokeCloudEntity(tr.endpos, up, 20, 48, 2000, surfaceColors[colorIndex][0], surfaceColors[colorIndex][1], surfaceColors[colorIndex][2], surfaceColors[colorIndex][3], cgs.media.smokePuffShader);
+			else if (tr.surfaceFlags & SURF_ICE)
+				CreateSmokeCloudEntity(tr.endpos, up, 10, 8, 500, surfaceColors[colorIndex][0], surfaceColors[colorIndex][1], surfaceColors[colorIndex][2], 0.6f, cgs.media.snowPuffShader);
+			else
+				CreateSmokeCloudEntity(tr.endpos, up, 20, 12, 1000, surfaceColors[colorIndex][0], surfaceColors[colorIndex][1], surfaceColors[colorIndex][2], surfaceColors[colorIndex][3], cgs.media.smokePuffShader);
 
 				cent->smokeTime[tireNum] = cg.time + 100;
 			}
@@ -3067,6 +3077,12 @@ static void CG_SurfaceEffects( centity_t *cent, vec3_t curOrigin, vec3_t up, int
 		else if ( tr.surfaceFlags & SURF_DUST ){
 			if ( VectorLength(delta) > 5 && cent->smokeTime[tireNum] < cg.time ){
 				CreateSmokeCloudEntity( tr.endpos, up, 20, 36, 1500, surfaceColors[colorIndex][0] * 1.3f, surfaceColors[colorIndex][1] * 1.3f, surfaceColors[colorIndex][2] * 1.3f, 0.8f, cgs.media.dustPuffShader);
+				cent->smokeTime[tireNum] = cg.time + 100;
+			}
+		}
+		else if ( tr.surfaceFlags & SURF_ICE ){
+			if ( VectorLength(delta) > 5 && cent->smokeTime[tireNum] < cg.time ){
+				CreateSmokeCloudEntity( tr.endpos, up, 10, 8, 500, surfaceColors[colorIndex][0], surfaceColors[colorIndex][1], surfaceColors[colorIndex][2], 0.6f, cgs.media.snowPuffShader);
 				cent->smokeTime[tireNum] = cg.time + 100;
 			}
 		}


### PR DESCRIPTION
## Summary
- Declare and register sand, snow, and ice skidmark shaders
- Map new surface types to corresponding skidmark shaders and suppress marks on slick ice while adding icy particle effects

## Testing
- `make -C engine` *(fails: SDL_version.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68bda8f11fb88324871304297c4d4967