### PR TITLE
Rename scoreboard draw routine to CG_DrawTabbedScoreboard

### DIFF
--- a/engine/code/cgame/cg_draw.c
+++ b/engine/code/cgame/cg_draw.c
@@ -2920,7 +2920,7 @@ static qboolean CG_DrawScoreboard( void ) {
 
 	return qtrue;
 #else
-	return CG_DrawOldScoreboard();
+        return CG_DrawTabbedScoreboard();
 #endif
 }
 

--- a/engine/code/cgame/cg_local.h
+++ b/engine/code/cgame/cg_local.h
@@ -1809,7 +1809,7 @@ void CG_DrawInformation( void );
 //
 // cg_scoreboard.c
 //
-qboolean CG_DrawOldScoreboard( void );
+qboolean CG_DrawTabbedScoreboard( void );
 // Q3Rally Code Start - removed
 // void CG_DrawTourneyScoreboard( void );
 // Q3Rally Code END

--- a/engine/code/cgame/cg_scoreboard.c
+++ b/engine/code/cgame/cg_scoreboard.c
@@ -1045,11 +1045,11 @@ static void CG_DrawScoreboardTabs(void) {
 
 /*
 =================
-CG_DrawScoreboard
+CG_DrawTabbedScoreboard
 Entry point that selects tab content
 =================
 */
-static qboolean CG_DrawScoreboard(void) {
+qboolean CG_DrawTabbedScoreboard(void) {
     CG_DrawScoreboardTabs();
 
     if (cg.activeScoreTab == SB_TAB_LAPRECORDS) {
@@ -1058,16 +1058,6 @@ static qboolean CG_DrawScoreboard(void) {
     }
 
     return CG_DrawModernScoreboard();
-}
-
-/*
-=================
-CG_DrawOldScoreboard
-Wrapper function to maintain compatibility
-=================
-*/
-qboolean CG_DrawOldScoreboard(void) {
-    return CG_DrawScoreboard();
 }
 
 /*


### PR DESCRIPTION
## Summary
- Rename CG_DrawScoreboard to CG_DrawTabbedScoreboard and remove legacy wrapper
- Update cg_draw wrapper and headers to use the new scoreboard function

## Testing
- `make` *(fails: SDL_version.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68c134c3563883248cb047b75bd9d04b