### PR TITLE
Move leaderboard UI into q3_ui and update references

### DIFF
--- a/engine/code/q3_ui/ui_leaderboards.c
+++ b/engine/code/q3_ui/ui_leaderboards.c
@@ -30,9 +30,13 @@ static void UI_LoadLeaderboards(void) {
             fileHandle_t f;
             char path[MAX_QPATH];
             Com_sprintf(path, sizeof(path), "Records/%s", fileptr);
-            if (trap_FS_FOpenFile(path, &f, FS_READ) >= 0) {
+            int size = trap_FS_FOpenFile(path, &f, FS_READ);
+            if (size >= 0) {
                 char buffer[1024];
-                int size = trap_FS_Read(buffer, sizeof(buffer) - 1, f);
+                if (size > sizeof(buffer) - 1) {
+                    size = sizeof(buffer) - 1;
+                }
+                trap_FS_Read(buffer, size, f);
                 trap_FS_FCloseFile(f);
                 buffer[size] = '\0';
                 // parse first line

--- a/engine/code/q3_ui/ui_local.h
+++ b/engine/code/q3_ui/ui_local.h
@@ -48,6 +48,7 @@ typedef void (*voidfunc_f)(void);
 #define	DEFAULT_RIM				"svt_cobra"
 #define	DEFAULT_PLATE			"plate_usa"
 #define	DEFAULT_PLATE_SKIN		"default"
+#define MAX_LEADERBOARD_ENTRIES 128
 // END
 
 // STONELANCE
@@ -696,6 +697,27 @@ typedef struct {
 	char			plateName[MAX_QPATH];
 // END
 } playerInfo_t;
+
+typedef struct {
+        char    map[MAX_QPATH];
+        char    name[64];
+        char    vehicle[64];
+        float   time;
+        float   speed;
+        qboolean hasSpeed;
+} leaderboardEntry_t;
+
+typedef struct {
+        displayContextDef_t uiDC;
+        leaderboardEntry_t leaderboards[MAX_LEADERBOARD_ENTRIES];
+        int leaderboardCount;
+} uiInfo_t;
+
+extern uiInfo_t uiInfo;
+
+void UI_Leaderboards_MenuInit(void);
+int UI_Leaderboards_FeederCount(void);
+const char *UI_Leaderboards_FeederItemText(int index, int column);
 
 void UI_DrawPlayer( float x, float y, float w, float h, playerInfo_t *pi, int time );
 // STONELANCE

--- a/engine/code/q3_ui/ui_main.c
+++ b/engine/code/q3_ui/ui_main.c
@@ -32,6 +32,8 @@ USER INTERFACE MAIN
 
 #include "ui_local.h"
 
+uiInfo_t uiInfo;
+
 
 /*
 ================


### PR DESCRIPTION
## Summary
- relocate `ui_leaderboards.c` from the ui module to q3_ui
- expose leaderboard data structures and functions in q3_ui headers
- initialize new `uiInfo` context for q3_ui leaderboard support

## Testing
- `make release BUILD_CLIENT=0 BUILD_SERVER=0 BUILD_GAME_SO=1 BUILD_GAME_QVM=0 BUILD_RENDERER_OPENGL1=0 BUILD_RENDERER_OPENGL2=0 BUILD_AUTOUPDATER=0`


------
https://chatgpt.com/codex/tasks/task_e_68c484cb3a248324bd8c22db1d7314ef