### PR TITLE
Validate userinfo client indices

### DIFF
--- a/engine/code/game/ai_dmq3.c
+++ b/engine/code/game/ai_dmq3.c
@@ -117,12 +117,15 @@ BotSetUserInfo
 ==================
 */
 void BotSetUserInfo(bot_state_t *bs, char *key, char *value) {
-	char userinfo[MAX_INFO_STRING];
-
-	trap_GetUserinfo(bs->client, userinfo, sizeof(userinfo));
-	Info_SetValueForKey(userinfo, key, value);
-	trap_SetUserinfo(bs->client, userinfo);
-	ClientUserinfoChanged( bs->client );
+        char userinfo[MAX_INFO_STRING];
+        if ( bs->client < 0 || bs->client >= level.maxclients ) {
+                G_Printf( "BotSetUserInfo: client %i out of range (max %i)\n", bs->client, level.maxclients );
+                return;
+        }
+        trap_GetUserinfo(bs->client, userinfo, sizeof(userinfo));
+        Info_SetValueForKey(userinfo, key, value);
+        trap_SetUserinfo(bs->client, userinfo);
+        ClientUserinfoChanged( bs->client );
 }
 
 /*
@@ -5325,9 +5328,13 @@ void BotDeathmatchAI(bot_state_t *bs, float thinktime) {
 		//get the gender characteristic
 		trap_Characteristic_String(bs->character, CHARACTERISTIC_GENDER, gender, sizeof(gender));
 		//set the bot gender
-		trap_GetUserinfo(bs->client, userinfo, sizeof(userinfo));
-		Info_SetValueForKey(userinfo, "sex", gender);
-		trap_SetUserinfo(bs->client, userinfo);
+                if ( bs->client < 0 || bs->client >= level.maxclients ) {
+                        G_Printf( "BotDeathmatchAI: client %i out of range (max %i)\n", bs->client, level.maxclients );
+                        return;
+                }
+                trap_GetUserinfo(bs->client, userinfo, sizeof(userinfo));
+                Info_SetValueForKey(userinfo, "sex", gender);
+                trap_SetUserinfo(bs->client, userinfo);
 		//set the chat gender
 		if (gender[0] == 'm') trap_BotSetChatGender(bs->cs, CHAT_GENDERMALE);
 		else if (gender[0] == 'f')  trap_BotSetChatGender(bs->cs, CHAT_GENDERFEMALE);

--- a/engine/code/game/g_bot.c
+++ b/engine/code/game/g_bot.c
@@ -475,8 +475,9 @@ G_CheckBotSpawn
 ===============
 */
 void G_CheckBotSpawn( void ) {
-	int		n;
-	char	userinfo[MAX_INFO_VALUE];
+        int             n;
+        char    userinfo[MAX_INFO_VALUE];
+        int             clientNum;
 
 	G_CheckMinimumPlayers();
 
@@ -487,13 +488,20 @@ void G_CheckBotSpawn( void ) {
 		if ( botSpawnQueue[n].spawnTime > level.time ) {
 			continue;
 		}
-		ClientBegin( botSpawnQueue[n].clientNum );
-		botSpawnQueue[n].spawnTime = 0;
+                clientNum = botSpawnQueue[n].clientNum;
+                if ( clientNum < 0 || clientNum >= level.maxclients ) {
+                        G_Printf( "G_CheckBotSpawn: client %i out of range (max %i)\n", clientNum, level.maxclients );
+                        botSpawnQueue[n].spawnTime = 0;
+                        continue;
+                }
 
-		if( g_gametype.integer == GT_SINGLE_PLAYER ) {
-			trap_GetUserinfo( botSpawnQueue[n].clientNum, userinfo, sizeof(userinfo) );
-			PlayerIntroSound( Info_ValueForKey (userinfo, "model") );
-		}
+                ClientBegin( clientNum );
+                botSpawnQueue[n].spawnTime = 0;
+
+                if( g_gametype.integer == GT_SINGLE_PLAYER ) {
+                        trap_GetUserinfo( clientNum, userinfo, sizeof(userinfo) );
+                        PlayerIntroSound( Info_ValueForKey (userinfo, "model") );
+                }
 	}
 }
 
@@ -547,6 +555,11 @@ G_BotConnect
 qboolean G_BotConnect( int clientNum, qboolean restart ) {
 	bot_settings_t	settings;
 	char			userinfo[MAX_INFO_STRING];
+
+	if ( clientNum < 0 || clientNum >= level.maxclients ) {
+		G_Printf( "G_BotConnect: client %i out of range (max %i)\n", clientNum, level.maxclients );
+		return qfalse;
+	}
 
 	trap_GetUserinfo( clientNum, userinfo, sizeof(userinfo) );
 

--- a/engine/code/game/g_client.c
+++ b/engine/code/game/g_client.c
@@ -870,7 +870,7 @@ if desired.
 ============
 */
 void ClientUserinfoChanged( int clientNum ) {
-	gentity_t *ent;
+        gentity_t *ent;
 	int		teamTask, teamLeader, health;
 	char	*s;
 	char	model[MAX_QPATH];
@@ -891,10 +891,15 @@ void ClientUserinfoChanged( int clientNum ) {
     char    yellowTeam[MAX_INFO_STRING];
 	char	userinfo[MAX_INFO_STRING];
 
-	ent = g_entities + clientNum;
-	client = ent->client;
+        if ( clientNum < 0 || clientNum >= level.maxclients ) {
+                G_Printf( "ClientUserinfoChanged: client %i out of range (max %i)\n", clientNum, level.maxclients );
+                return;
+        }
 
-	trap_GetUserinfo( clientNum, userinfo, sizeof( userinfo ) );
+        ent = g_entities + clientNum;
+        client = ent->client;
+
+        trap_GetUserinfo( clientNum, userinfo, sizeof( userinfo ) );
 
 	// check for malformed or illegal info strings
 	if ( !Info_Validate(userinfo) ) {
@@ -1489,9 +1494,13 @@ void ClientSpawn(gentity_t *ent) {
 	client->ps.persistant[PERS_SPAWN_COUNT]++;
 	client->ps.persistant[PERS_TEAM] = client->sess.sessionTeam;
 
-	client->airOutTime = level.time + 12000;
+        client->airOutTime = level.time + 12000;
 
-	trap_GetUserinfo( index, userinfo, sizeof(userinfo) );
+        if ( index < 0 || index >= level.maxclients ) {
+                G_Printf( "ClientSpawn: client %i out of range (max %i)\n", index, level.maxclients );
+                return;
+        }
+        trap_GetUserinfo( index, userinfo, sizeof(userinfo) );
 	// set max health
 	client->pers.maxHealth = atoi( Info_ValueForKey( userinfo, "handicap" ) );
 	if ( client->pers.maxHealth < 1 || client->pers.maxHealth > 100 ) {

--- a/engine/code/game/g_cmds.c
+++ b/engine/code/game/g_cmds.c
@@ -529,7 +529,11 @@ void Cmd_TeamTask_f( gentity_t *ent ) {
 	trap_Argv( 1, arg, sizeof( arg ) );
 	task = atoi( arg );
 
-	trap_GetUserinfo(client, userinfo, sizeof(userinfo));
+        if ( client < 0 || client >= level.maxclients ) {
+                G_Printf( "Cmd_TeamTask_f: client %i out of range (max %i)\n", client, level.maxclients );
+                return;
+        }
+        trap_GetUserinfo(client, userinfo, sizeof(userinfo));
 	Info_SetValueForKey(userinfo, "teamtask", va("%d", task));
 	trap_SetUserinfo(client, userinfo);
 	ClientUserinfoChanged(client);

--- a/engine/code/game/g_items.c
+++ b/engine/code/game/g_items.c
@@ -140,7 +140,11 @@ int Pickup_PersistantPowerup( gentity_t *ent, gentity_t *other ) {
 	switch( ent->item->giTag ) {
 	case PW_GUARD:
 		clientNum = other->client->ps.clientNum;
-		trap_GetUserinfo( clientNum, userinfo, sizeof(userinfo) );
+                if ( clientNum < 0 || clientNum >= level.maxclients ) {
+                        G_Printf( "Pickup_PersistantPowerup: client %i out of range (max %i)\n", clientNum, level.maxclients );
+                        return RESPAWN_POWERUP;
+                }
+                trap_GetUserinfo( clientNum, userinfo, sizeof(userinfo) );
 		handicap = atof( Info_ValueForKey( userinfo, "handicap" ) );
 		if( handicap<=0.0f || handicap>100.0f) {
 			handicap = 100.0f;
@@ -157,7 +161,11 @@ int Pickup_PersistantPowerup( gentity_t *ent, gentity_t *other ) {
 
 	case PW_SCOUT:
 		clientNum = other->client->ps.clientNum;
-		trap_GetUserinfo( clientNum, userinfo, sizeof(userinfo) );
+                if ( clientNum < 0 || clientNum >= level.maxclients ) {
+                        G_Printf( "Pickup_PersistantPowerup: client %i out of range (max %i)\n", clientNum, level.maxclients );
+                        return RESPAWN_POWERUP;
+                }
+                trap_GetUserinfo( clientNum, userinfo, sizeof(userinfo) );
 		handicap = atof( Info_ValueForKey( userinfo, "handicap" ) );
 		if( handicap<=0.0f || handicap>100.0f) {
 			handicap = 100.0f;
@@ -168,7 +176,11 @@ int Pickup_PersistantPowerup( gentity_t *ent, gentity_t *other ) {
 
 	case PW_DOUBLER:
 		clientNum = other->client->ps.clientNum;
-		trap_GetUserinfo( clientNum, userinfo, sizeof(userinfo) );
+                if ( clientNum < 0 || clientNum >= level.maxclients ) {
+                        G_Printf( "Pickup_PersistantPowerup: client %i out of range (max %i)\n", clientNum, level.maxclients );
+                        return RESPAWN_POWERUP;
+                }
+                trap_GetUserinfo( clientNum, userinfo, sizeof(userinfo) );
 		handicap = atof( Info_ValueForKey( userinfo, "handicap" ) );
 		if( handicap<=0.0f || handicap>100.0f) {
 			handicap = 100.0f;
@@ -177,7 +189,11 @@ int Pickup_PersistantPowerup( gentity_t *ent, gentity_t *other ) {
 		break;
 	case PW_AMMOREGEN:
 		clientNum = other->client->ps.clientNum;
-		trap_GetUserinfo( clientNum, userinfo, sizeof(userinfo) );
+                if ( clientNum < 0 || clientNum >= level.maxclients ) {
+                        G_Printf( "Pickup_PersistantPowerup: client %i out of range (max %i)\n", clientNum, level.maxclients );
+                        return RESPAWN_POWERUP;
+                }
+                trap_GetUserinfo( clientNum, userinfo, sizeof(userinfo) );
 		handicap = atof( Info_ValueForKey( userinfo, "handicap" ) );
 		if( handicap<=0.0f || handicap>100.0f) {
 			handicap = 100.0f;
@@ -187,7 +203,11 @@ int Pickup_PersistantPowerup( gentity_t *ent, gentity_t *other ) {
 		break;
 	default:
 		clientNum = other->client->ps.clientNum;
-		trap_GetUserinfo( clientNum, userinfo, sizeof(userinfo) );
+                if ( clientNum < 0 || clientNum >= level.maxclients ) {
+                        G_Printf( "Pickup_PersistantPowerup: client %i out of range (max %i)\n", clientNum, level.maxclients );
+                        return RESPAWN_POWERUP;
+                }
+                trap_GetUserinfo( clientNum, userinfo, sizeof(userinfo) );
 		handicap = atof( Info_ValueForKey( userinfo, "handicap" ) );
 		if( handicap<=0.0f || handicap>100.0f) {
 			handicap = 100.0f;

--- a/engine/code/game/g_main.c
+++ b/engine/code/game/g_main.c
@@ -318,8 +318,12 @@ void G_CheckBestTime( gentity_t *ent ) {
 			level.bestTimes[i].time = time;
 			Q_strncpyz( level.bestTimes[i].name, ent->client->pers.netname, sizeof( level.bestTimes[i].name ) );
 
-			trap_GetUserinfo( ent->s.clientNum, userinfo, sizeof( userinfo ) );
-			Q_strncpyz( level.bestTimes[i].car, Info_ValueForKey( userinfo, "model" ), sizeof( level.bestTimes[i].car ) );
+                        if ( ent->s.clientNum < 0 || ent->s.clientNum >= level.maxclients ) {
+                                G_Printf( "G_CheckBestTime: client %i out of range (max %i)\n", ent->s.clientNum, level.maxclients );
+                                return;
+                        }
+                        trap_GetUserinfo( ent->s.clientNum, userinfo, sizeof( userinfo ) );
+                        Q_strncpyz( level.bestTimes[i].car, Info_ValueForKey( userinfo, "model" ), sizeof( level.bestTimes[i].car ) );
 
 			G_SaveBestTimes();
 			break;

--- a/engine/code/game/g_syscalls.c
+++ b/engine/code/game/g_syscalls.c
@@ -135,7 +135,14 @@ void trap_GetConfigstring( int num, char *buffer, int bufferSize ) {
 }
 
 void trap_GetUserinfo( int num, char *buffer, int bufferSize ) {
-	syscall( G_GET_USERINFO, num, buffer, bufferSize );
+        if ( num < 0 || num >= level.maxclients ) {
+                G_Printf( "trap_GetUserinfo: client %i out of range (max %i)\n", num, level.maxclients );
+                if ( bufferSize > 0 && buffer ) {
+                        buffer[0] = '\0';
+                }
+                return;
+        }
+        syscall( G_GET_USERINFO, num, buffer, bufferSize );
 }
 
 void trap_SetUserinfo( int num, const char *buffer ) {


### PR DESCRIPTION
## Summary
- guard trap_GetUserinfo against invalid client indices
- assert client index ranges before fetching userinfo throughout game code
- add bot and powerup userinfo checks to prevent out-of-range access

## Testing
- `make BUILD_CLIENT=0`
- `gcc /tmp/test_userinfo.c engine/code/game/g_syscalls.c -Iengine/code -DARCH_STRING="x86_64" -o /tmp/test_userinfo && /tmp/test_userinfo`

------
https://chatgpt.com/codex/tasks/task_e_68c65e8382c483249998ed21a446d5f9