### PR TITLE
Record and save best lap times

### DIFF
--- a/engine/code/game/g_rally_mapents.c
+++ b/engine/code/game/g_rally_mapents.c
@@ -167,6 +167,15 @@ if ( self->number != other->number ) {
 return;
 }
 
+{
+int lapTime = level.time - other->client->startLapTime;
+if ( other->client->bestLapTime == 0 || lapTime < other->client->bestLapTime ) {
+other->client->bestLapTime = lapTime;
+G_SaveLapRecord( other, lapTime );
+}
+other->client->startLapTime = level.time;
+}
+
 other->client->lastCheckpointTime = level.time;
 other->client->finishRaceTime = level.time;
 other->s.weapon = WP_NONE;
@@ -242,11 +251,19 @@ void Touch_StartFinish (gentity_t *self, gentity_t *other, trace_t *trace ){
 		return;
 	}
 
-	if (self->number == other->number){
-		other->client->lastCheckpointTime = level.time;
-		other->currentLap++;
-		// increment lap
-		if ( other->currentLap > level.numberOfLaps && level.numberOfLaps ){
+        if (self->number == other->number){
+                other->client->lastCheckpointTime = level.time;
+                other->currentLap++;
+                {
+                        int lapTime = level.time - other->client->startLapTime;
+                        if ( other->client->bestLapTime == 0 || lapTime < other->client->bestLapTime ) {
+                                other->client->bestLapTime = lapTime;
+                                G_SaveLapRecord( other, lapTime );
+                        }
+                        other->client->startLapTime = level.time;
+                }
+                // increment lap
+                if ( other->currentLap > level.numberOfLaps && level.numberOfLaps ){
 			other->client->finishRaceTime = level.time;
 			other->s.weapon = WP_NONE;
 			other->takedamage = qfalse;


### PR DESCRIPTION
## Summary
- compute lap time when crossing start/finish and save as best record
- reset lap start time for next lap

## Testing
- `make -C engine release BUILD_GAME_SO=0 BUILD_SERVER=0` *(fails: SDL_version.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68c33a273a50832498fa62e382ff56d0