### PR TITLE
Fix weapon preview mapping in controls menu

### DIFF
--- a/engine/code/q3_ui/ui_controls2.c
+++ b/engine/code/q3_ui/ui_controls2.c
@@ -482,7 +482,7 @@ static void Controls_UpdateModel( int anim ) {
 		break;
 
 	case ANIM_WEAPON1:
-		s_controls.playerWeapon = WP_FLAME_THROWER;
+		s_controls.playerWeapon = WP_GAUNTLET;
 		break;
 
 	case ANIM_WEAPON2:
@@ -518,7 +518,7 @@ static void Controls_UpdateModel( int anim ) {
 		break;
 
 	case ANIM_WEAPON10:
-		s_controls.playerWeapon = WP_GRAPPLING_HOOK;
+		s_controls.playerWeapon = WP_FLAME_THROWER;
 		break;
 
 	case ANIM_ATTACK:


### PR DESCRIPTION
## Summary
- map control menu preview animations to correct weapons

## Testing
- `make -C engine` *(fails: SDL_version.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68bddd6c52988324994f43ceb87020f4