### PR TITLE
Remove unused scoreboard wrapper

### DIFF
--- a/engine/code/cgame/cg_consolecmds.c
+++ b/engine/code/cgame/cg_consolecmds.c
@@ -27,7 +27,6 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #include "cg_local.h"
 #ifdef MISSIONPACK
 #include "../ui/ui_shared.h"
-extern menuDef_t *menuScoreboard;
 #endif
 
 
@@ -117,7 +116,6 @@ static void CG_ScoresUp_f( void ) {
 }
 
 #ifdef MISSIONPACK
-extern menuDef_t *menuScoreboard;
 void Menu_Reset( void );			// FIXME: add to right include file
 
 static void CG_LoadHud_f( void) {
@@ -134,27 +132,9 @@ static void CG_LoadHud_f( void) {
 		hudSet = "ui/hud.txt";
 	}
 
-	CG_LoadMenus(hudSet);
-  menuScoreboard = NULL;
+        CG_LoadMenus(hudSet);
 }
 
-
-static void CG_scrollScoresDown_f( void) {
-	if (menuScoreboard && cg.scoreBoardShowing) {
-		Menu_ScrollFeeder(menuScoreboard, FEEDER_SCOREBOARD, qtrue);
-		Menu_ScrollFeeder(menuScoreboard, FEEDER_REDTEAM_LIST, qtrue);
-		Menu_ScrollFeeder(menuScoreboard, FEEDER_BLUETEAM_LIST, qtrue);
-	}
-}
-
-
-static void CG_scrollScoresUp_f( void) {
-	if (menuScoreboard && cg.scoreBoardShowing) {
-		Menu_ScrollFeeder(menuScoreboard, FEEDER_SCOREBOARD, qfalse);
-		Menu_ScrollFeeder(menuScoreboard, FEEDER_REDTEAM_LIST, qfalse);
-		Menu_ScrollFeeder(menuScoreboard, FEEDER_BLUETEAM_LIST, qfalse);
-	}
-}
 
 
 static void CG_spWin_f( void) {
@@ -704,8 +684,6 @@ static consoleCommand_t	commands[] = {
 	{ "tauntGauntlet", CG_TauntGauntlet_f },
 	{ "spWin", CG_spWin_f },
 	{ "spLose", CG_spLose_f },
-	{ "scoresDown", CG_scrollScoresDown_f },
-	{ "scoresUp", CG_scrollScoresUp_f },
 #endif
 // Q3Rally Code Start
 	{ "+hud", CG_HUDDown_f },

--- a/engine/code/cgame/cg_draw.c
+++ b/engine/code/cgame/cg_draw.c
@@ -31,7 +31,6 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 
 // used for scoreboard
 extern displayContextDef_t cgDC;
-menuDef_t *menuScoreboard = NULL;
 #else
 int drawTeamOverlayModificationCount = -1;
 #endif
@@ -2859,71 +2858,6 @@ static void CG_DrawTeamVote(void) {
 }
 
 
-static qboolean CG_DrawScoreboard( void ) {
-#ifdef MISSIONPACK
-	static qboolean firstTime = qtrue;
-
-    CG_SetScreenPlacement(PLACE_CENTER, PLACE_CENTER);
-
-	if (menuScoreboard) {
-		menuScoreboard->window.flags &= ~WINDOW_FORCED;
-	}
-	if (cg_paused.integer) {
-		cg.deferredPlayerLoading = 0;
-		firstTime = qtrue;
-		return qfalse;
-	}
-
-	// should never happen in Team Arena
-	if (cgs.gametype == GT_SINGLE_PLAYER && cg.predictedPlayerState.pm_type == PM_INTERMISSION ) {
-		cg.deferredPlayerLoading = 0;
-		firstTime = qtrue;
-		return qfalse;
-	}
-
-	// don't draw scoreboard during death while warmup up
-	if ( cg.warmup && !cg.showScores ) {
-		return qfalse;
-	}
-
-	if ( cg.showScores || cg.predictedPlayerState.pm_type == PM_DEAD || cg.predictedPlayerState.pm_type == PM_INTERMISSION ) {
-	} else {
-		if ( !CG_FadeColor( cg.scoreFadeTime, FADE_TIME ) ) {
-			// next time scoreboard comes up, don't print killer
-			cg.deferredPlayerLoading = 0;
-			cg.killerName[0] = 0;
-			firstTime = qtrue;
-			return qfalse;
-		}
-	}
-
-	if (menuScoreboard == NULL) {
-		if ( cgs.gametype >= GT_TEAM ) {
-			menuScoreboard = Menus_FindByName("teamscore_menu");
-		} else {
-			menuScoreboard = Menus_FindByName("score_menu");
-		}
-	}
-
-	if (menuScoreboard) {
-		if (firstTime) {
-			CG_SetScoreSelection(menuScoreboard);
-			firstTime = qfalse;
-		}
-		Menu_Paint(menuScoreboard, qtrue);
-	}
-
-	// load any models that have been deferred
-	if ( ++cg.deferredPlayerLoading > 10 ) {
-		CG_LoadDeferredPlayers();
-	}
-
-	return qtrue;
-#else
-        return CG_DrawTabbedScoreboard();
-#endif
-}
-
 /*
 ===================
 CG_DrawIntermission
@@ -2949,7 +2883,7 @@ static void CG_DrawIntermission( void ) {
 
 	if (!cg.scoreBoardShowing)
 // Q3Rally Code END
-		cg.scoreBoardShowing = CG_DrawScoreboard();
+               cg.scoreBoardShowing = CG_DrawTabbedScoreboard();
 }
 
 /*
@@ -3280,7 +3214,7 @@ static void CG_Draw2D(stereoFrame_t stereoFrame)
 
 	if (!cg.scoreBoardShowing)
 
-		cg.scoreBoardShowing = CG_DrawScoreboard();
+               cg.scoreBoardShowing = CG_DrawTabbedScoreboard();
 
 	if ( !cg.scoreBoardShowing) {
 		CG_DrawCenterString();


### PR DESCRIPTION
## Summary
- call the tabbed scoreboard directly instead of through a wrapper
- prune obsolete menu-based scoreboard hooks and commands

## Testing
- `make -C engine release BUILD_GAME_SO=0 BUILD_SERVER=0` *(fails: SDL_version.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68c135eec2388324acd16ab71d602ee5