### PR TITLE
Move variable declarations for x and y in parc ferme rendering loop

### DIFF
--- a/engine/code/cgame/cg_parcferme.c
+++ b/engine/code/cgame/cg_parcferme.c
@@ -28,13 +28,15 @@ void CG_DrawParcFerme( void ) {
     for ( i = 0; i < 3 && i < cg.numScores; i++ ) {
         score_t *score = &cg.scores[i];
         clientInfo_t *ci = &cgs.clientinfo[ score->client ];
+        float x;
+        float y;
 
         if ( !ci->infoValid ) {
             continue;
         }
 
-        float x = baseX + i * (size + spacing);
-        float y = 100.0f;
+        x = baseX + i * (size + spacing);
+        y = 100.0f;
 
         CG_Draw3DModel( x, y, size, size, ci->bodyModel, ci->bodySkin, origin, angles );
         CG_DrawBigStringColor( x, y + size + 10, va( "%i. %s", i + 1, ci->name ), colorWhite );


### PR DESCRIPTION
## Summary
- Declare `x` and `y` alongside other variables at the start of the parc ferme loop.
- Assign positions for the podium rendering after verifying client info validity.

## Testing
- `make` *(fails: SDL_version.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68bdf0c61d68832482bbc1ec577eb004