### PR TITLE
Add track list support for lap record browsing

### DIFF
--- a/engine/code/cgame/cg_local.h
+++ b/engine/code/cgame/cg_local.h
@@ -27,7 +27,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #include "cg_public.h"
 #define CS_LAPRECORDS_BASE      CS_PARTICLES
 #define MAX_BEST_LAP_TIMES      10
-#define MAX_TRACKS              1
+#define MAX_TRACKS              8
 #define MAX_NETNAME              36
 
 
@@ -65,8 +65,11 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 
 #define	MAX_VERTS_ON_POLY	10
 // Q3Rally Code Start
-//#define	MAX_MARK_POLYS		256
-#define	MAX_MARK_POLYS		2048
+	int				numRacers;
+	float			trackLength;
+	int				numTracks;
+	char			trackNames[MAX_TRACKS][MAX_QPATH];
+	lapRecord_t		lapRecords[MAX_TRACKS][MAX_BEST_LAP_TIMES];
 // Q3Rally Code END
 
 #define STAT_MINUS			10	// num frame for '-' stats digit
@@ -714,6 +717,7 @@ typedef struct {
 	qboolean	showScores;
 	qboolean	scoreBoardShowing;
 		sbTab_t		activeScoreTab;
+	int			activeTrack;
 	int			scoreFadeTime;
 	char		killerName[MAX_NAME_LENGTH];
 	char			spectatorList[MAX_STRING_CHARS];		// list of names
@@ -1326,8 +1330,10 @@ typedef struct {
 	cgMedia_t		media;
 
 // Q3Rally Code Start
-	int				numRacers;
+        int                             numRacers;
         float                   trackLength;
+        int                             numTracks;
+        char                    trackNames[MAX_TRACKS][MAX_QPATH];
         lapRecord_t             lapRecords[MAX_TRACKS][MAX_BEST_LAP_TIMES];
 // Q3Rally Code END
 
@@ -1509,6 +1515,7 @@ void QDECL CG_DebugLogPrintf( const char *fmt, ... ) __attribute__ ((format (pri
 // Q3Rally Code END
 
 void CG_StartMusic( void );
+void CG_ParseTrackList( const char *list );
 
 void CG_UpdateCvars( void );
 

--- a/engine/code/cgame/cg_main.c
+++ b/engine/code/cgame/cg_main.c
@@ -23,6 +23,8 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 //
 // cg_main.c -- initialization and primary entry point for cgame
 #include "cg_local.h"
+#include "../client/keycodes.h"
+#include <string.h>
 
 #ifdef MISSIONPACK
 #include "../ui/ui_shared.h"
@@ -1456,6 +1458,43 @@ void CG_BuildSpectatorString(void) {
 }
 
 
+/*
+==================
+CG_ParseTrackList
+==================
+*/
+void CG_ParseTrackList( const char *list ) {
+    char buffer[MAX_STRING_CHARS];
+    char *token;
+    int id;
+    char name[MAX_QPATH];
+
+    cgs.numTracks = 0;
+
+    if ( !list || !list[0] ) {
+        return;
+    }
+
+    Q_strncpyz( buffer, list, sizeof( buffer ) );
+    token = strtok( buffer, "," );
+    while ( token && cgs.numTracks < MAX_TRACKS ) {
+        if ( sscanf( token, "%i:%63s", &id, name ) == 2 ) {
+            if ( id >= 0 && id < MAX_TRACKS ) {
+                Q_strncpyz( cgs.trackNames[id], name, sizeof( cgs.trackNames[0] ) );
+                if ( id >= cgs.numTracks ) {
+                    cgs.numTracks = id + 1;
+                }
+            }
+        }
+        token = strtok( NULL, "," );
+    }
+
+    if ( cg.activeTrack >= cgs.numTracks ) {
+        cg.activeTrack = 0;
+    }
+}
+
+
 /*																																			
 ===================
 CG_RegisterClients
@@ -2389,6 +2428,19 @@ void CG_EventHandling(int type) {
 
 
 void CG_KeyEvent(int key, qboolean down) {
+    if ( !down ) {
+        return;
+    }
+
+    if ( cg.showScores && cg.activeScoreTab == SB_TAB_LAPRECORDS && cgs.numTracks > 0 ) {
+        if ( key == K_RIGHTARROW || key == ']' ) {
+            cg.activeTrack = ( cg.activeTrack + 1 ) % cgs.numTracks;
+            return;
+        } else if ( key == K_LEFTARROW || key == '[' ) {
+            cg.activeTrack = ( cg.activeTrack + cgs.numTracks - 1 ) % cgs.numTracks;
+            return;
+        }
+    }
 }
 
 void CG_MouseEvent(int x, int y) {

--- a/engine/code/cgame/cg_scoreboard.c
+++ b/engine/code/cgame/cg_scoreboard.c
@@ -993,7 +993,10 @@ static void CG_DrawLapRecords(void) {
     CG_DrawBigStringColor(vehicleX, y, "Vehicle", color);
     y += BIGCHAR_HEIGHT + 4;
 
-    activeTrack = 0;
+    activeTrack = cg.activeTrack;
+    if ( activeTrack < 0 || activeTrack >= cgs.numTracks ) {
+        activeTrack = 0;
+    }
     for (i = 0; i < MAX_BEST_LAP_TIMES; i++) {
         rec = &cgs.lapRecords[activeTrack][i];
         if (rec->time <= 0) {
@@ -1041,6 +1044,30 @@ static void CG_DrawScoreboardTabs(void) {
     }
 
     CG_FillRect(0, y + BIGCHAR_HEIGHT + 4, SCREEN_WIDTH, 2, lineColor);
+
+    if ( cg.activeScoreTab == SB_TAB_LAPRECORDS && cgs.numTracks > 0 ) {
+        int j, w2, x2, y2, total2;
+
+        total2 = 0;
+        for ( j = 0; j < cgs.numTracks; j++ ) {
+            total2 += CG_DrawStrlen( cgs.trackNames[j] ) * BIGCHAR_WIDTH + spacing;
+        }
+        if ( total2 > 0 ) {
+            total2 -= spacing;
+        }
+
+        x2 = ( SCREEN_WIDTH - total2 ) / 2;
+        y2 = y + BIGCHAR_HEIGHT + 8;
+
+        for ( j = 0; j < cgs.numTracks; j++ ) {
+            w2 = CG_DrawStrlen( cgs.trackNames[j] ) * BIGCHAR_WIDTH;
+            CG_DrawBigStringColor( x2, y2, cgs.trackNames[j],
+                                   ( j == cg.activeTrack ) ? activeColor : inactiveColor );
+            x2 += w2 + spacing;
+        }
+
+        CG_FillRect( 0, y2 + BIGCHAR_HEIGHT + 4, SCREEN_WIDTH, 2, lineColor );
+    }
 }
 
 /*

--- a/engine/code/cgame/cg_servercmds.c
+++ b/engine/code/cgame/cg_servercmds.c
@@ -282,6 +282,7 @@ cgs.scores4 = atoi( CG_ConfigString( CS_SCORES4 ) );
 // END
 cgs.levelStartTime = atoi( CG_ConfigString( CS_LEVEL_START_TIME ) );
 cgs.trackLength = atof( CG_ConfigString( CS_TRACKLENGTH ) );
+CG_ParseTrackList( CG_ConfigString( CS_TRACKLIST ) );
 if( cgs.gametype == GT_CTF ) {
 		s = CG_ConfigString( CS_FLAGSTATUS );
 		cgs.redflag = s[0] - '0';
@@ -381,11 +382,13 @@ static void CG_ConfigStringModified( void ) {
 	} else if ( num == CS_SCORES4 ) {
 		cgs.scores4 = atoi( str );
 // END
-	} else if ( num == CS_TRACKLENGTH ) {
-		cgs.trackLength = atof( str );
-	} else if ( num == CS_LEVEL_START_TIME ) {
-		cgs.levelStartTime = atoi( str );
-	} else if ( num == CS_VOTE_TIME ) {
+       } else if ( num == CS_TRACKLENGTH ) {
+               cgs.trackLength = atof( str );
+       } else if ( num == CS_TRACKLIST ) {
+               CG_ParseTrackList( str );
+       } else if ( num == CS_LEVEL_START_TIME ) {
+               cgs.levelStartTime = atoi( str );
+       } else if ( num == CS_VOTE_TIME ) {
 		cgs.voteTime = atoi( str );
 		cgs.voteModified = qtrue;
 	} else if ( num == CS_VOTE_YES ) {

--- a/engine/code/game/bg_public.h
+++ b/engine/code/game/bg_public.h
@@ -105,9 +105,10 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #define CS_REFLECTION_IMAGE             29
 #define CS_SIGILSTATUS                  30
 #define CS_TRACKLENGTH                  31
+#define CS_TRACKLIST                    32
 // Q3Rally Code END
 
-#define CS_MODELS                               32
+#define CS_MODELS                               33
 #define CS_SOUNDS                               (CS_MODELS+MAX_MODELS)
 // STONELANCE
 //#define       CS_PLAYERS                              (CS_SOUNDS+MAX_SOUNDS)

--- a/engine/code/game/g_rally_mapents.c
+++ b/engine/code/game/g_rally_mapents.c
@@ -309,10 +309,13 @@ void Think_StartFinish( gentity_t *self ){
                 level.trackLength = level.cpDist[level.numCheckpoints-1] + VectorLength( delta );
         }
 
-        trap_SetConfigstring( CS_TRACKLENGTH, va( "%i", (int)( level.trackLength / CP_M_2_QU ) ) );
+       trap_SetConfigstring( CS_TRACKLENGTH, va( "%i", (int)( level.trackLength / CP_M_2_QU ) ) );
 
-        self->number = level.numCheckpoints;
-        self->s.weapon = self->number;
+       // send track list to clients
+       trap_SetConfigstring( CS_TRACKLIST, "0:Default" );
+
+       self->number = level.numCheckpoints;
+       self->s.weapon = self->number;
 }
 
 void Think_Finish( gentity_t *self ){


### PR DESCRIPTION
## Summary
- add CS_TRACKLIST configstring and transmit default track list at map start
- parse track list on the client and expose as cgs.trackNames
- render track selection row in Lap Records tab and allow switching via arrow keys or [ ]

## Testing
- `make release BUILD_GAME_SO=0 BUILD_SERVER=0` *(fails: SDL_version.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68c1373d81f08324b96ee96b115d2ec7