### PR TITLE
Align controls menu columns

### DIFF
--- a/engine/code/q3_ui/ui_local.h
+++ b/engine/code/q3_ui/ui_local.h
@@ -162,7 +162,10 @@ extern vmCvar_t	ui_mmap_fov;
 //
 
 #define RCOLUMN_OFFSET			( BIGCHAR_WIDTH )
-#define LCOLUMN_OFFSET			(-BIGCHAR_WIDTH )
+#define LCOLUMN_OFFSET                  (-BIGCHAR_WIDTH )
+
+#define LABEL_COLUMN_X                  396
+#define VALUE_COLUMN_X                  412
 
 #define SLIDER_RANGE			10
 #define	MAX_EDIT_LINE			256

--- a/engine/code/q3_ui/ui_qmenu.c
+++ b/engine/code/q3_ui/ui_qmenu.c
@@ -526,8 +526,8 @@ static void RadioButton_Draw( menuradiobutton_s *rb )
 	int	style;
 	qboolean focus;
 
-	x = rb->generic.x;
-	y = rb->generic.y;
+	x = rb->generic.x - SMALLCHAR_WIDTH;
+        y = rb->generic.y;
 
 	focus = (rb->generic.parent->cursor == rb->generic.menuPosition);
 
@@ -555,17 +555,17 @@ static void RadioButton_Draw( menuradiobutton_s *rb )
 	}
 
 	if ( rb->generic.name )
-		UI_DrawString( x - SMALLCHAR_WIDTH, y, rb->generic.name, UI_RIGHT|UI_SMALLFONT, color );
+		UI_DrawString( LABEL_COLUMN_X, y, rb->generic.name, UI_RIGHT|UI_SMALLFONT, color );
 
 	if ( !rb->curvalue )
 	{
-		UI_DrawHandlePic( x + SMALLCHAR_WIDTH, y + 2, 16, 16, uis.rb_off);
-		UI_DrawString( x + SMALLCHAR_WIDTH + 16, y, "off", style, color );
+                UI_DrawHandlePic( VALUE_COLUMN_X - 16, y + 2, 16, 16, uis.rb_off );
+                UI_DrawString( VALUE_COLUMN_X, y, "off", style, color );
 	}
 	else
 	{
-		UI_DrawHandlePic( x + SMALLCHAR_WIDTH, y + 2, 16, 16, uis.rb_on );
-		UI_DrawString( x + SMALLCHAR_WIDTH + 16, y, "on", style, color );
+                UI_DrawHandlePic( VALUE_COLUMN_X - 16, y + 2, 16, 16, uis.rb_on );
+                UI_DrawString( VALUE_COLUMN_X, y, "on", style, color );
 	}
 }
 
@@ -666,8 +666,8 @@ static void Slider_Draw( menuslider_s *s ) {
 	int			button;
 	qboolean	focus;
 	
-	x =	s->generic.x;
-	y = s->generic.y;
+	x = s->generic.x - SMALLCHAR_WIDTH;
+        y = s->generic.y;
 	focus = (s->generic.parent->cursor == s->generic.menuPosition);
 
 	if( s->generic.flags & QMF_GRAYED ) {
@@ -684,11 +684,11 @@ static void Slider_Draw( menuslider_s *s ) {
 	}
 
 	// draw label
-	UI_DrawString( x - SMALLCHAR_WIDTH, y, s->generic.name, UI_RIGHT|style, color );
+	UI_DrawString( LABEL_COLUMN_X, y, s->generic.name, UI_RIGHT|style, color );
 
 	// draw slider
 	UI_SetColor( color );
-	UI_DrawHandlePic( x + SMALLCHAR_WIDTH, y, 96, 16, sliderBar );
+        UI_DrawHandlePic( VALUE_COLUMN_X, y, 96, 16, sliderBar );
 	UI_SetColor( NULL );
 
 	// clamp thumb
@@ -713,7 +713,7 @@ static void Slider_Draw( menuslider_s *s ) {
 		button = sliderButton_0;
 	}
 
-	UI_DrawHandlePic( (int)( x + 2*SMALLCHAR_WIDTH + (SLIDER_RANGE-1)*SMALLCHAR_WIDTH* s->range ) - 2, y - 2, 12, 20, button );
+	UI_DrawHandlePic( (int)( x + SMALLCHAR_WIDTH + (SLIDER_RANGE-1)*SMALLCHAR_WIDTH* s->range ) - 2, y - 2, 12, 20, button );
 }
 #else
 /*
@@ -730,8 +730,8 @@ static void Slider_Draw( menuslider_s *s )
 	int y;
 	qboolean focus;
 	
-	x =	s->generic.x;
-	y = s->generic.y;
+	x = s->generic.x - SMALLCHAR_WIDTH;
+        y = s->generic.y;
 	focus = (s->generic.parent->cursor == s->generic.menuPosition);
 
 	style = UI_SMALLFONT;
@@ -757,13 +757,13 @@ static void Slider_Draw( menuslider_s *s )
 	}
 
 	// draw label
-	UI_DrawString( x - SMALLCHAR_WIDTH, y, s->generic.name, UI_RIGHT|style, color );
+	UI_DrawString( LABEL_COLUMN_X, y, s->generic.name, UI_RIGHT|style, color );
 
 	// draw slider
-	UI_DrawChar( x + SMALLCHAR_WIDTH, y, 128, UI_LEFT|style, color);
+	UI_DrawChar( VALUE_COLUMN_X, y, 128, UI_LEFT|style, color);
 	for ( i = 0; i < SLIDER_RANGE; i++ )
-		UI_DrawChar( x + (i+2)*SMALLCHAR_WIDTH, y, 129, UI_LEFT|style, color);
-	UI_DrawChar( x + (i+2)*SMALLCHAR_WIDTH, y, 130, UI_LEFT|style, color);
+		UI_DrawChar( VALUE_COLUMN_X + (i+1)*SMALLCHAR_WIDTH, y, 129, UI_LEFT|style, color);
+	UI_DrawChar( VALUE_COLUMN_X + (i+1)*SMALLCHAR_WIDTH, y, 130, UI_LEFT|style, color);
 
 	// clamp thumb
 	if (s->maxvalue > s->minvalue)
@@ -782,7 +782,7 @@ static void Slider_Draw( menuslider_s *s )
 		style &= ~UI_PULSE;
 		style |= UI_BLINK;
 	}
-	UI_DrawChar( (int)( x + 2*SMALLCHAR_WIDTH + (SLIDER_RANGE-1)*SMALLCHAR_WIDTH* s->range ), y, 131, UI_LEFT|style, color);
+	UI_DrawChar( (int)( VALUE_COLUMN_X + (SLIDER_RANGE-1)*SMALLCHAR_WIDTH* s->range ), y, 131, UI_LEFT|style, color);
 }
 #endif
 

--- a/engine/code/q3_ui/ui_rally_controls.c
+++ b/engine/code/q3_ui/ui_rally_controls.c
@@ -616,21 +616,13 @@ static void Controls_Update( void ) {
 
 	// position controls
 	y = ( SCREEN_HEIGHT - j * SMALLCHAR_HEIGHT ) / 2;
-	for( j = 0;	(control = controls[j]); j++, y += SMALLCHAR_HEIGHT ) {
-// STONELANCE
-/*
-		control->x      = 320;
-		control->y      = y;
-		control->left   = 320 - 19*SMALLCHAR_WIDTH;
-		control->right  = 320 + 21*SMALLCHAR_WIDTH;
-*/
-		control->x      = 300 + (int)(((y - 240) / 14.0F) * ((y - 240) / 14.0F));
-		control->y      = y;
-		control->left   = control->x - 19*SMALLCHAR_WIDTH;
-		control->right  = control->x + 21*SMALLCHAR_WIDTH;
-// END
-		control->top    = y;
-		control->bottom = y + SMALLCHAR_HEIGHT;
+	for( j = 0;	(control = controls[j]); j++, y += SMALLCHAR_HEIGHT ) {		control->x      = VALUE_COLUMN_X;                control->x      = VALUE_COLUMN_X;
+                control->x      = VALUE_COLUMN_X;
+                control->y      = y;
+                control->left   = VALUE_COLUMN_X - 19*SMALLCHAR_WIDTH;
+                control->right  = VALUE_COLUMN_X + 21*SMALLCHAR_WIDTH;
+                control->top    = y;
+                control->bottom = y + SMALLCHAR_HEIGHT;
 	}
 
 	if( s_controls.waitingforkey ) {
@@ -707,7 +699,8 @@ static void Controls_DrawKeyBinding( void *self )
 
 	a = (menuaction_s*) self;
 
-	x =	a->generic.x;
+	// position cursor at column center
+	x = a->generic.x - SMALLCHAR_WIDTH;
 	y = a->generic.y;
 
 	c = (Menu_ItemAtCursor( a->generic.parent ) == a);
@@ -743,8 +736,8 @@ static void Controls_DrawKeyBinding( void *self )
 	{
 		UI_FillRect( a->generic.left, a->generic.top, a->generic.right-a->generic.left+1, a->generic.bottom-a->generic.top+1, listbar_color ); 
 
-		UI_DrawString( x - SMALLCHAR_WIDTH, y, g_bindings[b1].label, UI_RIGHT|UI_SMALLFONT, text_color_highlight );
-		UI_DrawString( x + SMALLCHAR_WIDTH, y, name, UI_LEFT|UI_SMALLFONT|UI_PULSE, text_color_highlight );
+		UI_DrawString( LABEL_COLUMN_X, y, g_bindings[b1].label, UI_RIGHT|UI_SMALLFONT, text_color_highlight );
+                UI_DrawString( VALUE_COLUMN_X, y, name, UI_LEFT|UI_SMALLFONT|UI_PULSE, text_color_highlight );
 
 		if (s_controls.waitingforkey)
 		{
@@ -762,17 +755,13 @@ static void Controls_DrawKeyBinding( void *self )
 	{
 		if (a->generic.flags & QMF_GRAYED)
 		{
-			UI_DrawString( x - SMALLCHAR_WIDTH, y, g_bindings[b1].label, UI_RIGHT|UI_SMALLFONT, text_color_disabled );
-			UI_DrawString( x + SMALLCHAR_WIDTH, y, name, UI_LEFT|UI_SMALLFONT, text_color_disabled );
+			UI_DrawString( LABEL_COLUMN_X, y, g_bindings[b1].label, UI_RIGHT|UI_SMALLFONT, text_color_disabled );
+                        UI_DrawString( VALUE_COLUMN_X, y, name, UI_LEFT|UI_SMALLFONT, text_color_disabled );
 		}
 		else
 		{
-// STONELANCE
-//			UI_DrawString( x - SMALLCHAR_WIDTH, y, g_bindings[b1].label, UI_RIGHT|UI_SMALLFONT, controls_binding_color );
-//			UI_DrawString( x + SMALLCHAR_WIDTH, y, name, UI_LEFT|UI_SMALLFONT, controls_binding_color );
-			UI_DrawString( x - SMALLCHAR_WIDTH, y, g_bindings[b1].label, UI_RIGHT|UI_SMALLFONT, text_color_normal );
-			UI_DrawString( x + SMALLCHAR_WIDTH, y, name, UI_LEFT|UI_SMALLFONT, text_color_normal );
-// END
+                        UI_DrawString( LABEL_COLUMN_X, y, g_bindings[b1].label, UI_RIGHT|UI_SMALLFONT, text_color_normal );
+                        UI_DrawString( VALUE_COLUMN_X, y, name, UI_LEFT|UI_SMALLFONT, text_color_normal );
 		}
 	}
 }


### PR DESCRIPTION
## Summary
- Define shared label and value column positions for consistent layout
- Use new column constants in controls menu and widgets
- Align key binding, radio button, and slider drawings to common columns

## Testing
- `make` *(fails: SDL_version.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68bdc56c51188324b6a996a9b19f3a48