### PR TITLE
Adjust RPM icon size in analog speed gauge

### DIFF
--- a/engine/code/cgame/cg_rally_hud.c
+++ b/engine/code/cgame/cg_rally_hud.c
@@ -977,7 +977,7 @@ static float CG_DrawSpeed( float y ) {
                                rpmIcon = trap_R_RegisterShaderNoMip( "icons/rpm" );
                        }
 
-                       rpmIconSize = rpmHeight * 2;
+                       rpmIconSize = rpmHeight * (4.0f / 3.0f);
                        rpmIconX = segX - rpmIconSize - 4;
                        rpmIconY = segY + (rpmHeight - rpmIconSize) * 0.5f;
 


### PR DESCRIPTION
## Summary
- tweak RPM icon scaling for analog HUD to use 4:3 ratio instead of 2x height

## Testing
- `make -C engine` *(fails: SDL_version.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68c6e65eb3048324a6ad9d5ccb1d3e58