### PR TITLE
Add parc ferme intermission display

### DIFF
--- a/engine/Makefile
+++ b/engine/Makefile
@@ -2710,6 +2710,7 @@ Q3CGOBJ_ = \
   $(B)/$(BASEGAME)/cgame/cg_rally_tools.o \
   $(B)/$(BASEGAME)/cgame/cg_scoreboard.o \
   $(B)/$(BASEGAME)/cgame/cg_servercmds.o \
+  $(B)/$(BASEGAME)/cgame/cg_parcferme.o \
   $(B)/$(BASEGAME)/cgame/cg_snapshot.o \
   $(B)/$(BASEGAME)/cgame/cg_view.o \
   $(B)/$(BASEGAME)/cgame/cg_weapons.o \
@@ -2741,6 +2742,7 @@ MPCGOBJ_ = \
   $(B)/$(MISSIONPACK)/cgame/cg_consolecmds.o \
   $(B)/$(MISSIONPACK)/cgame/cg_newdraw.o \
   $(B)/$(MISSIONPACK)/cgame/cg_draw.o \
+  $(B)/$(MISSIONPACK)/cgame/cg_parcferme.o \
   $(B)/$(MISSIONPACK)/cgame/cg_drawtools.o \
   $(B)/$(MISSIONPACK)/cgame/cg_effects.o \
   $(B)/$(MISSIONPACK)/cgame/cg_ents.o \

--- a/engine/code/cgame/cg_draw.c
+++ b/engine/code/cgame/cg_draw.c
@@ -25,6 +25,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 // active (after loading) gameplay
 
 #include "cg_local.h"
+#include "cg_parcferme.h"
 
 #ifdef MISSIONPACK
 #include "../ui/ui_shared.h"
@@ -2943,6 +2944,17 @@ static void CG_DrawIntermission( void ) {
 	}
 #endif
 	cg.scoreFadeTime = cg.time;
+
+        if ( cg.intermissionStarted ) {
+                CG_DrawParcFerme();
+                if ( cg.time >= cg.parcFermeEndTime ) {
+                        cg.scoreBoardShowing = CG_DrawModernScoreboard();
+                }
+                return;
+        }
+
+
+
 
 // Q3Rally Code Start
 	cg.scoreBoardShowing = CG_DrawHUD();

--- a/engine/code/cgame/cg_local.h
+++ b/engine/code/cgame/cg_local.h
@@ -611,6 +611,7 @@ typedef struct {
 	int			deferredPlayerLoading;
 	qboolean	loading;			// don't defer players at initial startup
 	qboolean	intermissionStarted;	// don't play voice rewards, because game will end shortly
+	int			parcFermeEndTime;		// time when parc ferme view ends
 
 	// there are only one or two snapshot_t that are relevant at a time
 	int			latestSnapshotNum;	// the number of snapshots the client system has received
@@ -1472,6 +1473,7 @@ extern	vmCvar_t		cg_engineSounds;
 
 extern  vmCvar_t                cg_fuelWarningLevel;
 extern	vmCvar_t		cg_drawBotPaths;
+extern	vmCvar_t		cg_parcFermeTime;
 // Q3Rally Code END
 
 //
@@ -1788,6 +1790,7 @@ void CG_DrawInformation( void );
 // cg_scoreboard.c
 //
 qboolean CG_DrawOldScoreboard( void );
+qboolean CG_DrawModernScoreboard( void );
 // Q3Rally Code Start - removed
 // void CG_DrawTourneyScoreboard( void );
 // Q3Rally Code END

--- a/engine/code/cgame/cg_main.c
+++ b/engine/code/cgame/cg_main.c
@@ -135,6 +135,7 @@ vmCvar_t	cg_shadows;
 vmCvar_t	cg_gibs;
 vmCvar_t	cg_drawTimer;
 vmCvar_t	cg_drawFPS;
+vmCvar_t    cg_parcFermeTime;
 vmCvar_t    cg_sigilSwitch;
 vmCvar_t	cg_drawSnapshot;
 vmCvar_t	cg_draw3dIcons;
@@ -305,6 +306,8 @@ static cvarTable_t cvarTable[] = {
 	{ &cg_drawStatus, "cg_drawStatus", "1", CVAR_ARCHIVE  },
 	{ &cg_drawTimer, "cg_drawTimer", "0", CVAR_ARCHIVE  },
 	{ &cg_drawFPS, "cg_drawFPS", "0", CVAR_ARCHIVE  },
+        { &cg_parcFermeTime, "cg_parcFermeTime", "7000", CVAR_ARCHIVE  },
+
     { &cg_sigilSwitch, "cg_sigilSwitch", "0", CVAR_ARCHIVE  },
 	{ &cg_drawSnapshot, "cg_drawSnapshot", "0", CVAR_ARCHIVE  },
 	{ &cg_draw3dIcons, "cg_draw3dIcons", "1", CVAR_ARCHIVE  },

--- a/engine/code/cgame/cg_parcferme.c
+++ b/engine/code/cgame/cg_parcferme.c
@@ -1,0 +1,43 @@
+/*
+=======================================================================
+  cg_parcferme.c -- rendering for parc ferme podium
+=======================================================================
+*/
+
+#include "cg_local.h"
+#include "cg_parcferme.h"
+
+/*
+=================
+CG_DrawParcFerme
+Draw top three vehicles and player names during intermission
+=================
+*/
+void CG_DrawParcFerme( void ) {
+    int i;
+    vec3_t origin = { 0, 0, 0 };
+    vec3_t angles = { 0, 0, 0 };
+    float size = 120.0f;
+    float spacing = 20.0f;
+    float baseX;
+
+    CG_SetScreenPlacement( PLACE_CENTER, PLACE_TOP );
+
+    baseX = 320 - (3 * size + 2 * spacing) / 2;
+
+    for ( i = 0; i < 3 && i < cg.numScores; i++ ) {
+        score_t *score = &cg.scores[i];
+        clientInfo_t *ci = &cgs.clientinfo[ score->client ];
+
+        if ( !ci->infoValid ) {
+            continue;
+        }
+
+        float x = baseX + i * (size + spacing);
+        float y = 100.0f;
+
+        CG_Draw3DModel( x, y, size, size, ci->bodyModel, ci->bodySkin, origin, angles );
+        CG_DrawBigStringColor( x, y + size + 10, va( "%i. %s", i + 1, ci->name ), colorWhite );
+    }
+}
+

--- a/engine/code/cgame/cg_parcferme.h
+++ b/engine/code/cgame/cg_parcferme.h
@@ -1,0 +1,13 @@
+/*
+=======================================================================
+  cg_parcferme.h -- prototypes for parc ferme drawing
+=======================================================================
+*/
+
+#ifndef CG_PARCFERME_H
+#define CG_PARCFERME_H
+
+void CG_DrawParcFerme( void );
+
+#endif // CG_PARCFERME_H
+

--- a/engine/code/cgame/cg_public.h
+++ b/engine/code/cgame/cg_public.h
@@ -238,3 +238,5 @@ typedef enum {
 } cgameExport_t;
 
 //----------------------------------------------
+
+void CG_DrawParcFerme( void );

--- a/engine/code/cgame/cg_servercmds.c
+++ b/engine/code/cgame/cg_servercmds.c
@@ -415,6 +415,10 @@ static void CG_ConfigStringModified( void ) {
 #endif
 	} else if ( num == CS_INTERMISSION ) {
 		cg.intermissionStarted = atoi( str );
+		if ( cg.intermissionStarted ) {
+			int duration = cg_parcFermeTime.integer ? cg_parcFermeTime.integer : 7000;
+			cg.parcFermeEndTime = cg.time + duration;
+		}
 	} else if ( num >= CS_MODELS && num < CS_MODELS+MAX_MODELS ) {
 		cgs.gameModels[ num-CS_MODELS ] = trap_R_RegisterModel( str );
 	} else if ( num >= CS_SOUNDS && num < CS_SOUNDS+MAX_SOUNDS ) {


### PR DESCRIPTION
## Summary
- show top three vehicles during intermission using a new parc-ferme renderer
- configure display duration via new `cg_parcFermeTime` cvar
- display modern scoreboard after parc-ferme countdown

## Testing
- `make` *(fails: SDL_version.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68bde9cc6c848324ad39708218832027