### PR TITLE
Track client max speed for races

### DIFF
--- a/engine/code/game/g_active.c
+++ b/engine/code/game/g_active.c
@@ -986,6 +986,7 @@ void ClientThink_real( gentity_t *ent ) {
 	int			start;
 	vec3_t		oldAngles;
 	int			oldTime;
+	float			speed;
 // END
 
 	client = ent->client;
@@ -1352,6 +1353,11 @@ void ClientThink_real( gentity_t *ent ) {
 #else
 		Pmove (&pm);
 #endif
+
+	speed = VectorLength( ent->client->ps.velocity );
+	if ( speed > ent->client->maxSpeed ) {
+		ent->client->maxSpeed = speed;
+	}
 
 // STONELANCE
 	AnglesSubtract( client->ps.viewangles, oldAngles, ent->s.apos.trDelta );

--- a/engine/code/game/g_client.c
+++ b/engine/code/game/g_client.c
@@ -1256,6 +1256,7 @@ void ClientBegin( int clientNum ) {
 	client->lastCheckpointTime = 0;
 	client->startLapTime = 0;
 	client->bestLapTime = 0;
+	client->maxSpeed = 0;
 // END
 
 	if ( ent->r.linked ) {

--- a/engine/code/game/g_local.h
+++ b/engine/code/game/g_local.h
@@ -414,6 +414,7 @@ struct gclient_s {
 	int			lastCheckpointTime;
 	int			startLapTime;
 	int			bestLapTime;
+	int			maxSpeed;
 // END
 
 	char		*areabits;

--- a/engine/code/game/g_rally_mapents.c
+++ b/engine/code/game/g_rally_mapents.c
@@ -140,6 +140,7 @@ G_Printf( "Client %i touched the start line.\n", other->s.clientNum );
 
 other->client->lastCheckpointTime = level.time;
 other->client->startLapTime = level.time;
+other->client->maxSpeed = 0;
 other->number = 1;
 other->client->ps.stats[STAT_NEXT_CHECKPOINT] = other->number;
 other->client->ps.stats[STAT_FRAC_TO_NEXT_CHECKPOINT] = FLOAT2SHORT(0.1f);
@@ -261,6 +262,7 @@ void Touch_StartFinish (gentity_t *self, gentity_t *other, trace_t *trace ){
                                 G_SaveLapRecord( other, lapTime );
                         }
                         other->client->startLapTime = level.time;
+                        other->client->maxSpeed = 0;
                 }
                 // increment lap
                 if ( other->currentLap > level.numberOfLaps && level.numberOfLaps ){


### PR DESCRIPTION
## Summary
- store max speed per race client
- reset max speed at new lap and start/finish touches
- update max speed after each Pmove

## Testing
- `make -C engine` *(fails: interrupted due to long build)*

------
https://chatgpt.com/codex/tasks/task_e_68c34056e3a08324ac4dc622d215388e