### PR TITLE
Provide minimal C headers for q3lcc

### DIFF
--- a/engine/code/tools/lcc/include/ctype.h
+++ b/engine/code/tools/lcc/include/ctype.h
@@ -1,0 +1,11 @@
+#ifndef LCC_CTYPE_H
+#define LCC_CTYPE_H
+
+int isalnum(int c);
+int isalpha(int c);
+int isdigit(int c);
+int isspace(int c);
+int tolower(int c);
+int toupper(int c);
+
+#endif /* LCC_CTYPE_H */

--- a/engine/code/tools/lcc/include/stddef.h
+++ b/engine/code/tools/lcc/include/stddef.h
@@ -1,0 +1,7 @@
+#ifndef LCC_STDDEF_H
+#define LCC_STDDEF_H
+
+typedef unsigned int size_t;
+#define NULL ((void *)0)
+
+#endif /* LCC_STDDEF_H */

--- a/engine/code/tools/lcc/include/stdlib.h
+++ b/engine/code/tools/lcc/include/stdlib.h
@@ -1,0 +1,12 @@
+#ifndef LCC_STDLIB_H
+#define LCC_STDLIB_H
+
+#include "stddef.h"
+
+void *malloc(size_t size);
+void free(void *ptr);
+void exit(int status);
+int atoi(const char *nptr);
+long strtol(const char *nptr, char **endptr, int base);
+
+#endif /* LCC_STDLIB_H */

--- a/engine/code/tools/lcc/include/string.h
+++ b/engine/code/tools/lcc/include/string.h
@@ -1,0 +1,22 @@
+#ifndef LCC_STRING_H
+#define LCC_STRING_H
+
+#include "stddef.h"
+
+void *memcpy(void *dest, const void *src, size_t n);
+void *memmove(void *dest, const void *src, size_t n);
+void *memset(void *s, int c, size_t n);
+int memcmp(const void *s1, const void *s2, size_t n);
+
+char *strcpy(char *dest, const char *src);
+char *strncpy(char *dest, const char *src, size_t n);
+char *strcat(char *dest, const char *src);
+char *strncat(char *dest, const char *src, size_t n);
+size_t strlen(const char *s);
+int strcmp(const char *s1, const char *s2);
+int strncmp(const char *s1, const char *s2, size_t n);
+char *strchr(const char *s, int c);
+char *strrchr(const char *s, int c);
+char *strdup(const char *s);
+
+#endif /* LCC_STRING_H */


### PR DESCRIPTION
## Summary
- add stripped-down string.h for the lcc toolchain
- supply minimal stddef.h, stdlib.h, and ctype.h in the lcc include directory

## Testing
- `LCCDIR=engine/build/release-linux-x86_64/tools engine/build/release-linux-x86_64/tools/q3lcc -v -S test.c`
- `ls` to confirm `test.asm` output

------
https://chatgpt.com/codex/tasks/task_e_68c1f7cd635083248776db27d93d94ee