### PR TITLE
Add leaderboards screen parsing record files

### DIFF
--- a/baseq3r/ui/leaderboards.menu
+++ b/baseq3r/ui/leaderboards.menu
@@ -1,0 +1,33 @@
+menuDef {
+    name            "leaderboards"
+    fullScreen      1
+    onOpen          { Leaderboards_MenuInit }
+    visible         1
+    items {
+        itemDef {
+            name        "list"
+            type        ITEM_TYPE_LISTBOX
+            rect        30 60 580 360
+            elementheight 16
+            visible     1
+            columns     5 0 140 32 140 80 16 220 120 32 340 120 16 460 80 16
+            forecolor   1 1 1 1
+            backcolor   0 0 0 0.25
+            border      1
+            bordercolor 1 1 1 0.25
+            feeder      FEEDER_LEADERBOARDS
+        }
+        itemDef {
+            name        "back"
+            type        ITEM_TYPE_BUTTON
+            rect        260 440 120 30
+            text        "BACK"
+            action      { close }
+        }
+        itemDef { name "colmap" type ITEM_TYPE_TEXT rect 30 44 140 16 text "MAP" textscale 0.35 }
+        itemDef { name "coltime" type ITEM_TYPE_TEXT rect 170 44 80 16 text "TIME" textscale 0.35 }
+        itemDef { name "colname" type ITEM_TYPE_TEXT rect 250 44 120 16 text "NAME" textscale 0.35 }
+        itemDef { name "colveh" type ITEM_TYPE_TEXT rect 370 44 120 16 text "VEH" textscale 0.35 }
+        itemDef { name "colspeed" type ITEM_TYPE_TEXT rect 490 44 80 16 text "SPEED" textscale 0.35 }
+    }
+}

--- a/baseq3r/ui/main.menu
+++ b/baseq3r/ui/main.menu
@@ -1,0 +1,14 @@
+menuDef {
+    name            "main"
+    fullScreen      1
+    visible         1
+    items {
+        itemDef {
+            name        "leaderboards"
+            type        ITEM_TYPE_BUTTON
+            rect        200 200 240 30
+            text        "LEADERBOARDS"
+            action      { open leaderboards }
+        }
+    }
+}

--- a/baseq3r/ui/menus.txt
+++ b/baseq3r/ui/menus.txt
@@ -1,0 +1,40 @@
+// menu defs
+//
+{
+        loadMenu { "ui/main.menu" }
+        loadMenu { "ui/joinserver.menu" }
+        loadMenu { "ui/filter.menu" }
+        loadMenu { "ui/punkbuster.menu" }
+        loadMenu { "ui/player.menu" }
+        loadMenu { "ui/setup.menu" }
+        loadMenu { "ui/fight.menu" }
+        loadMenu { "ui/skirmish.menu" }
+        loadMenu { "ui/createserver.menu" }
+        loadMenu { "ui/controls.menu" }
+        loadMenu { "ui/cdkey.menu" }
+        loadMenu { "ui/system.menu" }
+        loadMenu { "ui/options.menu" }
+        loadMenu { "ui/help.menu" }
+        loadMenu { "ui/ordershelp.menu" }
+        loadMenu { "ui/mod.menu" }
+        loadMenu { "ui/demo.menu" }
+        loadMenu { "ui/cinematicmenu.menu" }
+        loadMenu { "ui/credit.menu" }
+        loadMenu { "ui/demo_quit.menu" }
+        loadMenu { "ui/connect.menu" }
+        loadMenu { "ui/powerup.menu" }
+        loadMenu { "ui/password.menu" }
+        loadMenu { "ui/quake3.menu" }
+        loadMenu { "ui/quit.menu" }
+        loadMenu { "ui/vid_restart.menu" }
+        loadMenu { "ui/default.menu" }
+        loadMenu { "ui/addfilter.menu" }
+        loadMenu { "ui/error.menu" }
+        loadMenu { "ui/serverinfo.menu" }
+        loadMenu { "ui/findplayer.menu" }
+        loadMenu { "ui/endofgame.menu" }
+        loadMenu { "ui/quitcredit.menu" }
+        loadMenu { "ui/resetscore.menu" }
+        loadMenu { "ui/createfavorite.menu" }
+        loadMenu { "ui/leaderboards.menu" }
+}

--- a/engine/Makefile
+++ b/engine/Makefile
@@ -2933,6 +2933,7 @@ Q3UIOBJ_ = \
   $(B)/$(BASEGAME)/ui/ui_rally_servers.o \
   $(B)/$(BASEGAME)/ui/ui_rally_startserver.o \
   $(B)/$(BASEGAME)/ui/ui_rally_tools.o \
+  $(B)/$(BASEGAME)/ui/ui_leaderboards.o \
   $(B)/$(BASEGAME)/ui/ui_removebots.o \
   $(B)/$(BASEGAME)/ui/ui_saveconfig.o \
   $(B)/$(BASEGAME)/ui/ui_serverinfo.o \

--- a/engine/code/ui/ui_leaderboards.c
+++ b/engine/code/ui/ui_leaderboards.c
@@ -1,0 +1,91 @@
+#include "ui_local.h"
+
+#define MAX_LEADERBOARD_MAPS 128
+
+static leaderboardEntry_t leaderboardList[MAX_LEADERBOARD_MAPS];
+static int leaderboardCount;
+
+static void UI_LoadLeaderboards(void) {
+    char filelist[4096];
+    int numFiles;
+    char *fileptr;
+    int i;
+
+    leaderboardCount = 0;
+    numFiles = trap_FS_GetFileList("Records/", ".rec", filelist, sizeof(filelist));
+    fileptr = filelist;
+    for (i = 0; i < numFiles && leaderboardCount < MAX_LEADERBOARD_MAPS; i++) {
+        int len = strlen(fileptr);
+        if (len < 4) {
+            fileptr += len + 1;
+            continue;
+        }
+
+        leaderboardEntry_t *entry = &leaderboardList[leaderboardCount];
+        Q_strncpyz(entry->map, fileptr, sizeof(entry->map));
+        if (len > 4)
+            entry->map[len - 4] = '\0';
+
+        {
+            fileHandle_t f;
+            char path[MAX_QPATH];
+            Com_sprintf(path, sizeof(path), "Records/%s", fileptr);
+            if (trap_FS_FOpenFile(path, &f, FS_READ) >= 0) {
+                char buffer[1024];
+                int size = trap_FS_Read(buffer, sizeof(buffer) - 1, f);
+                trap_FS_FCloseFile(f);
+                buffer[size] = '\0';
+                // parse first line
+                entry->hasSpeed = qfalse;
+                if (size > 0) {
+                    char name[64], vehicle[64];
+                    float time, speed;
+                    int count = sscanf(buffer, "\"%63[^\"]\" %f %63s %f", name, &time, vehicle, &speed);
+                    Q_strncpyz(entry->name, name, sizeof(entry->name));
+                    entry->time = time;
+                    Q_strncpyz(entry->vehicle, vehicle, sizeof(entry->vehicle));
+                    if (count == 4) {
+                        entry->speed = speed;
+                        entry->hasSpeed = qtrue;
+                    }
+                }
+            }
+        }
+        leaderboardCount++;
+        fileptr += len + 1;
+    }
+}
+
+void UI_Leaderboards_MenuInit(void) {
+    UI_LoadLeaderboards();
+    uiInfo.leaderboardCount = leaderboardCount;
+    for (int i = 0; i < leaderboardCount; i++) {
+        uiInfo.leaderboards[i] = leaderboardList[i];
+    }
+}
+
+int UI_Leaderboards_FeederCount(void) {
+    return uiInfo.leaderboardCount;
+}
+
+const char *UI_Leaderboards_FeederItemText(int index, int column) {
+    if (index < 0 || index >= uiInfo.leaderboardCount)
+        return "";
+    leaderboardEntry_t *e = &uiInfo.leaderboards[index];
+    switch (column) {
+    case 0:
+        return e->map;
+    case 1:
+        return va("%0.3f", e->time);
+    case 2:
+        return e->name;
+    case 3:
+        return e->vehicle;
+    case 4:
+        if (e->hasSpeed) {
+            return va("%0.1f", e->speed);
+        }
+        return "";
+    }
+    return "";
+}

--- a/engine/code/ui/ui_local.h
+++ b/engine/code/ui/ui_local.h
@@ -638,6 +638,7 @@ typedef struct {
 #define MAPS_PER_TIER 3
 #define MAX_TIERS 16
 #define MAX_MODS 64
+#define MAX_LEADERBOARD_ENTRIES 128
 #define MAX_MOVIES 256
 #define MAX_PLAYERMODELS 256
 
@@ -755,9 +756,18 @@ typedef struct {
 } serverStatusInfo_t;
 
 typedef struct {
-	const char *modName;
-	const char *modDescr;
+        const char *modName;
+        const char *modDescr;
 } modInfo_t;
+
+typedef struct {
+        char    map[MAX_QPATH];
+        char    name[64];
+        char    vehicle[64];
+        float   time;
+        float   speed;
+        qboolean hasSpeed;
+} leaderboardEntry_t;
 
 
 typedef struct {
@@ -844,6 +854,8 @@ typedef struct {
 	qhandle_t	q3HeadIcons[MAX_PLAYERMODELS];
 	int				q3SelectedHead;
 
+        leaderboardEntry_t leaderboards[MAX_LEADERBOARD_ENTRIES];
+        int leaderboardCount;
 	int effectsColor;
 
 	qboolean inGameLoad;
@@ -851,6 +863,10 @@ typedef struct {
 }	uiInfo_t;
 
 extern uiInfo_t uiInfo;
+
+void UI_Leaderboards_MenuInit(void);
+int UI_Leaderboards_FeederCount(void);
+const char *UI_Leaderboards_FeederItemText(int index, int column);
 
 
 extern void			UI_Init( void );

--- a/engine/code/ui/ui_main.c
+++ b/engine/code/ui/ui_main.c
@@ -3261,12 +3261,14 @@ static void UI_RunMenuScript(char **args) {
 			UI_LoadDemos();
 		} else if (Q_stricmp(name, "LoadMovies") == 0) {
 			UI_LoadMovies();
-		} else if (Q_stricmp(name, "LoadMods") == 0) {
-			UI_LoadMods();
-		} else if (Q_stricmp(name, "playMovie") == 0) {
-			if (uiInfo.previewMovie >= 0) {
-			  trap_CIN_StopCinematic(uiInfo.previewMovie);
-			}
+               } else if (Q_stricmp(name, "LoadMods") == 0) {
+                       UI_LoadMods();
+               } else if (Q_stricmp(name, "Leaderboards_MenuInit") == 0) {
+                       UI_Leaderboards_MenuInit();
+               } else if (Q_stricmp(name, "playMovie") == 0) {
+                       if (uiInfo.previewMovie >= 0) {
+                          trap_CIN_StopCinematic(uiInfo.previewMovie);
+                       }
 			trap_Cmd_ExecuteText( EXEC_APPEND, va("cinematic %s.roq 2\n", uiInfo.movieList[uiInfo.movieIndex]));
 		} else if (Q_stricmp(name, "RunMod") == 0) {
 			trap_Cvar_Set( "fs_game", uiInfo.modList[uiInfo.modIndex].modName);
@@ -4212,10 +4214,12 @@ static int UI_FeederCount(float feederID) {
 		return uiInfo.myTeamCount;
 	} else if (feederID == FEEDER_MODS) {
 		return uiInfo.modCount;
-	} else if (feederID == FEEDER_DEMOS) {
-		return uiInfo.demoCount;
-	}
-	return 0;
+       } else if (feederID == FEEDER_DEMOS) {
+               return uiInfo.demoCount;
+       } else if (feederID == FEEDER_LEADERBOARDS) {
+               return UI_Leaderboards_FeederCount();
+       }
+       return 0;
 }
 
 static const char *UI_SelectedMap(int index, int *actual) {
@@ -4382,12 +4386,14 @@ static const char *UI_FeederItemText(float feederID, int index, int column, qhan
 		if (index >= 0 && index < uiInfo.movieCount) {
 			return uiInfo.movieList[index];
 		}
-	} else if (feederID == FEEDER_DEMOS) {
-		if (index >= 0 && index < uiInfo.demoCount) {
-			return uiInfo.demoList[index];
-		}
-	}
-	return "";
+       } else if (feederID == FEEDER_DEMOS) {
+               if (index >= 0 && index < uiInfo.demoCount) {
+                       return uiInfo.demoList[index];
+               }
+       } else if (feederID == FEEDER_LEADERBOARDS) {
+               return UI_Leaderboards_FeederItemText(index, column);
+       }
+       return "";
 }
 
 

--- a/engine/ui/menudef.h
+++ b/engine/ui/menudef.h
@@ -87,6 +87,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #define FEEDER_SERVERSTATUS					0x0d			// server status
 #define FEEDER_FINDPLAYER					0x0e			// find player
 #define FEEDER_CINEMATICS					0x0f			// cinematics
+#define FEEDER_LEADERBOARDS 0x10                    // map records
 
 // display flags
 #define CG_SHOW_BLUE_TEAM_HAS_REDFLAG     0x00000001


### PR DESCRIPTION
## Summary
- add leaderboards menu and register it so players can view map records
- hook new leaderboard feeder and parsing for `.rec` files
- expose Leaderboards button on the main menu

## Testing
- `make -C engine` *(fails: interrupted after partial build)*

------
https://chatgpt.com/codex/tasks/task_e_68c3a5601a988324bcc91ba167f88753