### PR TITLE
Adjust radio button interactive width

### DIFF
--- a/engine/code/q3_ui/ui_qmenu.c
+++ b/engine/code/q3_ui/ui_qmenu.c
@@ -248,7 +248,7 @@ static void PText_Draw( menutext_s *t )
 	style = t->style;
 	if( t->generic.flags & QMF_PULSEIFFOCUS ) {
 		if( Menu_ItemAtCursor( t->generic.parent ) == t ) {
-			style |= UI_PULSE;
+		style |= UI_PULSE;
 		}
 // STONELANCE
 /*
@@ -473,7 +473,7 @@ static void RadioButton_Init( menuradiobutton_s *rb )
 	rb->generic.left   = LABEL_COLUMN_X - SMALLCHAR_WIDTH - len * SMALLCHAR_WIDTH;
 // STONELANCE
 //	rb->generic.right  = VALUE_COLUMN_X + 6*SMALLCHAR_WIDTH;
-	rb->generic.right  = VALUE_COLUMN_X + 4*SMALLCHAR_WIDTH + 16;
+		rb->generic.right  = VALUE_COLUMN_X + 3*SMALLCHAR_WIDTH + 16;
 // END
 	rb->generic.top    = rb->generic.y;
 	rb->generic.bottom = rb->generic.y + SMALLCHAR_HEIGHT;


### PR DESCRIPTION
## Summary
- narrow the clickable region for radio buttons so it ends just after the icon and text

## Testing
- `make` *(fails: SDL_version.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68bdd509c5a08324917d1910d5d574eb