### PR TITLE
Declare vehicle info before best lap update

### DIFF
--- a/engine/code/game/g_rally_mapents.c
+++ b/engine/code/game/g_rally_mapents.c
@@ -149,15 +149,16 @@ void Touch_StartFinish (gentity_t *self, gentity_t *other, trace_t *trace ){
 	}
 
 	if (self->number == other->number){
-                int lapTime;
-                if ( other->client->startLapTime ) {
-                        lapTime = level.time - other->client->startLapTime;
-                        char userinfo[MAX_INFO_STRING];
-                        trap_GetUserinfo(other->s.clientNum, userinfo, sizeof(userinfo));
-                        const char *vehicle = Info_ValueForKey(userinfo, "model");
-                        G_UpdateBestLapTimes( other->client->pers.netname, lapTime, vehicle );
-                }
-                other->client->startLapTime = level.time;
+               int lapTime;
+               if ( other->client->startLapTime ) {
+                       char userinfo[MAX_INFO_STRING];
+                       const char *vehicle;
+                       lapTime = level.time - other->client->startLapTime;
+                       trap_GetUserinfo(other->s.clientNum, userinfo, sizeof(userinfo));
+                       vehicle = Info_ValueForKey(userinfo, "model");
+                       G_UpdateBestLapTimes( other->client->pers.netname, lapTime, vehicle );
+               }
+               other->client->startLapTime = level.time;
                 other->client->lastCheckpointTime = level.time;
 		other->currentLap++;
 		// increment lap


### PR DESCRIPTION
## Summary
- Refactor Touch_StartFinish to declare `userinfo` and `vehicle` before use and update lap time logic

## Testing
- `cd engine && make BUILD_GAME_SO=1 BUILD_CLIENT=0 BUILD_SERVER=0`

------
https://chatgpt.com/codex/tasks/task_e_68c12a19f9c88324a1ce7b7fa758ae6c