### PR TITLE
Track lap start times for clients

### DIFF
--- a/engine/code/game/g_client.c
+++ b/engine/code/game/g_client.c
@@ -1254,6 +1254,7 @@ void ClientBegin( int clientNum ) {
 	client->buttons = 0;
 	client->oldbuttons = 0;
 	client->lastCheckpointTime = 0;
+	client->startLapTime = level.startRaceTime;
 // END
 
 	if ( ent->r.linked ) {

--- a/engine/code/game/g_local.h
+++ b/engine/code/game/g_local.h
@@ -412,6 +412,7 @@ struct gclient_s {
 	int			horn_sound_time;
 
 	int			lastCheckpointTime;
+	int                     startLapTime;
 // END
 
 	char		*areabits;

--- a/engine/code/game/g_rally_racetools.c
+++ b/engine/code/game/g_rally_racetools.c
@@ -374,6 +374,9 @@ void RallyStarter_Think( gentity_t *ent ){
 		if (t == NULL){
 			// start race right away
 			level.startRaceTime = level.time;
+	for (i = 0; i < level.maxclients; i++) {
+		level.clients[i].startLapTime = level.startRaceTime;
+	}
 			trap_SendServerCommand( -1, va("raceTime %i", level.startRaceTime) );
 			CenterPrint_All("GO..");
 
@@ -431,6 +434,9 @@ void RallyStarter_Think( gentity_t *ent ){
 	if ( level.time > ent->pain_debounce_time + 5000 ){
 		level.startRaceTime = level.time;
 
+	for (i = 0; i < level.maxclients; i++) {
+		level.clients[i].startLapTime = level.startRaceTime;
+	}
 		trap_SendServerCommand( -1, va("raceTime %i", level.startRaceTime) );
 		RaceCountdown("GO!", 0);
 


### PR DESCRIPTION
## Summary
- add `startLapTime` field to track when a client begins a lap
- initialize lap start time on client connect and when a race begins

## Testing
- `make -C engine/code/game/tests run`
- `make -C engine BUILD_GAME_SO=1` *(fails: SDL_version.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68c326b875148324946183b9dfe195c4