### PR TITLE
Remove unused UI variables

### DIFF
--- a/engine/code/ui/ui_shared.c
+++ b/engine/code/ui/ui_shared.c
@@ -3294,20 +3294,6 @@ static bind_t g_bindings[] =
 
 static const int g_bindCount = ARRAY_LEN(g_bindings);
 
-#ifndef MISSIONPACK
-static configcvar_t g_configcvars[] =
-{
-	{"cl_run",			0,					0},
-	{"m_pitch",			0,					0},
-	{"cg_autoswitch",	0,					0},
-	{"sensitivity",		0,					0},
-	{"in_joystick",		0,					0},
-	{"joy_threshold",	0,					0},
-	{"m_filter",		0,					0},
-	{"cl_freelook",		0,					0},
-	{NULL,				0,					0}
-};
-#endif
 
 /*
 =================
@@ -5917,11 +5903,6 @@ void Menu_Reset(void) {
 displayContextDef_t *Display_GetContext(void) {
 	return DC;
 }
- 
-#ifndef MISSIONPACK
-static float captureX;
-static float captureY;
-#endif
 
 void *Display_CaptureItem(int x, int y) {
 	int i;


### PR DESCRIPTION
## Summary
- Drop unused `g_configcvars` array from ui_shared.c
- Eliminate unreferenced `captureX`/`captureY` declarations

## Testing
- `make` *(fails: SDL_version.h: No such file or directory)*
- `sudo apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68c5bde4d1e88324b8e63a99b7933aac