### PR TITLE
Draw RPM icon in analog speedometer

### DIFF
--- a/engine/code/cgame/cg_rally_hud.c
+++ b/engine/code/cgame/cg_rally_hud.c
@@ -969,6 +969,16 @@ static float CG_DrawSpeed( float y ) {
                        float segWidth = (fuelWidth - (segments - 1) * segGap) / segments;
                        float segX = left + (blockWidth - fuelWidth) * 0.5f;
                        float segY = top + gaugeSize + gaugeSpacing + fuelHeight + rpmSpacing;
+
+                       static qhandle_t rpmIcon;
+                       if ( !rpmIcon ) {
+                               rpmIcon = trap_R_RegisterShaderNoMip( "icons/rpm" );
+                       }
+                       float rpmIconSize = rpmHeight * 2;
+                       float rpmIconX = segX - rpmIconSize - 4;
+                       float rpmIconY = segY + (rpmHeight - rpmIconSize) * 0.5f;
+                       CG_DrawPic( rpmIconX, rpmIconY, rpmIconSize, rpmIconSize, rpmIcon );
+
                        for ( i = 0 ; i < segments ; i++ ) {
                                float xPos = segX + i * (segWidth + segGap);
                                if ( rpm >= (i + 1) * 1000 ) {


### PR DESCRIPTION
## Summary
- render RPM icon in analog speedometer gauge

## Testing
- `make -C engine` *(fails: SDL_version.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68c6b41e12d483249a65fb79cfda23fb