### PR TITLE
Guard SSE detection for x86 architectures

### DIFF
--- a/engine/code/qcommon/common.c
+++ b/engine/code/qcommon/common.c
@@ -108,7 +108,9 @@ long (QDECL *Q_ftol)(float f);
 int (QDECL *Q_VMftol)(void);
 void (QDECL *Q_SnapVector)(vec3_t vec);
 #endif
-#elif defined(__aarch64__)
+#endif
+
+#if defined(__aarch64__)
 #define Q_SnapVector SnapVector
 #define Q_ftol lrintf
 #endif


### PR DESCRIPTION
## Summary
- Restrict SSE-related global declarations to x86 builds
- Provide no-op Com_DetectSSE on non-x86 systems

## Testing
- `make -C engine` *(fails: SDL_version.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68bf40a59bc08324b684caf6e900b0cd