### PR TITLE
Replace EntitiesInBox with snapshot loop

### DIFF
--- a/engine/code/cgame/cg_rally_tools.c
+++ b/engine/code/cgame/cg_rally_tools.c
@@ -140,39 +140,36 @@ void CG_Sparks( const vec3_t origin, const vec3_t normal, const vec3_t direction
 
 qboolean CG_FrictionCalc( const carPoint_t *point, float *sCOF, float *kCOF )
 {
-	centity_t	*cent;
-	int			entityList[MAX_GENTITIES];
-	int			numListedEntities;
-	vec3_t		mins, maxs;
-	float		radius;
-	int			i;
+        centity_t       *cent;
+        entityState_t   *es;
+        float           radius;
+        int                     i;
 
-	radius = point->radius + SPLASH_RADIUS_SCALE * MAX_SPLASH_RADIUS;
+        for ( i = 0 ; i < cg.snap->numEntities ; i++ ) {
+                es = &cg.snap->entities[ i ];
 
-	for ( i = 0 ; i < 3 ; i++ ) {
-		mins[i] = point->r[i] - radius;
-		maxs[i] = point->r[i] + radius;
-	}
+                if ( es->eType != ET_EVENTS + EV_HAZARD ) {
+                        continue;
+                }
+                if ( es->weapon != HT_OIL ) {
+                        continue;
+                }
 
-	numListedEntities = trap_EntitiesInBox( mins, maxs, entityList, MAX_GENTITIES );
+                cent = &cg_entities[ es->number ];
 
-	for ( i = 0 ; i < numListedEntities ; i++ ) {
-		cent = &cg_entities[entityList[ i ]];
+                radius = ( es->eventParm * SPLASH_RADIUS_SCALE ) + point->radius;
+                radius *= radius;
+                if ( DistanceSquared( cent->lerpOrigin, point->r ) > radius ) {
+                        continue;
+                }
 
-		if( cent->currentState.eType != ET_EVENTS + EV_HAZARD ) continue;
-		if( cent->currentState.weapon != HT_OIL ) continue;
+                *sCOF = CP_OIL_SCOF;
+                *kCOF = CP_OIL_KCOF;
 
-		radius = ( cent->currentState.eventParm * SPLASH_RADIUS_SCALE ) + point->radius;
-		radius *= radius;
-		if( DistanceSquared( cent->lerpOrigin, point->r ) > radius ) continue;
+                return qtrue;
+        }
 
-		*sCOF = CP_OIL_SCOF;
-		*kCOF = CP_OIL_KCOF;
-
-		return qtrue;
-	}
-
-	return qfalse;
+        return qfalse;
 }
 
 

--- a/engine/code/cgame/tests/test_cg_frictioncalc.c
+++ b/engine/code/cgame/tests/test_cg_frictioncalc.c
@@ -5,45 +5,33 @@
 #define SPLASH_RADIUS_SCALE 16.0f
 #define MAX_SPLASH_RADIUS 14.0f
 
-static int stubEntityList[MAX_GENTITIES];
-static int stubEntityCount;
-
+cg_t cg;
+snapshot_t snap;
 centity_t cg_entities[MAX_GENTITIES];
-
-int trap_EntitiesInBox(const vec3_t mins, const vec3_t maxs, int *entityList, int maxcount) {
-    int count = stubEntityCount < maxcount ? stubEntityCount : maxcount;
-    for (int i = 0; i < count; ++i) {
-        entityList[i] = stubEntityList[i];
-    }
-    return count;
-}
 
 qboolean CG_FrictionCalc( const carPoint_t *point, float *sCOF, float *kCOF ) {
     centity_t   *cent;
-    int         entityList[MAX_GENTITIES];
-    int         numListedEntities;
-    vec3_t      mins, maxs;
+    entityState_t *es;
     float       radius;
     int         i;
 
-    radius = point->radius + SPLASH_RADIUS_SCALE * MAX_SPLASH_RADIUS;
+    for ( i = 0 ; i < cg.snap->numEntities ; i++ ) {
+        es = &cg.snap->entities[ i ];
 
-    for ( i = 0 ; i < 3 ; i++ ) {
-        mins[i] = point->r[i] - radius;
-        maxs[i] = point->r[i] + radius;
-    }
+        if ( es->eType != ET_EVENTS + EV_HAZARD ) {
+            continue;
+        }
+        if ( es->weapon != HT_OIL ) {
+            continue;
+        }
 
-    numListedEntities = trap_EntitiesInBox( mins, maxs, entityList, MAX_GENTITIES );
+        cent = &cg_entities[ es->number ];
 
-    for ( i = 0 ; i < numListedEntities ; i++ ) {
-        cent = &cg_entities[entityList[ i ]];
-
-        if( cent->currentState.eType != ET_EVENTS + EV_HAZARD ) continue;
-        if( cent->currentState.weapon != HT_OIL ) continue;
-
-        radius = ( cent->currentState.eventParm * SPLASH_RADIUS_SCALE ) + point->radius;
+        radius = ( es->eventParm * SPLASH_RADIUS_SCALE ) + point->radius;
         radius *= radius;
-        if( DistanceSquared( cent->lerpOrigin, point->r ) > radius ) continue;
+        if ( DistanceSquared( cent->lerpOrigin, point->r ) > radius ) {
+            continue;
+        }
 
         *sCOF = CP_OIL_SCOF;
         *kCOF = CP_OIL_KCOF;
@@ -63,7 +51,9 @@ static void test_no_hazard(void) {
     float sCOF = 0.5f;
     float kCOF = 0.4f;
 
-    stubEntityCount = 0;
+    memset(&cg, 0, sizeof(cg));
+    cg.snap = &snap;
+    memset(&snap, 0, sizeof(snap));
     qboolean result = CG_FrictionCalc(&point, &sCOF, &kCOF);
     assert(result == qfalse);
     assert(sCOF == 0.5f);
@@ -85,8 +75,14 @@ static void test_oil_hazard(void) {
     cg_entities[0].currentState.eventParm = 1;
     cg_entities[0].lerpOrigin[0] = cg_entities[0].lerpOrigin[1] = cg_entities[0].lerpOrigin[2] = 0.0f;
 
-    stubEntityList[0] = 0;
-    stubEntityCount = 1;
+    memset(&cg, 0, sizeof(cg));
+    cg.snap = &snap;
+    memset(&snap, 0, sizeof(snap));
+    snap.numEntities = 1;
+    snap.entities[0].eType = ET_EVENTS + EV_HAZARD;
+    snap.entities[0].weapon = HT_OIL;
+    snap.entities[0].eventParm = 1;
+    snap.entities[0].number = 0;
 
     qboolean result = CG_FrictionCalc(&point, &sCOF, &kCOF);
     assert(result == qtrue);


### PR DESCRIPTION
## Summary
- scan cg.snap entities instead of calling trap_EntitiesInBox in CG_FrictionCalc
- update friction calculation unit test to build a snapshot and entities directly

## Testing
- `gcc engine/code/cgame/tests/test_cg_frictioncalc.c -Iengine/code/cgame -Iengine/code -DARCH_STRING=\"x86\" -o engine/code/cgame/tests/test_cg_frictioncalc`
- `engine/code/cgame/tests/test_cg_frictioncalc && echo OK`


------
https://chatgpt.com/codex/tasks/task_e_68bf3621af048324b6cc72d92c2ebd2a