### PR TITLE
Track lap start times for races

### DIFF
--- a/engine/code/game/g_client.c
+++ b/engine/code/game/g_client.c
@@ -1254,6 +1254,8 @@ void ClientBegin( int clientNum ) {
 	client->buttons = 0;
 	client->oldbuttons = 0;
 	client->lastCheckpointTime = 0;
+	client->startLapTime = 0;
+	client->bestLapTime = 0;
 // END
 
 	if ( ent->r.linked ) {

--- a/engine/code/game/g_local.h
+++ b/engine/code/game/g_local.h
@@ -412,6 +412,8 @@ struct gclient_s {
 	int			horn_sound_time;
 
 	int			lastCheckpointTime;
+	int			startLapTime;
+	int			bestLapTime;
 // END
 
 	char		*areabits;

--- a/engine/code/game/g_rally_mapents.c
+++ b/engine/code/game/g_rally_mapents.c
@@ -46,6 +46,7 @@ if ( g_developer.integer )
 G_Printf( "Client %i touched the start line.\n", other->s.clientNum );
 
 other->client->lastCheckpointTime = level.time;
+other->client->startLapTime = level.time;
 other->number = 1;
 other->client->ps.stats[STAT_NEXT_CHECKPOINT] = other->number;
 other->client->ps.stats[STAT_FRAC_TO_NEXT_CHECKPOINT] = FLOAT2SHORT(0.1f);


### PR DESCRIPTION
## Summary
- add `startLapTime` and `bestLapTime` fields to `gclient_s` for lap timing
- reset lap timing fields on spawn and initialize `startLapTime` when touching the start line

## Testing
- `make -C engine/code/game/tests run`
- `make -C engine BUILD_BASEGAME=1 BUILD_GAME_SO=1` *(fails: SDL_version.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68c335d04a2083249e76edfe33c8f648