### PR TITLE
Implement SSAO post-processing stage

### DIFF
--- a/engine/code/renderergl2/glsl/ssao_fp.glsl
+++ b/engine/code/renderergl2/glsl/ssao_fp.glsl
@@ -1,100 +1,44 @@
 uniform sampler2D u_ScreenDepthMap;
-
+uniform sampler2D u_LevelsMap;
 uniform vec4   u_ViewInfo; // zfar / znear, zfar, 1/width, 1/height
 
 varying vec2   var_ScreenTex;
 
-#if 0
-vec2 poissonDisc[9] = vec2[9](
-vec2(-0.7055767, 0.196515),    vec2(0.3524343, -0.7791386),
-vec2(0.2391056, 0.9189604),    vec2(-0.07580382, -0.09224417),
-vec2(0.5784913, -0.002528916), vec2(0.192888, 0.4064181),
-vec2(-0.6335801, -0.5247476),  vec2(-0.5579782, 0.7491854),
-vec2(0.7320465, 0.6317794)
+const int NUM_SAMPLES = 16;
+const vec3 sampleKernel[16] = vec3[16](
+    vec3(0.5381, 0.1856, 0.4319),
+    vec3(0.1379, 0.2486, 0.4430),
+    vec3(0.3371, 0.5679, 0.0057),
+    vec3(-0.6999, -0.0451, -0.0019),
+    vec3(0.0689, -0.1598, -0.8547),
+    vec3(0.0560, 0.0069, -0.1843),
+    vec3(-0.0146, 0.1402, 0.0762),
+    vec3(0.0100, -0.1924, 0.2779),
+    vec3(-0.3577, -0.5301, -0.4358),
+    vec3(-0.3169, 0.1063, 0.0158),
+    vec3(0.0103, -0.5869, -0.0046),
+    vec3(-0.0897, -0.4940, 0.3287),
+    vec3(0.7119, -0.0154, -0.0918),
+    vec3(-0.0533, 0.0596, -0.5411),
+    vec3(0.0352, 0.0631, 0.5460),
+    vec3(-0.4776, 0.2847, -0.0271)
 );
-#endif
 
-#define NUM_SAMPLES 3
-
-// Input: It uses texture coords as the random number seed.
-// Output: Random number: [0,1), that is between 0.0 and 0.999999... inclusive.
-// Author: Michael Pohoreski
-// Copyright: Copyleft 2012 :-)
-// Source: http://stackoverflow.com/questions/5149544/can-i-generate-a-random-number-inside-a-pixel-shader
-
-float random( const vec2 p )
-{
-  // We need irrationals for pseudo randomness.
-  // Most (all?) known transcendental numbers will (generally) work.
-  const vec2 r = vec2(
-    23.1406926327792690,  // e^pi (Gelfond's constant)
-     2.6651441426902251); // 2^sqrt(2) (Gelfond-Schneider constant)
-  //return fract( cos( mod( 123456789., 1e-7 + 256. * dot(p,r) ) ) );
-  return mod( 123456789., 1e-7 + 256. * dot(p,r) );  
-}
-
-mat2 randomRotation( const vec2 p )
-{
-	float r = random(p);
-	float sinr = sin(r);
-	float cosr = cos(r);
-	return mat2(cosr, sinr, -sinr, cosr);
-}
-
-float getLinearDepth(sampler2D depthMap, const vec2 tex, const float zFarDivZNear)
-{
-	float sampleZDivW = texture2D(depthMap, tex).r;
-	return 1.0 / mix(zFarDivZNear, 1.0, sampleZDivW);
-}
-
-float ambientOcclusion(sampler2D depthMap, const vec2 tex, const float zFarDivZNear, const float zFar, const vec2 scale)
-{
-	vec2 poissonDisc[9];
-
-	poissonDisc[0] = vec2(-0.7055767, 0.196515);
-	poissonDisc[1] = vec2(0.3524343, -0.7791386);
-	poissonDisc[2] = vec2(0.2391056, 0.9189604);
-	poissonDisc[3] = vec2(-0.07580382, -0.09224417);
-	poissonDisc[4] = vec2(0.5784913, -0.002528916);
-	poissonDisc[5] = vec2(0.192888, 0.4064181);
-	poissonDisc[6] = vec2(-0.6335801, -0.5247476);
-	poissonDisc[7] = vec2(-0.5579782, 0.7491854);
-	poissonDisc[8] = vec2(0.7320465, 0.6317794);
-
-	float result = 0.0;
-
-	float sampleZ = getLinearDepth(depthMap, tex, zFarDivZNear);
-	float scaleZ = zFarDivZNear * sampleZ;
-
-	vec2 slope = vec2(dFdx(sampleZ), dFdy(sampleZ)) / vec2(dFdx(tex.x), dFdy(tex.y));
-
-	if (length(slope) * zFar > 5000.0)
-		return 1.0;
-
-	vec2 offsetScale = vec2(scale * 1024.0 / scaleZ);
-
-	mat2 rmat = randomRotation(tex);
-
-	float invZFar = 1.0 / zFar;
-	float zLimit = 20.0 * invZFar;
-	for (int i = 0; i < NUM_SAMPLES; i++)
-	{
-		vec2 offset = rmat * poissonDisc[i] * offsetScale;
-		float sampleDiff = getLinearDepth(depthMap, tex + offset, zFarDivZNear) - sampleZ;
-
-		bool s1 = abs(sampleDiff) > zLimit;
-		bool s2 = sampleDiff + invZFar > dot(slope, offset);
-		result += float(s1 || s2);
-	}
-
-	result *= 1.0 / float(NUM_SAMPLES);
-
-	return result;
+float getDepth(vec2 texCoord) {
+    return texture2D(u_ScreenDepthMap, texCoord).r;
 }
 
 void main()
 {
-	float result = ambientOcclusion(u_ScreenDepthMap, var_ScreenTex, u_ViewInfo.x, u_ViewInfo.y, u_ViewInfo.wz);
-
-	gl_FragColor = vec4(vec3(result), 1.0);
+    float depth = getDepth(var_ScreenTex);
+    vec3 randomVec = texture2D(u_LevelsMap, var_ScreenTex * 4.0).xyz * 2.0 - 1.0;
+    float occ = 0.0;
+    for (int i = 0; i < NUM_SAMPLES; i++) {
+        vec3 sampleDir = reflect(sampleKernel[i], randomVec);
+        vec2 offset = sampleDir.xy * 4.0 * u_ViewInfo.zw;
+        float sampleDepth = getDepth(var_ScreenTex + offset);
+        occ += sampleDepth >= depth + sampleDir.z ? 1.0 : 0.0;
+    }
+    occ = 1.0 - (occ / float(NUM_SAMPLES));
+    gl_FragColor = vec4(vec3(occ), 1.0);
 }

--- a/engine/code/renderergl2/tr_backend.c
+++ b/engine/code/renderergl2/tr_backend.c
@@ -1060,75 +1060,10 @@ const void	*RB_DrawSurfs( const void *data ) {
 					RB_InstantQuad2(quadVerts, texCoords);
 				}
 			}
-
-			if (r_ssao->integer)
-			{
-				vec4_t quadVerts[4];
-				vec2_t texCoords[4];
-
-				viewInfo[2] = 1.0f / ((float)(tr.quarterImage[0]->width)  * tan(backEnd.viewParms.fovX * M_PI / 360.0f) * 2.0f);
-				viewInfo[3] = 1.0f / ((float)(tr.quarterImage[0]->height) * tan(backEnd.viewParms.fovY * M_PI / 360.0f) * 2.0f);
-				viewInfo[3] *= (float)backEnd.viewParms.viewportHeight / (float)backEnd.viewParms.viewportWidth;
-
-				FBO_Bind(tr.quarterFbo[0]);
-
-				qglViewport(0, 0, tr.quarterFbo[0]->width, tr.quarterFbo[0]->height);
-				qglScissor(0, 0, tr.quarterFbo[0]->width, tr.quarterFbo[0]->height);
-
-				VectorSet4(quadVerts[0], -1,  1, 0, 1);
-				VectorSet4(quadVerts[1],  1,  1, 0, 1);
-				VectorSet4(quadVerts[2],  1, -1, 0, 1);
-				VectorSet4(quadVerts[3], -1, -1, 0, 1);
-
-				texCoords[0][0] = 0; texCoords[0][1] = 1;
-				texCoords[1][0] = 1; texCoords[1][1] = 1;
-				texCoords[2][0] = 1; texCoords[2][1] = 0;
-				texCoords[3][0] = 0; texCoords[3][1] = 0;
-
-				GL_State( GLS_DEPTHTEST_DISABLE );
-
-				GLSL_BindProgram(&tr.ssaoShader);
-
-				GL_BindToTMU(tr.hdrDepthImage, TB_COLORMAP);
-
-				GLSL_SetUniformVec4(&tr.ssaoShader, UNIFORM_VIEWINFO, viewInfo);
-
-				RB_InstantQuad2(quadVerts, texCoords); //, color, shaderProgram, invTexRes);
-
-
-				viewInfo[2] = 1.0f / (float)(tr.quarterImage[0]->width);
-				viewInfo[3] = 1.0f / (float)(tr.quarterImage[0]->height);
-
-				FBO_Bind(tr.quarterFbo[1]);
-
-				qglViewport(0, 0, tr.quarterFbo[1]->width, tr.quarterFbo[1]->height);
-				qglScissor(0, 0, tr.quarterFbo[1]->width, tr.quarterFbo[1]->height);
-
-				GLSL_BindProgram(&tr.depthBlurShader[0]);
-
-				GL_BindToTMU(tr.quarterImage[0],  TB_COLORMAP);
-				GL_BindToTMU(tr.hdrDepthImage, TB_LIGHTMAP);
-
-				GLSL_SetUniformVec4(&tr.depthBlurShader[0], UNIFORM_VIEWINFO, viewInfo);
-
-				RB_InstantQuad2(quadVerts, texCoords); //, color, shaderProgram, invTexRes);
-
-
-				FBO_Bind(tr.screenSsaoFbo);
-
-				qglViewport(0, 0, tr.screenSsaoFbo->width, tr.screenSsaoFbo->height);
-				qglScissor(0, 0, tr.screenSsaoFbo->width, tr.screenSsaoFbo->height);
-
-				GLSL_BindProgram(&tr.depthBlurShader[1]);
-
-				GL_BindToTMU(tr.quarterImage[1],  TB_COLORMAP);
-				GL_BindToTMU(tr.hdrDepthImage, TB_LIGHTMAP);
-
-				GLSL_SetUniformVec4(&tr.depthBlurShader[1], UNIFORM_VIEWINFO, viewInfo);
-
-
-				RB_InstantQuad2(quadVerts, texCoords); //, color, shaderProgram, invTexRes);
-			}
+                        if (r_ssao->integer)
+                        {
+                                RB_SSAO();
+                        }
 		}
 
 		// reset viewport and scissor
@@ -1500,22 +1435,12 @@ const void *RB_PostProcess(const void *data)
 		srcFbo = tr.msaaResolveFbo;
 	}
 
-	dstBox[0] = backEnd.viewParms.viewportX;
-	dstBox[1] = backEnd.viewParms.viewportY;
-	dstBox[2] = backEnd.viewParms.viewportWidth;
-	dstBox[3] = backEnd.viewParms.viewportHeight;
+       dstBox[0] = backEnd.viewParms.viewportX;
+       dstBox[1] = backEnd.viewParms.viewportY;
+       dstBox[2] = backEnd.viewParms.viewportWidth;
+       dstBox[3] = backEnd.viewParms.viewportHeight;
 
-	if (r_ssao->integer)
-	{
-		srcBox[0] = backEnd.viewParms.viewportX      * tr.screenSsaoImage->width  / (float)glConfig.vidWidth;
-		srcBox[1] = backEnd.viewParms.viewportY      * tr.screenSsaoImage->height / (float)glConfig.vidHeight;
-		srcBox[2] = backEnd.viewParms.viewportWidth  * tr.screenSsaoImage->width  / (float)glConfig.vidWidth;
-		srcBox[3] = backEnd.viewParms.viewportHeight * tr.screenSsaoImage->height / (float)glConfig.vidHeight;
-
-		FBO_Blit(tr.screenSsaoFbo, srcBox, NULL, srcFbo, dstBox, NULL, NULL, GLS_SRCBLEND_DST_COLOR | GLS_DSTBLEND_ZERO);
-	}
-
-	srcBox[0] = backEnd.viewParms.viewportX;
+       srcBox[0] = backEnd.viewParms.viewportX;
 	srcBox[1] = backEnd.viewParms.viewportY;
 	srcBox[2] = backEnd.viewParms.viewportWidth;
 	srcBox[3] = backEnd.viewParms.viewportHeight;

--- a/engine/code/renderergl2/tr_glsl.c
+++ b/engine/code/renderergl2/tr_glsl.c
@@ -1470,7 +1470,8 @@ void GLSL_InitGPUShaders(void)
 
 		GLSL_InitUniforms(&tr.ssaoShader);
 
-		GLSL_SetUniformInt(&tr.ssaoShader, UNIFORM_SCREENDEPTHMAP, TB_COLORMAP);
+               GLSL_SetUniformInt(&tr.ssaoShader, UNIFORM_SCREENDEPTHMAP, TB_COLORMAP);
+               GLSL_SetUniformInt(&tr.ssaoShader, UNIFORM_LEVELSMAP, TB_LEVELSMAP);
 
 		GLSL_FinishGPUShader(&tr.ssaoShader);
 

--- a/engine/code/renderergl2/tr_image.c
+++ b/engine/code/renderergl2/tr_image.c
@@ -24,6 +24,8 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 
 #include "tr_dsa.h"
 
+#include <stdlib.h>
+
 static byte			 s_intensitytable[256];
 static unsigned char s_gammatable[256];
 
@@ -2963,10 +2965,23 @@ void R_CreateBuiltinImages( void ) {
 			tr.quarterImage[x] = R_CreateImage(va("*quarter%d", x), NULL, width / 2, height / 2, IMGTYPE_COLORALPHA, IMGFLAG_NO_COMPRESSION | IMGFLAG_CLAMPTOEDGE, GL_RGBA8);
 		}
 
-		if (r_ssao->integer)
-		{
-			tr.screenSsaoImage = R_CreateImage("*screenSsao", NULL, width / 2, height / 2, IMGTYPE_COLORALPHA, IMGFLAG_NO_COMPRESSION | IMGFLAG_CLAMPTOEDGE, GL_RGBA8);
-		}
+               if (r_ssao->integer)
+               {
+                       byte noiseData[4 * 4 * 4];
+                       int i;
+
+                       tr.screenSsaoImage = R_CreateImage("*screenSsao", NULL, width / 2, height / 2, IMGTYPE_COLORALPHA, IMGFLAG_NO_COMPRESSION | IMGFLAG_CLAMPTOEDGE, GL_RGBA8);
+
+                       for (i = 0; i < 16; i++)
+                       {
+                               noiseData[i*4+0] = rand() & 255;
+                               noiseData[i*4+1] = rand() & 255;
+                               noiseData[i*4+2] = 0;
+                               noiseData[i*4+3] = 255;
+                       }
+
+                       tr.ssaoNoiseImage = R_CreateImage("*ssaoNoise", noiseData, 4, 4, IMGTYPE_COLORALPHA, IMGFLAG_NO_COMPRESSION, GL_RGBA8);
+               }
 
 		for( x = 0; x < MAX_DRAWN_PSHADOWS; x++)
 		{

--- a/engine/code/renderergl2/tr_local.h
+++ b/engine/code/renderergl2/tr_local.h
@@ -1549,7 +1549,8 @@ typedef struct {
 	image_t					*fixedLevelsImage;
 	image_t					*sunShadowDepthImage[4];
 	image_t                 *screenShadowImage;
-	image_t                 *screenSsaoImage;
+       image_t                 *screenSsaoImage;
+       image_t                 *ssaoNoiseImage;
 	image_t					*hdrDepthImage;
 	image_t                 *renderCubeImage;
 	image_t			*defaultReflectImage;

--- a/engine/code/renderergl2/tr_postprocess.c
+++ b/engine/code/renderergl2/tr_postprocess.c
@@ -90,7 +90,67 @@ void RB_ToneMap(FBO_t *hdrFbo, ivec4_t hdrBox, FBO_t *ldrFbo, ivec4_t ldrBox, in
 	else
 		GL_BindToTMU(tr.fixedLevelsImage, TB_LEVELSMAP);
 
-	FBO_Blit(hdrFbo, hdrBox, NULL, ldrFbo, ldrBox, &tr.tonemapShader, color, 0);
+       FBO_Blit(hdrFbo, hdrBox, NULL, ldrFbo, ldrBox, &tr.tonemapShader, color, 0);
+
+       if (r_ssao->integer)
+       {
+               ivec4_t srcBox;
+
+               srcBox[0] = hdrBox[0] * tr.screenSsaoImage->width  / (float)hdrFbo->width;
+               srcBox[1] = hdrBox[1] * tr.screenSsaoImage->height / (float)hdrFbo->height;
+               srcBox[2] = hdrBox[2] * tr.screenSsaoImage->width  / (float)hdrFbo->width;
+               srcBox[3] = hdrBox[3] * tr.screenSsaoImage->height / (float)hdrFbo->height;
+
+               FBO_Blit(tr.screenSsaoFbo, srcBox, NULL, ldrFbo, ldrBox, NULL, NULL,
+                        GLS_SRCBLEND_DST_COLOR | GLS_DSTBLEND_ZERO);
+       }
+}
+
+void RB_SSAO(void)
+{
+       vec4_t quadVerts[4];
+       vec2_t texCoords[4];
+       vec4_t viewInfo;
+       FBO_t *dst = tr.screenSsaoFbo;
+       FBO_t *oldFbo;
+       int width, height;
+
+       if (!dst)
+               return;
+
+       width = dst->width;
+       height = dst->height;
+
+       oldFbo = glState.currentFBO;
+       FBO_Bind(dst);
+
+       qglViewport(0, 0, width, height);
+       qglScissor(0, 0, width, height);
+
+       VectorSet4(quadVerts[0], -1,  1, 0, 1);
+       VectorSet4(quadVerts[1],  1,  1, 0, 1);
+       VectorSet4(quadVerts[2],  1, -1, 0, 1);
+       VectorSet4(quadVerts[3], -1, -1, 0, 1);
+
+       texCoords[0][0] = 0; texCoords[0][1] = 1;
+       texCoords[1][0] = 1; texCoords[1][1] = 1;
+       texCoords[2][0] = 1; texCoords[2][1] = 0;
+       texCoords[3][0] = 0; texCoords[3][1] = 0;
+
+       GL_State(GLS_DEPTHTEST_DISABLE);
+
+       GLSL_BindProgram(&tr.ssaoShader);
+
+       GL_BindToTMU(tr.hdrDepthImage, TB_COLORMAP);
+       GL_BindToTMU(tr.ssaoNoiseImage, TB_LEVELSMAP);
+
+       VectorSet4(viewInfo, backEnd.viewParms.zFar / r_znear->value, backEnd.viewParms.zFar,
+                       1.0f / width, 1.0f / height);
+       GLSL_SetUniformVec4(&tr.ssaoShader, UNIFORM_VIEWINFO, viewInfo);
+
+       RB_InstantQuad2(quadVerts, texCoords);
+
+       FBO_Bind(oldFbo);
 }
 
 /*

--- a/engine/code/renderergl2/tr_postprocess.h
+++ b/engine/code/renderergl2/tr_postprocess.h
@@ -29,5 +29,6 @@ void RB_ToneMap(FBO_t *hdrFbo, ivec4_t hdrBox, FBO_t *ldrFbo, ivec4_t ldrBox, in
 void RB_BokehBlur(FBO_t *src, ivec4_t srcBox, FBO_t *dst, ivec4_t dstBox, float blur);
 void RB_SunRays(FBO_t *srcFbo, ivec4_t srcBox, FBO_t *dstFbo, ivec4_t dstBox);
 void RB_GaussianBlur(FBO_t *srcFbo, FBO_t *dstFbo, float blur);
+void RB_SSAO(void);
 
 #endif


### PR DESCRIPTION
## Summary
- Add RB_SSAO to generate ambient occlusion from the depth buffer
- Blend SSAO output during tone mapping and supply noise/kernels in GLSL shader
- Support SSAO resources: noise texture, shader uniform bindings, and backend hookup

## Testing
- `make -C engine` *(fails: SDL_version.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68bface742e08324a46e0c8165b207bd