### PR TITLE
Validate client index in G_GET_USERINFO

### DIFF
--- a/engine/code/server/sv_game.c
+++ b/engine/code/server/sv_game.c
@@ -385,6 +385,10 @@ intptr_t SV_GameSystemCalls( intptr_t *args ) {
 		SV_SetUserinfo( args[1], VMA(2) );
 		return 0;
 	case G_GET_USERINFO:
+		if ( args[1] < 0 || args[1] >= sv_maxclients->integer ) {
+			Com_Printf( "G_GET_USERINFO: bad index %i\n", args[1] );
+			return 0;
+		}
 		SV_GetUserinfo( args[1], VMA(2), args[3] );
 		return 0;
 	case G_GET_SERVERINFO:


### PR DESCRIPTION
## Summary
- guard G_GET_USERINFO against out-of-range client indexes
- log invalid indexes instead of dropping the server

## Testing
- `make release BUILD_SERVER=0 BUILD_GAME_SO=0` *(fails: SDL_version.h: No such file or directory)*
- `apt-get update` *(fails: 403  Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68c5f0d28c14832482892517797b177e