### PR TITLE
Render parc-ferme podium vehicles

### DIFF
--- a/engine/code/cgame/cg_local.h
+++ b/engine/code/cgame/cg_local.h
@@ -1616,6 +1616,7 @@ qhandle_t CG_StatusHandle(int task);
 void CG_Player( centity_t *cent );
 void CG_ResetPlayerEntity( centity_t *cent );
 void CG_AddRefEntityWithPowerups( refEntity_t *ent, entityState_t *state, int team );
+void CG_AddWheels( centity_t *cent, refEntity_t *body, float angle );
 void CG_NewClientInfo( int clientNum );
 sfxHandle_t	CG_CustomSound( int clientNum, const char *soundName );
 

--- a/engine/code/cgame/cg_parcferme.c
+++ b/engine/code/cgame/cg_parcferme.c
@@ -26,10 +26,16 @@ void CG_DrawParcFerme( void ) {
     baseX = 320 - (3 * size + 2 * spacing) / 2;
 
     for ( i = 0; i < 3 && i < cg.numScores; i++ ) {
-        score_t *score = &cg.scores[i];
-        clientInfo_t *ci = &cgs.clientinfo[ score->client ];
-        float x;
-        float y;
+        float x, y, wheelAngle, x2, y2, w2, h2;
+        score_t *score;
+        clientInfo_t *ci;
+        centity_t *cent;
+        refdef_t refdef;
+        refEntity_t body;
+
+        score = &cg.scores[i];
+        ci = &cgs.clientinfo[ score->client ];
+        cent = &cg_entities[ score->client ];
 
         if ( !ci->infoValid ) {
             continue;
@@ -38,7 +44,42 @@ void CG_DrawParcFerme( void ) {
         x = baseX + i * (size + spacing);
         y = 100.0f;
 
-        CG_Draw3DModel( x, y, size, size, ci->bodyModel, ci->bodySkin, origin, angles );
+        x2 = x;
+        y2 = y;
+        w2 = size;
+        h2 = size;
+        CG_AdjustFrom640( &x2, &y2, &w2, &h2 );
+
+        memset( &refdef, 0, sizeof( refdef ) );
+        refdef.rdflags = RDF_NOWORLDMODEL;
+        AxisClear( refdef.viewaxis );
+        refdef.fov_x = 30;
+        refdef.fov_y = 30;
+        refdef.x = x2;
+        refdef.y = y2;
+        refdef.width = w2;
+        refdef.height = h2;
+        refdef.time = cg.time;
+
+        memset( &body, 0, sizeof( body ) );
+        body.hModel = ci->bodyModel;
+        body.customSkin = ci->bodySkin;
+        VectorCopy( origin, body.origin );
+        AnglesToAxis( angles, body.axis );
+        body.renderfx = RF_NOSHADOW;
+
+        if ( ci->controlMode == CT_MOUSE ) {
+            wheelAngle = WheelAngle( cent->currentState.apos.trBase[YAW],
+                                    cent->currentState.angles2[YAW] );
+        } else {
+            wheelAngle = cent->currentState.angles2[YAW];
+        }
+
+        trap_R_ClearScene();
+        CG_AddRefEntityWithPowerups( &body, &cent->currentState, ci->team );
+        CG_AddWheels( cent, &body, wheelAngle );
+        trap_R_RenderScene( &refdef );
+
         CG_DrawBigStringColor( x, y + size + 10, va( "%i. %s", i + 1, ci->name ), colorWhite );
     }
 }

--- a/engine/code/cgame/cg_players.c
+++ b/engine/code/cgame/cg_players.c
@@ -3135,7 +3135,7 @@ Adds the wheels to the car body.
 // Q3Rally Code Start
 // FIXME: could increase the speed by only looking for components that
 // need to be drawn once when the model is loaded
-static void CG_AddWheels( centity_t *cent, refEntity_t *body, float angle )
+void CG_AddWheels( centity_t *cent, refEntity_t *body, float angle )
 {
 	clientInfo_t	*ci;
 	centity_t		*cent2;


### PR DESCRIPTION
## Summary
- Render podium cars by building ref entities and wheels instead of using `CG_Draw3DModel`
- Expose `CG_AddWheels` for reuse in parc-ferme rendering

## Testing
- `make release BUILD_GAME_SO=0 BUILD_SERVER=0 USE_LOCAL_HEADERS=1` *(fails: SDL_version.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68bdf56226f88324bb571bb0cebc6c27