### PR TITLE
Validate client before sending best times

### DIFF
--- a/engine/code/game/g_cmds.c
+++ b/engine/code/game/g_cmds.c
@@ -2243,7 +2243,17 @@ void Cmd_GetBestTimes_f( gentity_t *ent ) {
 	char		string[MAX_STRING_CHARS];
 	char		entry[1024];
 	int			i;
+	int		clientNum;
 	besttime_t	bestTimes[10];
+
+	if ( !ent || !ent->client ) {
+		return;
+	}
+
+	clientNum = ent - g_entities;
+	if ( clientNum < 0 || clientNum >= level.maxclients ) {
+		return;
+	}
 
 	if ( trap_Argc() < 2 ) {
 		return;
@@ -2263,5 +2273,5 @@ void Cmd_GetBestTimes_f( gentity_t *ent ) {
 		Q_strcat(string, sizeof(string), entry);
 	}
 
-	trap_SendServerCommand( ent-g_entities, va("besttimes%s", string) );
+	trap_SendServerCommand( clientNum, va("besttimes%s", string) );
 }


### PR DESCRIPTION
## Summary
- guard `Cmd_GetBestTimes_f` against invalid entity pointers and client indices
- avoid sending best times to invalid clients

## Testing
- `make` *(fails: SDL_version.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68c5eb9d1b388324b99174686a4fea5c