### PR TITLE
Align digital speedometer text to right edge

### DIFF
--- a/engine/code/cgame/cg_rally_hud.c
+++ b/engine/code/cgame/cg_rally_hud.c
@@ -798,6 +798,7 @@ static float CG_DrawSpeed( float y ) {
                 float   iconOffset = gaugeHeight * 2 + 4;
                  float   blockWidth, blockHeight, barWidth;
                  int             i;
+                int             speedWidth, gearWidth;
 
 		Com_sprintf( speedStr, sizeof( speedStr ), "%i %s", vel_speed, cg_metricUnits.integer ? "KPH" : "MPH" );
 
@@ -845,22 +846,25 @@ static float CG_DrawSpeed( float y ) {
 			}
 			CG_DrawPic( x, y, rpmIconSize, rpmIconSize, rpmIcon );
 		}
-		for ( i = 0; i < segments; i++ ) {
-			float segX = x + rpmIconOffset + i * (segmentWidth + segmentGap);
-			if ( rpm >= (i + 1) * 1000 ) {
-				CG_FillRect( segX, y, segmentWidth, segmentHeight, colorWhite );
-			} else {
-				CG_DrawRect( segX, y, segmentWidth, segmentHeight, 1, colorWhite );
-			}
-		}
+               for ( i = 0; i < segments; i++ ) {
+                       float segX = x + rpmIconOffset + i * (segmentWidth + segmentGap);
+                       if ( rpm >= (i + 1) * 1000 ) {
+                               CG_FillRect( segX, y, segmentWidth, segmentHeight, colorWhite );
+                       } else {
+                               CG_DrawRect( segX, y, segmentWidth, segmentHeight, 1, colorWhite );
+                       }
+               }
 
-		y += segmentHeight;
-		CG_DrawGiantDigitalStringColor( x, y, speedStr, colorWhite );
-		y += GIANTCHAR_HEIGHT;
-		CG_DrawGiantDigitalStringColor( x, y, gearStr, colorWhite );
+               speedWidth = CG_DrawStrlen( speedStr ) * GIANTCHAR_WIDTH;
+               gearWidth  = CG_DrawStrlen( gearStr )  * GIANTCHAR_WIDTH;
 
-                y += GIANTCHAR_HEIGHT;
-                CG_DrawFuelGauge( x + iconOffset, y, barWidth, gaugeHeight );
+               y += segmentHeight;
+               CG_DrawGiantDigitalStringColor( x + blockWidth - speedWidth, y, speedStr, colorWhite );
+               y += GIANTCHAR_HEIGHT;
+               CG_DrawGiantDigitalStringColor( x + blockWidth - gearWidth, y, gearStr, colorWhite );
+
+               y += GIANTCHAR_HEIGHT;
+               CG_DrawFuelGauge( x + iconOffset, y, barWidth, gaugeHeight );
                 y = yorg;
                y -= 44;
                y -= blockHeight;


### PR DESCRIPTION
## Summary
- Calculate width of speed and gear strings
- Right-align digital speed and gear text within HUD block

## Testing
- `make release BUILD_CLIENT=0 BUILD_SERVER=0 BUILD_AUTOUPDATER=0 BUILD_GAME_SO=0 BUILD_GAME_QVM=1 BUILD_BASEGAME=1 BUILD_MISSIONPACK=0`

------
https://chatgpt.com/codex/tasks/task_e_68c6e87f98b883248f967edd3b64216c