### PR TITLE
Add lap record configstrings and client handling

### DIFF
--- a/engine/code/cgame/cg_local.h
+++ b/engine/code/cgame/cg_local.h
@@ -25,6 +25,11 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #include "../renderercommon/tr_types.h"
 #include "../game/bg_public.h"
 #include "cg_public.h"
+#define CS_LAPRECORDS_BASE      CS_PARTICLES
+#define MAX_BEST_LAP_TIMES      10
+#define MAX_TRACKS              1
+#define MAX_NETNAME              36
+
 
 
 // The entire cgame module is unloaded and reloaded on each level change,
@@ -408,6 +413,12 @@ typedef struct {
 	int				damageTaken;
 	int				position;
 } score_t;
+typedef struct {
+    char name[MAX_NETNAME];
+    int time;
+    char vehicle[MAX_QPATH];
+} lapRecord_t;
+
 
 // each client has an associated clientInfo_t
 // that contains media references necessary to present the
@@ -1307,6 +1318,7 @@ typedef struct {
 // Q3Rally Code Start
 	int				numRacers;
         float                   trackLength;
+        lapRecord_t             lapRecords[MAX_TRACKS][MAX_BEST_LAP_TIMES];
 // Q3Rally Code END
 
 } cgs_t;

--- a/engine/code/cgame/cg_servercmds.c
+++ b/engine/code/cgame/cg_servercmds.c
@@ -441,14 +441,26 @@ static void CG_ConfigStringModified( void ) {
 		}
 #endif
 	}
-	else if ( num == CS_SIGILSTATUS ) {
-		if( cgs.gametype == GT_DOMINATION ) {
-			CG_ParseSigilStatus();
-		}
-	}
-	else if ( num == CS_SHADERSTATE ) {
-		CG_ShaderStateChanged();
-	}
+       else if ( num == CS_SIGILSTATUS ) {
+               if( cgs.gametype == GT_DOMINATION ) {
+                       CG_ParseSigilStatus();
+               }
+       }
+       else if ( num >= CS_LAPRECORDS_BASE && num < CS_LAPRECORDS_BASE + MAX_TRACKS * MAX_BEST_LAP_TIMES ) {
+               int track = (num - CS_LAPRECORDS_BASE) / MAX_BEST_LAP_TIMES;
+               int index = (num - CS_LAPRECORDS_BASE) % MAX_BEST_LAP_TIMES;
+               lapRecord_t *rec = &cgs.lapRecords[track][index];
+               if ( *str ) {
+                       sscanf( str, "%i %31s %63s", &rec->time, rec->name, rec->vehicle );
+               } else {
+                       rec->time = 0;
+                       rec->name[0] = '\0';
+                       rec->vehicle[0] = '\0';
+               }
+       }
+       else if ( num == CS_SHADERSTATE ) {
+               CG_ShaderStateChanged();
+       }
 		
 }
 

--- a/engine/code/game/g_local.h
+++ b/engine/code/game/g_local.h
@@ -42,6 +42,9 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #define REWARD_SPRITE_TIME	2500
 
 #define	INTERMISSION_DELAY_TIME	1000
+#define CS_LAPRECORDS_BASE      CS_PARTICLES
+#define MAX_BEST_LAP_TIMES      10
+
 #define	SP_INTERMISSION_DELAY_TIME	5000
 
 // gentity->flags
@@ -422,10 +425,6 @@ typedef struct {
     int time;
     char vehicle[MAX_QPATH];
 } lapRecord_t;
-
-#define MAX_BEST_LAP_TIMES 10
-
-
 
 //
 // this structure is cleared as each map is entered

--- a/engine/code/game/g_rally_mapents.c
+++ b/engine/code/game/g_rally_mapents.c
@@ -537,6 +537,16 @@ void G_UpdateBestLapTimes( const char *name, int time, const char *vehicle ) {
     Q_strncpyz( level.bestLapTimes[i].name, name, sizeof( level.bestLapTimes[i].name ) );
     level.bestLapTimes[i].time = time;
     Q_strncpyz( level.bestLapTimes[i].vehicle, vehicle, sizeof( level.bestLapTimes[i].vehicle ) );
+
+    // broadcast updated records to clients
+    for ( i = 0; i < MAX_BEST_LAP_TIMES; i++ ) {
+        if ( i < level.numBestLapTimes ) {
+            trap_SetConfigstring( CS_LAPRECORDS_BASE + i, va( "%i %s %s", level.bestLapTimes[i].time,
+                    level.bestLapTimes[i].name, level.bestLapTimes[i].vehicle ) );
+        } else {
+            trap_SetConfigstring( CS_LAPRECORDS_BASE + i, "" );
+        }
+    }
 }
 
 void G_LoadBestLapTimes( void ) {
@@ -545,6 +555,7 @@ void G_LoadBestLapTimes( void ) {
     char mapname[MAX_QPATH];
     int len;
     char buffer[1024];
+    int i;
 
     char *ptr;
 
@@ -589,6 +600,16 @@ void G_LoadBestLapTimes( void ) {
         ptr = eol + 1;
 
     }
+
+    // send loaded records to clients
+    for ( i = 0; i < MAX_BEST_LAP_TIMES; i++ ) {
+        if ( i < level.numBestLapTimes ) {
+            trap_SetConfigstring( CS_LAPRECORDS_BASE + i, va( "%i %s %s", level.bestLapTimes[i].time,
+                    level.bestLapTimes[i].name, level.bestLapTimes[i].vehicle ) );
+        } else {
+            trap_SetConfigstring( CS_LAPRECORDS_BASE + i, "" );
+        }
+    }
 }
 
 void G_SaveBestLapTimes( void ) {
@@ -608,5 +629,15 @@ void G_SaveBestLapTimes( void ) {
         trap_FS_Write( line, strlen( line ), f );
     }
     trap_FS_FCloseFile( f );
+
+    // ensure clients have the latest records
+    for ( i = 0; i < MAX_BEST_LAP_TIMES; i++ ) {
+        if ( i < level.numBestLapTimes ) {
+            trap_SetConfigstring( CS_LAPRECORDS_BASE + i, va( "%i %s %s", level.bestLapTimes[i].time,
+                    level.bestLapTimes[i].name, level.bestLapTimes[i].vehicle ) );
+        } else {
+            trap_SetConfigstring( CS_LAPRECORDS_BASE + i, "" );
+        }
+    }
 }
 


### PR DESCRIPTION
## Summary
- define `CS_LAPRECORDS_BASE` and `MAX_BEST_LAP_TIMES`
- broadcast lap record updates via configstrings
- mirror lap record structs on the client and parse incoming configstrings

## Testing
- `cd engine && make BUILD_CLIENT=0 BUILD_SERVER=0 BUILD_RENDERER_OPENGL1=0 BUILD_RENDERER_OPENGL2=0 BUILD_GAME_SO=1 >/tmp/build.log && tail -n 20 /tmp/build.log`


------
https://chatgpt.com/codex/tasks/task_e_68c12e95dbf08324b2a8c71da207f994