### PR TITLE
Include ui_shared in UI module

### DIFF
--- a/engine/Makefile
+++ b/engine/Makefile
@@ -2947,6 +2947,7 @@ Q3UIOBJ_ = \
   $(B)/$(BASEGAME)/ui/ui_teamorders.o \
   $(B)/$(BASEGAME)/ui/ui_video.o \
   $(B)/$(BASEGAME)/ui/ui_rally_bots.o \
+  $(B)/$(BASEGAME)/ui/ui_shared.o \
   \
   $(B)/$(BASEGAME)/qcommon/q_math.o \
   $(B)/$(BASEGAME)/qcommon/q_shared.o
@@ -3183,6 +3184,12 @@ $(B)/$(BASEGAME)/ui/bg_%.asm: $(GDIR)/bg_%.c $(Q3LCC)
 	$(DO_UI_Q3LCC)
 
 $(B)/$(BASEGAME)/ui/%.asm: $(Q3UIDIR)/%.c $(Q3LCC)
+	$(DO_UI_Q3LCC)
+
+$(B)/$(BASEGAME)/ui/ui_shared.o: $(UIDIR)/ui_shared.c
+	$(DO_UI_CC)
+
+$(B)/$(BASEGAME)/ui/ui_shared.asm: $(UIDIR)/ui_shared.c $(Q3LCC)
 	$(DO_UI_Q3LCC)
 
 $(B)/$(MISSIONPACK)/ui/bg_%.o: $(GDIR)/bg_%.c


### PR DESCRIPTION
## Summary
- extend Q3UIOBJ_ to build ui_shared.o so menu helpers Menus_CloseAll and Menus_ActivateByName are linked
- add build rules for ui_shared.c in base UI module

## Testing
- `make BUILD_CLIENT=0 BUILD_SERVER=0 BUILD_GAME_SO=0 BUILD_GAME_QVM=1` *(fails: multiple definitions for symbols in ui_shared.asm)*

------
https://chatgpt.com/codex/tasks/task_e_68c5b7282ac8832487107d343e04df66