### PR TITLE
Add static prototype for Controls_GetConfig

### DIFF
--- a/engine/code/ui/ui_shared.c
+++ b/engine/code/ui/ui_shared.c
@@ -24,6 +24,8 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 
 #include "ui_shared.h"
 
+static void Controls_GetConfig(void);
+
 #define SCROLL_TIME_START					500
 #define SCROLL_TIME_ADJUST				150
 #define SCROLL_TIME_ADJUSTOFFSET	40
@@ -3340,7 +3342,7 @@ static void Controls_GetKeyAssignment (char *command, int *twokeys)
 Controls_GetConfig
 =================
 */
-void Controls_GetConfig( void )
+static void Controls_GetConfig( void )
 {
 	int		i;
 	int		twokeys[2];


### PR DESCRIPTION
## Summary
- Declare `Controls_GetConfig` after the include block
- Mark `Controls_GetConfig` definition as `static`

## Testing
- `make -C engine` *(fails: SDL_version.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68c5bc5a557883249f8b9e85c0735f13