### PR TITLE
Show scoreboard after Parc Ferme in intermission

### DIFF
--- a/engine/code/cgame/cg_draw.c
+++ b/engine/code/cgame/cg_draw.c
@@ -2948,9 +2948,12 @@ static void CG_DrawIntermission( void ) {
 	cg.scoreFadeTime = cg.time;
 
         if ( cg.intermissionStarted ) {
-                CG_DrawParcFerme();
-                if ( cg.time >= cg.parcFermeEndTime ) {
+                if ( !CG_DrawParcFerme() ) {
                         cg.scoreBoardShowing = CG_DrawModernScoreboard();
+                        cg.showScores = cg.scoreBoardShowing;
+                } else {
+                        cg.scoreBoardShowing = qfalse;
+                        cg.showScores = qfalse;
                 }
                 return;
         }

--- a/engine/code/cgame/cg_parcferme.c
+++ b/engine/code/cgame/cg_parcferme.c
@@ -29,13 +29,17 @@ CG_DrawParcFerme
 Draw top three vehicles and player names during intermission
 =================
 */
-void CG_DrawParcFerme( void ) {
+qboolean CG_DrawParcFerme( void ) {
     int i;
     vec3_t origin = { 0, 0, 0 };
     vec3_t angles = { 0, 0, 0 };
     float size = 120.0f;
     float spacing = 20.0f;
     float baseX;
+
+    if ( cg.time >= cg.parcFermeEndTime ) {
+        return qfalse;
+    }
 
     CG_SetScreenPlacement( PLACE_CENTER, PLACE_TOP );
 
@@ -112,5 +116,7 @@ void CG_DrawParcFerme( void ) {
 
         CG_DrawBigStringColor( x, y + size + 10, va( "%i. %s", i + 1, ci->name ), colorWhite );
     }
+
+    return qtrue;
 }
 

--- a/engine/code/cgame/cg_parcferme.h
+++ b/engine/code/cgame/cg_parcferme.h
@@ -9,7 +9,7 @@
 
 void CG_ParcFerme_Begin( void );
 void CG_ParcFerme_End( void );
-void CG_DrawParcFerme( void );
+qboolean CG_DrawParcFerme( void );
 
 #endif // CG_PARCFERME_H
 

--- a/engine/code/cgame/cg_public.h
+++ b/engine/code/cgame/cg_public.h
@@ -239,4 +239,4 @@ typedef enum {
 
 //----------------------------------------------
 
-void CG_DrawParcFerme( void );
+qboolean CG_DrawParcFerme( void );


### PR DESCRIPTION
## Summary
- Return a qboolean from `CG_DrawParcFerme` and stop drawing once the timer expires.
- In `CG_DrawIntermission`, use the return value of `CG_DrawParcFerme` to switch to the modern scoreboard and keep `cg.showScores` in sync with `cg.scoreBoardShowing`.
- Update public headers to reflect the new `CG_DrawParcFerme` signature.

## Testing
- `make` *(fails: SDL_version.h: No such file or directory)*
- `apt-get update` *(fails: repository not signed)*


------
https://chatgpt.com/codex/tasks/task_e_68bdfd2cf8ac8324a14a7a301b1415be