### PR TITLE
Init Parc Ferme on intermission transition

### DIFF
--- a/engine/code/cgame/cg_draw.c
+++ b/engine/code/cgame/cg_draw.c
@@ -44,6 +44,8 @@ char systemChat[256];
 char teamChat1[256];
 char teamChat2[256];
 
+static qboolean parcFermeActive = qfalse;
+
 static float CG_DrawRallyPowerups( float y );
 
 #ifdef MISSIONPACK
@@ -3193,14 +3195,24 @@ CG_Draw2D
 static void CG_Draw2D(stereoFrame_t stereoFrame)
 {
 #ifdef MISSIONPACK
-	if (cgs.orderPending && cg.time > cgs.orderTime) {
-		CG_CheckOrderPending();
-	}
+        if (cgs.orderPending && cg.time > cgs.orderTime) {
+                CG_CheckOrderPending();
+        }
 #endif
-	// if we are taking a levelshot for the menu, don't draw anything
-	if ( cg.levelShot ) {
-		return;
-	}
+       // handle parc ferme initialization and cleanup
+       if ( cg.intermissionStarted ) {
+               if ( !parcFermeActive ) {
+                       CG_ParcFerme_Begin();
+                       parcFermeActive = qtrue;
+               }
+       } else if ( parcFermeActive ) {
+               CG_ParcFerme_End();
+               parcFermeActive = qfalse;
+       }
+        // if we are taking a levelshot for the menu, don't draw anything
+        if ( cg.levelShot ) {
+                return;
+        }
 
 	if ( cg_draw2D.integer == 0 ) {
 		return;

--- a/engine/code/cgame/cg_parcferme.c
+++ b/engine/code/cgame/cg_parcferme.c
@@ -9,6 +9,22 @@
 
 /*
 =================
+CG_ParcFerme_Begin
+=================
+*/
+void CG_ParcFerme_Begin( void ) {
+}
+
+/*
+=================
+CG_ParcFerme_End
+=================
+*/
+void CG_ParcFerme_End( void ) {
+}
+
+/*
+=================
 CG_DrawParcFerme
 Draw top three vehicles and player names during intermission
 =================

--- a/engine/code/cgame/cg_parcferme.h
+++ b/engine/code/cgame/cg_parcferme.h
@@ -7,6 +7,8 @@
 #ifndef CG_PARCFERME_H
 #define CG_PARCFERME_H
 
+void CG_ParcFerme_Begin( void );
+void CG_ParcFerme_End( void );
 void CG_DrawParcFerme( void );
 
 #endif // CG_PARCFERME_H


### PR DESCRIPTION
## Summary
- Add tracking for `cg.intermissionStarted` to begin and end Parc Ferme once per intermission
- Stub out `CG_ParcFerme_Begin`/`End` functions

## Testing
- `make -C engine` *(fails: SDL_version.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68bdfbb7bf908324ac3274a2a8ffbe2c