### PR TITLE
Refactor car physics constants into per-vehicle fields

### DIFF
--- a/engine/code/game/bg_physics.c
+++ b/engine/code/game/bg_physics.c
@@ -33,13 +33,10 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 float CP_CURRENT_GRAVITY;
 
 // not actually used now, use cvars instead
-float CP_SPRING_STRENGTH = 110 * (CP_FRAME_MASS / 350.0f) * CP_GRAVITY; // 110
 float CP_SHOCK_STRENGTH = 13 * CP_GRAVITY; // 12
 float CP_SWAYBAR_STRENGTH = 21 * CP_GRAVITY; // 20 * grav
 
 float CP_M_2_QU = CP_FT_2_QU / CP_FT_2_M; // 35.66
-float CP_WR_STRENGTH = 2400.0f * CP_WHEEL_MASS;
-float CP_WR_DAMP_STRENGTH = 140.0f * CP_WHEEL_MASS;
 
 
 static int	numTraces;
@@ -122,7 +119,10 @@ void PM_SetCoM( carBody_t *body, carPoint_t *points ){
 	int		i;
 
 	VectorClear(temp);
-	totalMass = CP_CAR_MASS;
+        totalMass = 0.0f;
+        for (i = 0; i < LAST_FRAME_POINT; i++){
+                totalMass += points[i].mass;
+        }
 
 	for (i = FIRST_FRAME_POINT; i < LAST_FRAME_POINT; i++){
 		VectorMA(temp, points[i].mass, points[i].r, temp);
@@ -439,6 +439,20 @@ void PM_InitializeVehicle( car_t *car, vec3_t origin, vec3_t angles, vec3_t velo
 
 	// UPDATE: use memset?
 
+        if (!car->frameMass) car->frameMass = 300.0f;
+        if (!car->wheelMass) car->wheelMass = 50.0f;
+        if (!car->gearRatios[0]){
+                float defaults[6] = {3.33f, 2.10f, 1.43f, 1.14f, 0.89f, 0.69f};
+                memcpy(car->gearRatios, defaults, sizeof(defaults));
+        }
+        if (!car->axleGear) car->axleGear = 3.07f;
+        if (!car->rpmMax) car->rpmMax = CP_RPM_MAX;
+        if (!car->torquePeak) car->torquePeak = 400.0f;
+        if (!car->rpmTorquePeak) car->rpmTorquePeak = 2800.0f;
+        if (!car->hpPeak) car->hpPeak = 320.0f;
+        if (!car->rpmHpPeak) car->rpmHpPeak = 5000.0f;
+        if (!car->fuelConsumption) car->fuelConsumption = 1.0f;
+
 	VectorCopy(origin, car->sBody.r);
 	AnglesToOrientation(angles, car->sBody.t);
 //	AnglesToQuaternion(angles, car->sBody.q);
@@ -473,11 +487,11 @@ void PM_InitializeVehicle( car_t *car, vec3_t origin, vec3_t angles, vec3_t velo
 	PM_InitializeWheel(&car->sBody, car->sPoints, RL_WHEEL, -1.0f, -1.0f);
 	PM_InitializeWheel(&car->sBody, car->sPoints, RR_WHEEL, -1.0f,  1.0f);
 
-	car->sBody.mass = 4 * CP_FRAME_MASS;
-	car->tBody.mass = 4 * CP_FRAME_MASS;
+	car->sBody.mass = 4 * car->frameMass;
+	car->tBody.mass = 4 * car->frameMass;
 
 	for (i = 0; i < FIRST_FRAME_POINT; i++){
-		car->sPoints[i].mass = CP_WHEEL_MASS;
+		car->sPoints[i].mass = car->wheelMass;
 		car->sPoints[i].elasticity = CP_WHEEL_ELASTICITY;
 		car->sPoints[i].scof = CP_SCOF;
 		car->sPoints[i].kcof = CP_KCOF;
@@ -485,7 +499,7 @@ void PM_InitializeVehicle( car_t *car, vec3_t origin, vec3_t angles, vec3_t velo
 		car->sPoints[i].onGround = qfalse;
 		car->sPoints[i].onGroundTime = 0;
 		car->sPoints[i].radius = WHEEL_RADIUS;
-		car->tPoints[i].mass = CP_WHEEL_MASS;
+		car->tPoints[i].mass = car->wheelMass;
 		car->tPoints[i].elasticity = CP_WHEEL_ELASTICITY;
 		car->tPoints[i].scof = CP_SCOF;
 		car->tPoints[i].kcof = CP_KCOF;
@@ -541,7 +555,7 @@ void PM_InitializeVehicle( car_t *car, vec3_t origin, vec3_t angles, vec3_t velo
 	car->inverseBodyInertiaTensor[1][1] = pm->car_IT_yScale * 3.0f / (car->sBody.mass * (halfWidth * halfWidth + halfHeight * halfHeight));
 	car->inverseBodyInertiaTensor[2][2] = pm->car_IT_zScale * 3.0f / (car->sBody.mass * (halfWidth * halfWidth + halfLength * halfLength));
 
-	car->springStrength = CP_SPRING_STRENGTH;
+	car->springStrength = 110 * (car->frameMass / 350.0f) * CP_GRAVITY;
 	car->springMaxLength = CP_SPRING_MAXLEN;
 	car->springMinLength = CP_SPRING_MINLEN;
 //	car->shockStrength = CP_SHOCK_STRENGTH;
@@ -1202,7 +1216,7 @@ static int PM_Generate_FrameWheel_Forces(car_t *car, carPoint_t *points, int fra
 		compression = (car->springMaxLength - car->springMinLength) * (exp( compression / (car->springMaxLength - car->springMinLength)) - 1 ) / 1.718281828f;
 
 	if (compression < 0)
-		VectorScale(car->sBody.up, 3.0f * CP_SPRING_STRENGTH * compression, frame->forces[SPRING]);
+		VectorScale(car->sBody.up, 3.0f * car->springStrength * compression, frame->forces[SPRING]);
 	else
 		VectorScale(car->sBody.up, car->springStrength * compression, frame->forces[SPRING]);
 
@@ -1431,10 +1445,10 @@ static void PM_CalculateForces( car_t *car, carBody_t *body, carPoint_t *points,
 
 		if ( length > 2.0f ){
 			// k = 10000; // good at 90fps
-			k = pm->car_wheel * CP_WHEEL_MASS;
+			k = pm->car_wheel * car->wheelMass;
 
 //			b = 2 * sqrt(k * points[i].mass);
-			b = pm->car_wheel_damp * CP_WHEEL_MASS;
+			b = pm->car_wheel_damp * car->wheelMass;
 
 			VectorScale(diff, -k * length, force);
 
@@ -2311,9 +2325,9 @@ void PM_DriveMove( car_t *car, float time, qboolean includeBodies )
 	// set spring strengths for "jump" and "crouch"
 // FIXME: change this so it works in cgame and game
 #if GAME
-	car->springStrength = pm->car_spring * (CP_FRAME_MASS / 350.0f) * CP_GRAVITY;
+        car->springStrength = pm->car_spring * (car->frameMass / 350.0f) * CP_GRAVITY;
 #else
-	car->springStrength = CP_SPRING_STRENGTH;
+        car->springStrength = 110 * (car->frameMass / 350.0f) * CP_GRAVITY;
 #endif
 //	car->shockStrength = CP_SHOCK_STRENGTH;
 
@@ -2337,7 +2351,7 @@ void PM_DriveMove( car_t *car, float time, qboolean includeBodies )
     
 	if ( car->fuel > 0.0f ) {
 		float fuelUse;
-		fuelUse = fabs(car->throttle) * (fabs(car->rpm) / CP_RPM_MAX) * CP_FUEL_CONSUMPTION * time;
+		fuelUse = fabs(car->throttle) * (fabs(car->rpm) / car->rpmMax) * car->fuelConsumption * time;
 		car->fuel -= fuelUse;
 		if ( car->fuelLeak ) {
 			car->fuel -= CP_FUEL_LEAK_RATE * time;

--- a/engine/code/game/bg_physics.h
+++ b/engine/code/game/bg_physics.h
@@ -57,11 +57,7 @@ extern float CP_CURRENT_GRAVITY;
 extern	float CP_M_2_QU;
 //static	float CP_M_2_QU = CP_FT_2_QU / 0.3048f; // 35.66
 
-#define	CP_FRAME_MASS		300.0f // 350
-#define	CP_WHEEL_MASS		50.0f // 100
-#define	CP_CAR_MASS			( CP_FRAME_MASS * 4 + CP_WHEEL_MASS * 4 )
 #define CP_MAX_FUEL             100.0f
-#define CP_FUEL_CONSUMPTION     1.0f
 #define CP_FUEL_LEAK_RATE       1.0f
 
 #define	CP_BODY_ELASTICITY	0.05f
@@ -80,14 +76,8 @@ extern	float CP_M_2_QU;
 
 
 // strength of the fake spring that returns the wheel to perpendicular
-extern	float CP_WR_STRENGTH;
-extern	float CP_SPRING_STRENGTH;
 extern	float CP_SHOCK_STRENGTH;
 extern	float CP_SWAYBAR_STRENGTH;
-/*
-extern	float CP_TORQUE_SLOPE;
-extern	float CP_GEAR_RATIOS[];
-*/
 
 #define	CP_AIR_COF			0.31f
 #define	CP_FRAC_TO_DF		0.50f
@@ -119,30 +109,15 @@ extern	float CP_GEAR_RATIOS[];
 #define	CP_LAVA_DENSITY		60000.0f
 #define	CP_SLIME_DENSITY	20000.0f
 
-#define	CP_AXLEGEAR			3.07f
 #define	CP_GEARR			-2.80f
 #define	CP_GEARN			0.00f
 
 // Six speed transmission gear ratios
-#define	CP_GEAR1			3.33f
-#define	CP_GEAR2			2.10f
-#define	CP_GEAR3			1.43f
-#define	CP_GEAR4			1.14f
-#define	CP_GEAR5			0.89f
-#define	CP_GEAR6			0.69f
 
 
 #define	CP_RPM_MAX	      6250
 #define	CP_RPM_MIN			  750
 
-// #define	CP_HP_PEAK			191.0f
-// #define	CP_RPM_HP_PEAK		4600.0f
-#define	CP_HP_PEAK			320.0f
-#define	CP_RPM_HP_PEAK		5000.0f
-// #define	CP_TORQUE_PEAK		230.0f
-// #define	CP_RPM_TORQUE_PEAK	3800.0f
-#define	CP_TORQUE_PEAK		400.0f
-#define	CP_RPM_TORQUE_PEAK	2800.0f
 
 #define HTYPE_NO_HIT		0
 #define HTYPE_BOTTOMED_OUT	1
@@ -294,12 +269,23 @@ typedef struct {
 
 //	pointHistory_t	oldPoints[3][LAST_RW_POINT];
 //	bodyHistory_t	oldBodies[3];
+        // vehicle configuration
+        float   frameMass;
+        float   wheelMass;
+        float   gearRatios[6];
+        float   axleGear;
+        float   rpmMax;
+        float   torquePeak;
+        float   rpmTorquePeak;
+        float   hpPeak;
+        float   rpmHpPeak;
+        float   fuelConsumption;
 
-	// FIXME: remove these to save memory if i can
+        // FIXME: remove these to save memory if i can
 
-	float	springStrength;
-	float	springMaxLength;
-	float	springMinLength;
+        float   springStrength;
+        float   springMaxLength;
+        float   springMinLength;
 //	float	shockStrength;
 //	float	swayBarStrength;
 

--- a/engine/code/game/bg_wheel_forces.c
+++ b/engine/code/game/bg_wheel_forces.c
@@ -30,9 +30,9 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #include "bg_public.h"
 #include "bg_local.h"
 
-
-static float CP_TORQUE_SLOPE = (float)(CP_RPM_HP_PEAK * M_PI * CP_TORQUE_PEAK - 16500 * CP_HP_PEAK) / (float)(CP_RPM_HP_PEAK * M_PI * (CP_RPM_HP_PEAK*CP_RPM_HP_PEAK - 2 * CP_RPM_HP_PEAK * CP_RPM_TORQUE_PEAK + CP_RPM_TORQUE_PEAK*CP_RPM_TORQUE_PEAK));
-static float CP_GEAR_RATIOS[] = {CP_GEAR1, CP_GEAR2, CP_GEAR3, CP_GEAR4, CP_GEAR5, CP_GEAR6};
+static float PM_CalcTorqueSlope( car_t *car ) {
+        return (float)(car->rpmHpPeak * M_PI * car->torquePeak - 16500 * car->hpPeak) / (float)(car->rpmHpPeak * M_PI * (car->rpmHpPeak*car->rpmHpPeak - 2 * car->rpmHpPeak * car->rpmTorquePeak + car->rpmTorquePeak*car->rpmTorquePeak));
+}
 
 
 #if 0
@@ -49,10 +49,10 @@ static float PM_RPMtoWheelSpeed( car_t *car ){
 	else if (car->gear == 0)
 		ratio = CP_GEARN;
 	else
-		ratio = CP_GEAR_RATIOS[car->gear-1];
+		ratio = car->gearRatios[car->gear-1];
 
-//	return (-(car->rpm-CP_RPM_MIN) * M_PI / 30) / (ratio * CP_AXLEGEAR);
-	return (-(car->rpm) * M_PI / 30) / (ratio * CP_AXLEGEAR);
+//	return (-(car->rpm-CP_RPM_MIN) * M_PI / 30) / (ratio * car->axleGear);
+	return (-(car->rpm) * M_PI / 30) / (ratio * car->axleGear);
 }
 #endif
 
@@ -71,7 +71,7 @@ static float PM_WheelSpeedtoRPM( car_t *car, carPoint_t *points ){
 	else if (car->gear == 0)
 		ratio = CP_GEARN;
 	else
-		ratio = CP_GEAR_RATIOS[car->gear-1];
+		ratio = car->gearRatios[car->gear-1];
 
 	w = 0;
 	if (car->gear >= 0){
@@ -85,8 +85,8 @@ static float PM_WheelSpeedtoRPM( car_t *car, carPoint_t *points ){
 		}
 	}
 
-//	return (-w / M_PI * 30) * (ratio * CP_AXLEGEAR) + CP_RPM_MIN;
-	return (-w / M_PI * 30) * (ratio * CP_AXLEGEAR);
+//	return (-w / M_PI * 30) * (ratio * car->axleGear) + CP_RPM_MIN;
+	return (-w / M_PI * 30) * (ratio * car->axleGear);
 }
 
 
@@ -99,13 +99,13 @@ static void PM_UpdateRPM(car_t *car, carPoint_t *points){
 	float	rpmTemp;
 	float	shiftDownRPM, shiftUpRPM;
 
-	shiftDownRPM = CP_RPM_MIN + (CP_RPM_MAX - CP_RPM_MIN) * (0.4f + 0.2f * car->throttle);
-	shiftUpRPM = CP_RPM_MIN + (CP_RPM_MAX - CP_RPM_MIN) * (0.8f + 0.2f * car->throttle);
+	shiftDownRPM = CP_RPM_MIN + (car->rpmMax - CP_RPM_MIN) * (0.4f + 0.2f * car->throttle);
+	shiftUpRPM = CP_RPM_MIN + (car->rpmMax - CP_RPM_MIN) * (0.8f + 0.2f * car->throttle);
 
 //  Com_Printf("shiftDownRPM: %f shiftUpRPM: %f\n", shiftDownRPM, shiftUpRPM);
 
-	if ( shiftUpRPM > CP_RPM_MAX )
-		shiftUpRPM = CP_RPM_MAX;
+	if ( shiftUpRPM > car->rpmMax )
+		shiftUpRPM = car->rpmMax;
 
 	if (car->gear > 0){
 		rpmTemp = PM_WheelSpeedtoRPM(car, points);
@@ -123,16 +123,16 @@ static void PM_UpdateRPM(car_t *car, carPoint_t *points){
 				break;
 
 			rpmTemp = PM_WheelSpeedtoRPM(car, points);
-			if (rpmTemp > CP_RPM_MAX)
-				rpmTemp = CP_RPM_MAX;
+			if (rpmTemp > car->rpmMax)
+				rpmTemp = car->rpmMax;
 		}
 
 //		Com_Printf("2 Gear: %i RPM temp: %f\n", car->gear, rpmTemp);
 
 		while ( rpmTemp > shiftUpRPM ){
 			if ( !points[2].onGround || !points[3].onGround || points[2].slipping || points[3].slipping ){
-				if ( rpmTemp > CP_RPM_MAX ){
-					rpmTemp = CP_RPM_MAX;
+				if ( rpmTemp > car->rpmMax ){
+					rpmTemp = car->rpmMax;
 					break;
 				}
 				else if ( rpmTemp > shiftUpRPM )
@@ -143,8 +143,8 @@ static void PM_UpdateRPM(car_t *car, carPoint_t *points){
 				if ( points[2].onGround && points[3].onGround && !points[2].slipping && !points[3].slipping )
 					car->gear++;
 			}
-			else if ( rpmTemp > CP_RPM_MAX ){
-				rpmTemp = CP_RPM_MAX;
+			else if ( rpmTemp > car->rpmMax ){
+				rpmTemp = car->rpmMax;
 				break;
 			}
 
@@ -162,8 +162,8 @@ static void PM_UpdateRPM(car_t *car, carPoint_t *points){
 		rpmTemp = PM_WheelSpeedtoRPM(car, points);
 		if (rpmTemp < CP_RPM_MIN)
 			rpmTemp = CP_RPM_MIN;
-		if (rpmTemp > CP_RPM_MAX)
-			rpmTemp = CP_RPM_MAX;
+		if (rpmTemp > car->rpmMax)
+			rpmTemp = car->rpmMax;
 
 		car->rpm = rpmTemp;
 	}
@@ -411,7 +411,7 @@ static void PM_TireEngineForces( car_t *car, carPoint_t *points, int i, vec3_t f
 		return;
 	}
 
-	if (car->rpm >= CP_RPM_MAX){
+	if (car->rpm >= car->rpmMax){
 		// just add enough torque to stay at constant speed
 		return;
 //		points[i].w = PM_RPMtoWheelSpeed(car);
@@ -419,8 +419,8 @@ static void PM_TireEngineForces( car_t *car, carPoint_t *points, int i, vec3_t f
 	}
 
 
-	relrpm = (car->rpm - CP_RPM_TORQUE_PEAK);
-	torque = car->throttle * ((-1.0f * CP_TORQUE_SLOPE * relrpm * relrpm) + CP_TORQUE_PEAK); // ft.lb
+	relrpm = (car->rpm - car->rpmTorquePeak);
+	torque = car->throttle * ((-1.0f * PM_CalcTorqueSlope(car) * relrpm * relrpm) + car->torquePeak); // ft.lb
 //	power = torque * car->rpm / (30 * 550 / M_PI); // hp
 
 	if (car->gear < 0)
@@ -428,13 +428,13 @@ static void PM_TireEngineForces( car_t *car, carPoint_t *points, int i, vec3_t f
 	else if (car->gear == 0)
 		ratio = CP_GEARN;
 	else
-		ratio = CP_GEAR_RATIOS[car->gear-1];
+		ratio = car->gearRatios[car->gear-1];
 
 	friction = 0;
 	if (fabs(car->throttle < 0.01f) && car->gear)
 		friction = (CP_M_2_QU * CP_M_2_QU * (car->rpm - CP_RPM_MIN) / 10.0f / ratio);// frictional torque
 
-	ratio *= CP_AXLEGEAR;
+	ratio *= car->axleGear;
 
 	torque *= 1.355818f; // Nm = kg*m^2/s^2
 	torque *= -ratio;
@@ -473,7 +473,7 @@ static void PM_TireBrakingForces( car_t *car, carPoint_t *points, int i, vec3_t 
 		return;
 	}
 
-	normalForce = CP_CURRENT_GRAVITY * (CP_FRAME_MASS + CP_WHEEL_MASS);
+	normalForce = CP_CURRENT_GRAVITY * (car->frameMass + car->wheelMass);
 	torque = throttle * normalForce * CP_SCOF * 0.6f * WHEEL_RADIUS;
 
 	if (points[i].w < 0.0f)


### PR DESCRIPTION
## Summary
- move frame and wheel mass, gear ratios and powerband values into `car_t`
- derive vehicle setup from these fields in `PM_InitializeVehicle`
- use per-vehicle RPM, torque and gearing in wheel force calculations

## Testing
- `make -C engine release BUILD_CLIENT=0 BUILD_SERVER=0 BUILD_GAME_SO=0`

------
https://chatgpt.com/codex/tasks/task_e_68c6fb3c183c8324a24485204b6d29af