### PR TITLE
Add client number bounds check in ClientConnect

### DIFF
--- a/engine/code/game/g_client.c
+++ b/engine/code/game/g_client.c
@@ -1114,6 +1114,10 @@ char *ClientConnect( int clientNum, qboolean firstTime, qboolean isBot ) {
 	char		userinfo[MAX_INFO_STRING];
 	gentity_t	*ent;
 
+	if ( clientNum < 0 || clientNum >= level.maxclients ) {
+		return "Invalid client number";
+	}
+
 	ent = &g_entities[ clientNum ];
 
 	trap_GetUserinfo( clientNum, userinfo, sizeof( userinfo ) );


### PR DESCRIPTION
## Summary
- Validate clientNum against level.maxclients in ClientConnect
- Avoid calling trap_GetUserinfo with an invalid client number

## Testing
- `make -C engine BUILD_GAME_SO=1` *(fails: SDL_version.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68c5efaf8f08832497f460301153620c