### PR TITLE
Log when SSAO resources are missing

### DIFF
--- a/engine/code/renderergl2/tr_postprocess.c
+++ b/engine/code/renderergl2/tr_postprocess.c
@@ -116,8 +116,10 @@ void RB_SSAO(void)
        int width, height;
        int samples;
 
-       if (!dst || r_ssao->integer <= 0)
-               return;
+	if (!dst || r_ssao->integer <= 0) {
+		ri.Printf(PRINT_DEVELOPER, "SSAO disabled (r_ssao=%d or FBO missing)\n", r_ssao->integer);
+		return;
+	}
 
        width = dst->width;
        height = dst->height;


### PR DESCRIPTION
## Summary
- log a developer message when SSAO is disabled due to missing FBO or r_ssao being zero

## Testing
- `make` *(fails: SDL_version.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68c099ed9d9883249fb09260b96da564