### PR TITLE
Handle missing vehicle models in Parc Ferme

### DIFF
--- a/engine/code/cgame/cg_parcferme.c
+++ b/engine/code/cgame/cg_parcferme.c
@@ -64,21 +64,35 @@ void CG_DrawParcFerme( void ) {
         memset( &body, 0, sizeof( body ) );
         body.hModel = ci->bodyModel;
         body.customSkin = ci->bodySkin;
-        VectorCopy( origin, body.origin );
-        AnglesToAxis( angles, body.axis );
-        body.renderfx = RF_NOSHADOW;
 
-        if ( ci->controlMode == CT_MOUSE ) {
-            wheelAngle = WheelAngle( cent->currentState.apos.trBase[YAW],
-                                    cent->currentState.angles2[YAW] );
+        if ( body.hModel ) {
+            VectorCopy( origin, body.origin );
+            AnglesToAxis( angles, body.axis );
+            body.renderfx = RF_NOSHADOW;
+
+            if ( ci->controlMode == CT_MOUSE ) {
+                wheelAngle = WheelAngle( cent->currentState.apos.trBase[YAW],
+                                        cent->currentState.angles2[YAW] );
+            } else {
+                wheelAngle = cent->currentState.angles2[YAW];
+            }
+
+            trap_R_ClearScene();
+            CG_AddRefEntityWithPowerups( &body, &cent->currentState, ci->team );
+            CG_AddWheels( cent, &body, wheelAngle );
+            trap_R_RenderScene( &refdef );
         } else {
-            wheelAngle = cent->currentState.angles2[YAW];
-        }
+            qhandle_t icon;
 
-        trap_R_ClearScene();
-        CG_AddRefEntityWithPowerups( &body, &cent->currentState, ci->team );
-        CG_AddWheels( cent, &body, wheelAngle );
-        trap_R_RenderScene( &refdef );
+            icon = ci->modelIcon;
+            if ( !icon ) {
+                icon = cgs.media.deferShader;
+            }
+
+            if ( icon ) {
+                CG_DrawPic( x, y, size, size, icon );
+            }
+        }
 
         CG_DrawBigStringColor( x, y + size + 10, va( "%i. %s", i + 1, ci->name ), colorWhite );
     }


### PR DESCRIPTION
## Summary
- use `clientInfo_t` vehicle model and icon when drawing Parc Ferme podium
- draw vehicle icon when model handle is missing

## Testing
- `make -C engine BUILD_GAME_QVM=1` *(fails: SDL_version.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68bdfa7ab76c8324be3e1922bd5fab56