### PR TITLE
Abort on invalid userinfo indices

### DIFF
--- a/engine/code/server/sv_game.c
+++ b/engine/code/server/sv_game.c
@@ -384,13 +384,14 @@ intptr_t SV_GameSystemCalls( intptr_t *args ) {
 	case G_SET_USERINFO:
 		SV_SetUserinfo( args[1], VMA(2) );
 		return 0;
-	case G_GET_USERINFO:
-		if ( args[1] < 0 || args[1] >= sv_maxclients->integer ) {
-			Com_Printf( "G_GET_USERINFO: bad index %i\n", args[1] );
-			return 0;
-		}
-		SV_GetUserinfo( args[1], VMA(2), args[3] );
-		return 0;
+        case G_GET_USERINFO:
+                if ( args[1] < 0 || args[1] >= sv_maxclients->integer ) {
+                        Com_Error( ERR_DROP,
+                                "%s: G_GET_USERINFO: bad index %d (maxclients %d)",
+                                __func__, (int)args[1], sv_maxclients->integer );
+                }
+                SV_GetUserinfo( args[1], VMA(2), args[3] );
+                return 0;
 	case G_GET_SERVERINFO:
 		SV_GetServerinfo( VMA(1), args[2] );
 		return 0;


### PR DESCRIPTION
## Summary
- Abort with detailed error when qagame requests invalid client userinfo
- Include calling context, offending index, and max clients in log

## Testing
- `./make-linux-portable.sh x86_64 BUILD_CLIENT=0 BUILD_SERVER=1 BUILD_GAME_SO=0`
- `SDL_VIDEODRIVER=dummy ./engine/build/release-linux-x86_64/q3rally-server.x86_64 +set fs_basepath "." +set vm_game 2 +map q3r_babel` *(fails: SV_GameSystemCalls: G_GET_USERINFO: bad index -805306368 (maxclients 8))*

------
https://chatgpt.com/codex/tasks/task_e_68c5f53bdbac8324986fd448f10f5cbe