### PR TITLE
Link ui_shared in UI build for leaderboards

### DIFF
--- a/engine/Makefile
+++ b/engine/Makefile
@@ -2948,6 +2948,7 @@ Q3UIOBJ_ = \
   $(B)/$(BASEGAME)/ui/ui_teamorders.o \
   $(B)/$(BASEGAME)/ui/ui_video.o \
   $(B)/$(BASEGAME)/ui/ui_rally_bots.o \
+  $(B)/$(BASEGAME)/ui/ui_shared.o \
   \
   $(B)/$(BASEGAME)/qcommon/q_math.o \
   $(B)/$(BASEGAME)/qcommon/q_shared.o


### PR DESCRIPTION
## Summary
- Link `ui_shared.o` into the UI build so the leaderboards menu can use shared UI functionality

## Testing
- `make` *(fails: SDL_version.h missing)*

------
https://chatgpt.com/codex/tasks/task_e_68c494c114888324bc3588804404f96d