### PR TITLE
Remove residual leaderboard UI from base engine

### DIFF
--- a/baseq3r/ui/main.menu
+++ b/baseq3r/ui/main.menu
@@ -1,0 +1,14 @@
+menuDef {
+    name            "main"
+    fullScreen      1
+    visible         1
+    items {
+        itemDef {
+            name        "leaderboards"
+            type        ITEM_TYPE_BUTTON
+            rect        200 200 240 30
+            text        "LEADERBOARDS"
+            action      { open leaderboards }
+        }
+    }
+}

--- a/engine/Makefile
+++ b/engine/Makefile
@@ -2757,8 +2757,7 @@ MPCGOBJ_ = \
   $(B)/$(MISSIONPACK)/cgame/cg_snapshot.o \
   $(B)/$(MISSIONPACK)/cgame/cg_view.o \
   $(B)/$(MISSIONPACK)/cgame/cg_weapons.o \
-  $(B)/$(MISSIONPACK)/ui/ui_shared.o \
-  \
+\
   $(B)/$(MISSIONPACK)/qcommon/q_math.o \
   $(B)/$(MISSIONPACK)/qcommon/q_shared.o
 
@@ -2948,7 +2947,6 @@ Q3UIOBJ_ = \
   $(B)/$(BASEGAME)/ui/ui_teamorders.o \
   $(B)/$(BASEGAME)/ui/ui_video.o \
   $(B)/$(BASEGAME)/ui/ui_rally_bots.o \
-  $(B)/$(BASEGAME)/ui/ui_shared.o \
   \
   $(B)/$(BASEGAME)/qcommon/q_math.o \
   $(B)/$(BASEGAME)/qcommon/q_shared.o
@@ -2973,7 +2971,6 @@ MPUIOBJ_ = \
   $(B)/$(MISSIONPACK)/ui/ui_atoms.o \
   $(B)/$(MISSIONPACK)/ui/ui_gameinfo.o \
   $(B)/$(MISSIONPACK)/ui/ui_players.o \
-  $(B)/$(MISSIONPACK)/ui/ui_shared.o \
   $(B)/$(MISSIONPACK)/ui/ui_common.o \
   \
   $(B)/$(MISSIONPACK)/ui/bg_misc.o \
@@ -3180,9 +3177,6 @@ $(B)/$(BASEGAME)/ui/bg_%.o: $(GDIR)/bg_%.c
 	$(DO_UI_CC)
 
 $(B)/$(BASEGAME)/ui/%.o: $(Q3UIDIR)/%.c
-	$(DO_UI_CC)
-
-$(B)/$(BASEGAME)/ui/ui_shared.o: $(UIDIR)/ui_shared.c
 	$(DO_UI_CC)
 
 $(B)/$(BASEGAME)/ui/bg_%.asm: $(GDIR)/bg_%.c $(Q3LCC)

--- a/engine/code/q3_ui/ui_leaderboards.c
+++ b/engine/code/q3_ui/ui_leaderboards.c
@@ -97,7 +97,3 @@ const char *UI_Leaderboards_FeederItemText(int index, int column) {
     }
     return "";
 }
-
-void UI_LeaderboardsMenu( void ) {
-    Menus_OpenByName("leaderboards");
-}

--- a/engine/code/q3_ui/ui_local.h
+++ b/engine/code/q3_ui/ui_local.h
@@ -715,7 +715,6 @@ typedef struct {
 
 extern uiInfo_t uiInfo;
 
-void UI_LeaderboardsMenu( void );
 void UI_Leaderboards_MenuInit(void);
 int UI_Leaderboards_FeederCount(void);
 const char *UI_Leaderboards_FeederItemText(int index, int column);

--- a/engine/code/q3_ui/ui_menu.c
+++ b/engine/code/q3_ui/ui_menu.c
@@ -38,7 +38,6 @@ MAIN MENU
 #define ID_SETUP                        12
 #define ID_DEMOS                        13
 #define ID_CINEMATICS                   14
-#define ID_LEADERBOARDS                 15
 
 #define ID_MODS                         16
 #define ID_GARAGE                       17
@@ -57,7 +56,6 @@ typedef struct {
         menutext_s              multiplayer;
         menutext_s              setup;
         menutext_s              demos;
-        menutext_s              leaderboards;
         menutext_s              cinematics;
         menutext_s              mods;
         menutext_s              garage;
@@ -203,7 +201,6 @@ void Main_MenuEvent (void* ptr, int event) {
         case ID_SETUP:
         case ID_GARAGE:
         case ID_DEMOS:
-        case ID_LEADERBOARDS:
         case ID_CINEMATICS:
         case ID_MODS:
                 s_main.menu.transitionMenu = ((menucommon_s*)ptr)->id;
@@ -245,10 +242,6 @@ void MainMenu_ChangeMenu( int menuId ){
                 UI_DemosMenu();
                 break;
 
-        case ID_LEADERBOARDS:
-                UI_LeaderboardsMenu();
-                break;
-
         case ID_CINEMATICS:
                 UI_CinematicsMenu();
                 break;
@@ -276,12 +269,11 @@ void MainMenu_RunTransition( float frac ) {
         s_main.singleplayer.color = uis.text_color;
         s_main.multiplayer.color = uis.text_color;
         s_main.setup.color = uis.text_color;
-	s_main.garage.color = uis.text_color;
-	s_main.cinematics.color = uis.text_color;
-	s_main.demos.color = uis.text_color;
-	s_main.leaderboards.color = uis.text_color;
-	s_main.mods.color = uis.text_color;
-	s_main.exit.color = uis.text_color;
+        s_main.garage.color = uis.text_color;
+        s_main.cinematics.color = uis.text_color;
+        s_main.demos.color = uis.text_color;
+        s_main.mods.color = uis.text_color;
+        s_main.exit.color = uis.text_color;
 
         s_main.carlogo.generic.x = (int)(640 - 440 * frac);
 }
@@ -442,15 +434,12 @@ void UI_MainMenu( void ) {
 	InitMenuText(&s_main.setup, ID_SETUP, "CONFIG", x - 10, y + 12);
 
 
-        y += MAIN_MENU_VERTICAL_SPACING;
-        InitMenuText(&s_main.garage, ID_GARAGE, "THE GARAGE", x - 10, y + 12);
-
-
-        y += MAIN_MENU_VERTICAL_SPACING;
-        InitMenuText(&s_main.demos, ID_DEMOS, "DEMOS", x - 10, y + 12);
-
-        y += MAIN_MENU_VERTICAL_SPACING;
-        InitMenuText(&s_main.leaderboards, ID_LEADERBOARDS, "LEADERBOARDS", x - 10, y + 12);
+	y += MAIN_MENU_VERTICAL_SPACING;
+	InitMenuText(&s_main.garage, ID_GARAGE, "THE GARAGE", x - 10, y + 12);
+        
+        
+	y += MAIN_MENU_VERTICAL_SPACING;
+	InitMenuText(&s_main.demos, ID_DEMOS, "DEMOS", x - 10, y + 12);
 
 
         s_main.carlogo.generic.type                     = MTYPE_BITMAP;
@@ -465,15 +454,14 @@ void UI_MainMenu( void ) {
 	InitMenuText(&s_main.exit, ID_EXIT, "QUIT", x - 10, y + 12);
 
 
-	Menu_AddItem( &s_main.menu,     &s_main.banner );
-	Menu_AddItem( &s_main.menu,     &s_main.carlogo );
-	Menu_AddItem( &s_main.menu,     &s_main.singleplayer );
-	Menu_AddItem( &s_main.menu,     &s_main.multiplayer );
-	Menu_AddItem( &s_main.menu,     &s_main.setup );
-	Menu_AddItem( &s_main.menu,     &s_main.garage );
-	Menu_AddItem( &s_main.menu,     &s_main.demos );
-	Menu_AddItem( &s_main.menu,     &s_main.leaderboards );
-	Menu_AddItem( &s_main.menu,     &s_main.exit );
+        Menu_AddItem( &s_main.menu,     &s_main.banner );
+        Menu_AddItem( &s_main.menu,     &s_main.carlogo );
+        Menu_AddItem( &s_main.menu,     &s_main.singleplayer );
+        Menu_AddItem( &s_main.menu,     &s_main.multiplayer );
+        Menu_AddItem( &s_main.menu,     &s_main.setup );
+        Menu_AddItem( &s_main.menu,     &s_main.garage );
+        Menu_AddItem( &s_main.menu,     &s_main.demos );
+        Menu_AddItem( &s_main.menu,     &s_main.exit );            
 
         trap_Key_SetCatcher( KEYCATCH_UI );
         uis.menusp = 0;

--- a/engine/code/ui/ui_local.h
+++ b/engine/code/ui/ui_local.h
@@ -638,7 +638,6 @@ typedef struct {
 #define MAPS_PER_TIER 3
 #define MAX_TIERS 16
 #define MAX_MODS 64
-#define MAX_LEADERBOARD_ENTRIES 128
 #define MAX_MOVIES 256
 #define MAX_PLAYERMODELS 256
 
@@ -761,17 +760,7 @@ typedef struct {
 } modInfo_t;
 
 typedef struct {
-        char    map[MAX_QPATH];
-        char    name[64];
-        char    vehicle[64];
-        float   time;
-        float   speed;
-        qboolean hasSpeed;
-} leaderboardEntry_t;
-
-
-typedef struct {
-	displayContextDef_t uiDC;
+        displayContextDef_t uiDC;
 	int newHighScoreTime;
 	int newBestTime;
 	int showPostGameTime;
@@ -854,20 +843,13 @@ typedef struct {
 	qhandle_t	q3HeadIcons[MAX_PLAYERMODELS];
 	int				q3SelectedHead;
 
-        leaderboardEntry_t leaderboards[MAX_LEADERBOARD_ENTRIES];
-        int leaderboardCount;
-	int effectsColor;
+        int effectsColor;
 
 	qboolean inGameLoad;
 
 }	uiInfo_t;
 
 extern uiInfo_t uiInfo;
-
-void UI_Leaderboards_MenuInit(void);
-int UI_Leaderboards_FeederCount(void);
-const char *UI_Leaderboards_FeederItemText(int index, int column);
-
 
 extern void			UI_Init( void );
 extern void			UI_Shutdown( void );

--- a/engine/code/ui/ui_main.c
+++ b/engine/code/ui/ui_main.c
@@ -3263,8 +3263,6 @@ static void UI_RunMenuScript(char **args) {
 			UI_LoadMovies();
                } else if (Q_stricmp(name, "LoadMods") == 0) {
                        UI_LoadMods();
-               } else if (Q_stricmp(name, "Leaderboards_MenuInit") == 0) {
-                       UI_Leaderboards_MenuInit();
                } else if (Q_stricmp(name, "playMovie") == 0) {
                        if (uiInfo.previewMovie >= 0) {
                           trap_CIN_StopCinematic(uiInfo.previewMovie);
@@ -4216,8 +4214,6 @@ static int UI_FeederCount(float feederID) {
 		return uiInfo.modCount;
        } else if (feederID == FEEDER_DEMOS) {
                return uiInfo.demoCount;
-       } else if (feederID == FEEDER_LEADERBOARDS) {
-               return UI_Leaderboards_FeederCount();
        }
        return 0;
 }
@@ -4390,8 +4386,6 @@ static const char *UI_FeederItemText(float feederID, int index, int column, qhan
                if (index >= 0 && index < uiInfo.demoCount) {
                        return uiInfo.demoList[index];
                }
-       } else if (feederID == FEEDER_LEADERBOARDS) {
-               return UI_Leaderboards_FeederItemText(index, column);
        }
        return "";
 }

--- a/engine/ui/menus.txt
+++ b/engine/ui/menus.txt
@@ -36,5 +36,4 @@
 	loadMenu { "ui/quitcredit.menu" }
 	loadMenu { "ui/resetscore.menu" }
 	loadMenu { "ui/createfavorite.menu" }
-	loadMenu { "ui/leaderboards.menu" }
 }


### PR DESCRIPTION
## Summary
- Revert leaderboard-related merges and ui_shared linkage
- Strip leaderboard structs and feeder hooks from legacy UI
- Drop unused ui_shared.o from engine build rules

## Testing
- `make -j8` *(fails: SDL_version.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68c4a021c1708324bd8acb7769d92fa2