### PR TITLE
Persist and load best lap records

### DIFF
--- a/engine/code/game/g_local.h
+++ b/engine/code/game/g_local.h
@@ -407,7 +407,8 @@ struct gclient_s {
 	float		pmoveTime;
 
 	// race variables
-	int			finishRaceTime;
+	int                     startLapTime;
+        int                     finishRaceTime;
 
 	int			horn_sound_time;
 
@@ -416,6 +417,13 @@ struct gclient_s {
 
 	char		*areabits;
 };
+typedef struct {
+    char name[MAX_NETNAME];
+    int time;
+} lapRecord_t;
+
+#define MAX_BEST_LAP_TIMES 10
+
 
 
 //
@@ -525,6 +533,9 @@ typedef struct {
         float                   cpDist[MAX_GENTITIES];
         gentity_t       *checkpoints[MAX_GENTITIES];
         float                   trackLength;
+        lapRecord_t     bestLapTimes[MAX_BEST_LAP_TIMES];
+        int                     numBestLapTimes;
+
 
         int                     testModelID;
 // END
@@ -805,6 +816,10 @@ void CreateRallyStarter( void );
 void CalculatePlayerPositions( void );
 void Cmd_RacePositions_f( void );
 void Cmd_Times_f( gentity_t *ent );
+void G_LoadBestLapTimes( void );
+void G_SaveBestLapTimes( void );
+void G_UpdateBestLapTimes( const char *name, int time );
+
 gentity_t *SelectLastMarkerForSpawn( gentity_t *ent, vec3_t origin, vec3_t angles, qboolean isbot );
 gentity_t *SelectGridPositionSpawn( gentity_t *ent, vec3_t origin, vec3_t angles, qboolean isbot );
 

--- a/engine/code/game/g_main.c
+++ b/engine/code/game/g_main.c
@@ -653,6 +653,7 @@ void G_InitGame( int levelTime, int randomSeed, int restart ) {
 	}
 
 	G_RemapTeamShaders();
+        G_LoadBestLapTimes();
 
 	trap_SetConfigstring( CS_INTERMISSION, "" );
 
@@ -1437,6 +1438,10 @@ void LogExit( const char *string ) {
 	team_t team = TEAM_RED;
 #endif
 	G_LogPrintf( "Exit: %s\n", string );
+        if ( isRallyRace() ) {
+                G_SaveBestLapTimes();
+        }
+
 
 	level.intermissionQueued = level.time;
 

--- a/engine/code/game/g_rally_mapents.c
+++ b/engine/code/game/g_rally_mapents.c
@@ -149,7 +149,13 @@ void Touch_StartFinish (gentity_t *self, gentity_t *other, trace_t *trace ){
 	}
 
 	if (self->number == other->number){
-		other->client->lastCheckpointTime = level.time;
+                int lapTime;
+                if ( other->client->startLapTime ) {
+                        lapTime = level.time - other->client->startLapTime;
+                        G_UpdateBestLapTimes( other->client->pers.netname, lapTime );
+                }
+                other->client->startLapTime = level.time;
+                other->client->lastCheckpointTime = level.time;
 		other->currentLap++;
 		// increment lap
 		if ( other->currentLap > level.numberOfLaps && level.numberOfLaps ){
@@ -504,5 +510,92 @@ void SP_rally_weather_snow( gentity_t *ent ){
 	ent->s.legsAnim = 0;
 
 	trap_LinkEntity (ent);
+}
+
+
+void G_UpdateBestLapTimes( const char *name, int time ) {
+    int i, j;
+
+    for ( i = 0; i < level.numBestLapTimes && i < MAX_BEST_LAP_TIMES; i++ ) {
+        if ( time < level.bestLapTimes[i].time ) {
+            break;
+        }
+    }
+    if ( i >= MAX_BEST_LAP_TIMES ) {
+        return;
+    }
+    if ( level.numBestLapTimes < MAX_BEST_LAP_TIMES ) {
+        level.numBestLapTimes++;
+    }
+    for ( j = level.numBestLapTimes - 1; j > i; j-- ) {
+        level.bestLapTimes[j] = level.bestLapTimes[j-1];
+    }
+    Q_strncpyz( level.bestLapTimes[i].name, name, sizeof( level.bestLapTimes[i].name ) );
+    level.bestLapTimes[i].time = time;
+}
+
+void G_LoadBestLapTimes( void ) {
+    fileHandle_t f;
+    char filename[MAX_QPATH];
+    char mapname[MAX_QPATH];
+    int len;
+    char buffer[1024];
+    char *ptr;
+
+    trap_Cvar_VariableStringBuffer( "mapname", mapname, sizeof( mapname ) );
+    Com_sprintf( filename, sizeof( filename ), "records/%s.txt", mapname );
+    len = trap_FS_FOpenFile( filename, &f, FS_READ );
+    level.numBestLapTimes = 0;
+    if ( !f ) {
+        return;
+    }
+    if ( len >= sizeof( buffer ) ) {
+        len = sizeof( buffer ) - 1;
+    }
+    trap_FS_Read( buffer, len, f );
+    buffer[len] = '\0';
+    trap_FS_FCloseFile( f );
+
+    ptr = buffer;
+    while ( *ptr && level.numBestLapTimes < MAX_BEST_LAP_TIMES ) {
+        char *eol;
+        int time;
+        char name[MAX_NETNAME];
+
+        eol = strchr( ptr, '\n' );
+        if ( eol ) {
+            *eol = '\0';
+        }
+
+        if ( sscanf( ptr, "%i %31[^\n]", &time, name ) == 2 ) {
+            level.bestLapTimes[level.numBestLapTimes].time = time;
+            Q_strncpyz( level.bestLapTimes[level.numBestLapTimes].name, name, sizeof( level.bestLapTimes[0].name ) );
+            level.numBestLapTimes++;
+        }
+
+        if ( !eol ) {
+            break;
+        }
+        ptr = eol + 1;
+    }
+}
+
+void G_SaveBestLapTimes( void ) {
+    fileHandle_t f;
+    char filename[MAX_QPATH];
+    char mapname[MAX_QPATH];
+    int i;
+
+    trap_Cvar_VariableStringBuffer( "mapname", mapname, sizeof( mapname ) );
+    Com_sprintf( filename, sizeof( filename ), "records/%s.txt", mapname );
+    if ( trap_FS_FOpenFile( filename, &f, FS_WRITE ) < 0 ) {
+        return;
+    }
+    for ( i = 0; i < level.numBestLapTimes && i < MAX_BEST_LAP_TIMES; i++ ) {
+        char line[64 + MAX_NETNAME];
+        Com_sprintf( line, sizeof( line ), "%i %s\n", level.bestLapTimes[i].time, level.bestLapTimes[i].name );
+        trap_FS_Write( line, strlen( line ), f );
+    }
+    trap_FS_FCloseFile( f );
 }
 

--- a/engine/code/game/g_rally_racetools.c
+++ b/engine/code/game/g_rally_racetools.c
@@ -431,7 +431,13 @@ void RallyStarter_Think( gentity_t *ent ){
 	if ( level.time > ent->pain_debounce_time + 5000 ){
 		level.startRaceTime = level.time;
 
-		trap_SendServerCommand( -1, va("raceTime %i", level.startRaceTime) );
+                for ( i = 0; i < level.maxclients; i++ ) {
+                        player = &g_entities[i];
+                        if ( !player->inuse || !player->client ) continue;
+                        player->client->startLapTime = level.startRaceTime;
+                }
+
+                trap_SendServerCommand( -1, va("raceTime %i", level.startRaceTime) );
 		RaceCountdown("GO!", 0);
 
 		Rally_Sound( ent, EV_GLOBAL_SOUND, CHAN_ANNOUNCER, G_SoundIndex("sound/rally/race/go.wav") );


### PR DESCRIPTION
## Summary
- Track completed lap times and maintain top records server-side
- Load and save per-map lap time records for persistence
- Fix best lap time loading by replacing `strtok` usage with manual parsing

## Testing
- `make -C engine BUILD_SERVER=0 BUILD_CLIENT=0 BUILD_GAME_SO=1 BUILD_GAME_QVM=0`


------
https://chatgpt.com/codex/tasks/task_e_68c105edea208324a14f9f5856955228