### PR TITLE
Adjust radio button cursor position

### DIFF
--- a/engine/code/q3_ui/ui_qmenu.c
+++ b/engine/code/q3_ui/ui_qmenu.c
@@ -526,7 +526,7 @@ static void RadioButton_Draw( menuradiobutton_s *rb )
 	int	style;
 	qboolean focus;
 
-	x = rb->generic.x - SMALLCHAR_WIDTH;
+	x = rb->generic.x - 3*SMALLCHAR_WIDTH;
         y = rb->generic.y;
 
 	focus = (rb->generic.parent->cursor == rb->generic.menuPosition);


### PR DESCRIPTION
## Summary
- Position radio button highlight arrow three character widths left of the icon so the indicator appears before the on/off graphic.

## Testing
- `make` *(fails: SDL_version.h: No such file or directory)*
- `apt-get update` *(fails: 403 Repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68bdd3b9694c8324b1ab4372ea119ee2