### PR TITLE
Remove duplicate track globals and restore mark poly limit

### DIFF
--- a/engine/code/cgame/cg_local.h
+++ b/engine/code/cgame/cg_local.h
@@ -64,13 +64,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #define	MAX_STEP_CHANGE		32
 
 #define	MAX_VERTS_ON_POLY	10
-// Q3Rally Code Start
-	int				numRacers;
-	float			trackLength;
-	int				numTracks;
-	char			trackNames[MAX_TRACKS][MAX_QPATH];
-	lapRecord_t		lapRecords[MAX_TRACKS][MAX_BEST_LAP_TIMES];
-// Q3Rally Code END
+#define MAX_MARK_POLYS          2048
 
 #define STAT_MINUS			10	// num frame for '-' stats digit
 


### PR DESCRIPTION
## Summary
- remove redundant track-related globals from `cg_local.h`
- restore `MAX_MARK_POLYS` definition

## Testing
- `make BUILD_CLIENT=0` *(fails: cpp could not find <string.h>)*
- `gcc -DARCH_STRING="x86_64" -DSTANDALONE -DPRODUCT_VERSION="1" -Icode -Icode/cgame -Icode/game -Icode/qcommon -Icode/renderercommon -c code/cgame/cg_main.c -o /tmp/cg_main.o`

------
https://chatgpt.com/codex/tasks/task_e_68c1b0a03a608324afe37724fce6ebbf