### PR TITLE
Declare UI_DrawBackground in ui_shared

### DIFF
--- a/engine/code/ui/ui_shared.c
+++ b/engine/code/ui/ui_shared.c
@@ -24,6 +24,8 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 
 #include "ui_shared.h"
 
+void UI_DrawBackground( qhandle_t shader );
+
 static void Controls_GetConfig(void);
 
 #define SCROLL_TIME_START					500


### PR DESCRIPTION
## Summary
- declare `UI_DrawBackground` in `ui_shared.c` to ensure prototype is visible

## Testing
- `make -C engine` *(fails: SDL_version.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68c5bd2b150c8324978589ee01daeff4