### PR TITLE
Add build rule for base ui_shared.c

### DIFF
--- a/engine/Makefile
+++ b/engine/Makefile
@@ -3182,6 +3182,9 @@ $(B)/$(BASEGAME)/ui/bg_%.o: $(GDIR)/bg_%.c
 $(B)/$(BASEGAME)/ui/%.o: $(Q3UIDIR)/%.c
 	$(DO_UI_CC)
 
+$(B)/$(BASEGAME)/ui/ui_shared.o: $(UIDIR)/ui_shared.c
+	$(DO_UI_CC)
+
 $(B)/$(BASEGAME)/ui/bg_%.asm: $(GDIR)/bg_%.c $(Q3LCC)
 	$(DO_UI_Q3LCC)
 


### PR DESCRIPTION
## Summary
- add explicit build rule for `ui/ui_shared.c` from base UI directory
- confirm `ui_shared.o` links into the UI library

## Testing
- `make -C engine` *(fails: SDL_version.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68c49a890f2c83249aa823561039faf6