### PR TITLE
Use vehicle maxHealth for player health and damage

### DIFF
--- a/engine/code/game/bg_physics.h
+++ b/engine/code/game/bg_physics.h
@@ -303,6 +303,7 @@ typedef struct {
 
     float	fuel;
 	float	maxFuel;
+	int		maxHealth;
 	qboolean	fuelLeak;
 
 	qboolean	preserveFuel;

--- a/engine/code/game/g_client.c
+++ b/engine/code/game/g_client.c
@@ -889,7 +889,6 @@ void ClientUserinfoChanged( int clientNum ) {
 	char	blueTeam[MAX_INFO_STRING];
     char    greenTeam[MAX_INFO_STRING];
     char    yellowTeam[MAX_INFO_STRING];
-	char	userinfo[MAX_INFO_STRING];
 
 	ent = g_entities + clientNum;
 	client = ent->client;
@@ -1335,7 +1334,6 @@ void ClientSpawn(gentity_t *ent) {
 //	char	*savedAreaBits;
 	int		accuracy_hits, accuracy_shots;
 	int		eventSequence;
-	char	userinfo[MAX_INFO_STRING];
 // STONELANCE
 	int		savedFinishRaceTime;
 	int		savedDamageTaken;
@@ -1485,17 +1483,14 @@ void ClientSpawn(gentity_t *ent) {
 	client->ps.persistant[PERS_SPAWN_COUNT]++;
 	client->ps.persistant[PERS_TEAM] = client->sess.sessionTeam;
 
-	client->airOutTime = level.time + 12000;
+       client->airOutTime = level.time + 12000;
 
-	trap_GetUserinfo( index, userinfo, sizeof(userinfo) );
-	// set max health
-	client->pers.maxHealth = atoi( Info_ValueForKey( userinfo, "handicap" ) );
-	if ( client->pers.maxHealth < 1 || client->pers.maxHealth > 100 ) {
-		client->pers.maxHealth = 100;
-	}
-	// clear entity values
-       client->ps.stats[STAT_MAX_HEALTH] = client->pers.maxHealth;
-       client->ps.eFlags = flags;
+       // set max health from vehicle setup
+       client->car.maxHealth = g_vehicleHealth.integer;
+       client->pers.maxHealth = client->car.maxHealth;
+       // clear entity values
+      client->ps.stats[STAT_MAX_HEALTH] = client->pers.maxHealth;
+      client->ps.eFlags = flags;
        ent->s.eFlags &= ~EF_HEADLIGHTS;
        if ( client->sess.headlights ) {
                client->ps.extra_eFlags |= CF_HEADLIGHTS;
@@ -1550,7 +1545,7 @@ client->ps.stats[STAT_WEAPONS] = ( 1u << WP_DERBY_RAM );
         }
 
 	// health will count down towards max_health
-	ent->health = client->ps.stats[STAT_HEALTH] = client->ps.stats[STAT_MAX_HEALTH] + 25;
+       ent->health = client->ps.stats[STAT_HEALTH] = client->car.maxHealth + 25;
 
 	G_SetOrigin( ent, spawn_origin );
 	VectorCopy( spawn_origin, client->ps.origin );

--- a/engine/code/game/g_combat.c
+++ b/engine/code/game/g_combat.c
@@ -959,7 +959,7 @@ void G_Damage( gentity_t *targ, gentity_t *inflictor, gentity_t *attacker,
 	// reduce damage by the attacker's handicap value
 	// unless they are rocket jumping
 	if ( attacker->client && attacker != targ ) {
-		max = attacker->client->ps.stats[STAT_MAX_HEALTH];
+max = attacker->client->car.maxHealth;
 #ifdef MISSIONPACK
 		if( bg_itemlist[attacker->client->ps.stats[STAT_PERSISTANT_POWERUP]].giTag == PW_GUARD ) {
 			max /= 2;
@@ -1169,7 +1169,7 @@ void G_Damage( gentity_t *targ, gentity_t *inflictor, gentity_t *attacker,
 		if ( targ->client ) {
 			targ->client->ps.stats[STAT_HEALTH] = targ->health;
 			if ( !targ->client->car.fuelLeak ) {
-				int leakThreshold = g_vehicleHealth.integer / 4;
+int leakThreshold = targ->client->car.maxHealth / 4;
 				if ( targ->health > 0 && targ->health <= leakThreshold ) {
 					targ->client->car.fuelLeak = qtrue;
 				}

--- a/engine/code/game/g_items.c
+++ b/engine/code/game/g_items.c
@@ -129,74 +129,47 @@ int Pickup_Powerup( gentity_t *ent, gentity_t *other ) {
 
 #ifdef MISSIONPACK
 int Pickup_PersistantPowerup( gentity_t *ent, gentity_t *other ) {
-	int		clientNum;
-	char	userinfo[MAX_INFO_STRING];
-	float	handicap;
+
 	int		max;
 
 	other->client->ps.stats[STAT_PERSISTANT_POWERUP] = ent->item - bg_itemlist;
-	other->client->persistantPowerup = ent;
+        other->client->persistantPowerup = ent;
 
-	switch( ent->item->giTag ) {
-	case PW_GUARD:
-		clientNum = other->client->ps.clientNum;
-		trap_GetUserinfo( clientNum, userinfo, sizeof(userinfo) );
-		handicap = atof( Info_ValueForKey( userinfo, "handicap" ) );
-		if( handicap<=0.0f || handicap>100.0f) {
-			handicap = 100.0f;
-		}
-		max = (int)(2 *	 handicap);
+        switch( ent->item->giTag ) {
+        case PW_GUARD:
+                max = 2 * other->client->car.maxHealth;
 
-		other->health = max;
-		other->client->ps.stats[STAT_HEALTH] = max;
-		other->client->ps.stats[STAT_MAX_HEALTH] = max;
-		other->client->ps.stats[STAT_ARMOR] = max;
-		other->client->pers.maxHealth = max;
+                other->health = max;
+                other->client->ps.stats[STAT_HEALTH] = max;
+                other->client->car.maxHealth = max;
+                other->client->ps.stats[STAT_MAX_HEALTH] = max;
+                other->client->ps.stats[STAT_ARMOR] = max;
+                other->client->pers.maxHealth = other->client->car.maxHealth;
 
-		break;
+                break;
 
-	case PW_SCOUT:
-		clientNum = other->client->ps.clientNum;
-		trap_GetUserinfo( clientNum, userinfo, sizeof(userinfo) );
-		handicap = atof( Info_ValueForKey( userinfo, "handicap" ) );
-		if( handicap<=0.0f || handicap>100.0f) {
-			handicap = 100.0f;
-		}
-		other->client->pers.maxHealth = handicap;
-		other->client->ps.stats[STAT_ARMOR] = 0;
-		break;
+        case PW_SCOUT:
+                other->client->pers.maxHealth = other->client->car.maxHealth;
+                other->client->ps.stats[STAT_MAX_HEALTH] = other->client->pers.maxHealth;
+                other->client->ps.stats[STAT_ARMOR] = 0;
+                break;
 
-	case PW_DOUBLER:
-		clientNum = other->client->ps.clientNum;
-		trap_GetUserinfo( clientNum, userinfo, sizeof(userinfo) );
-		handicap = atof( Info_ValueForKey( userinfo, "handicap" ) );
-		if( handicap<=0.0f || handicap>100.0f) {
-			handicap = 100.0f;
-		}
-		other->client->pers.maxHealth = handicap;
-		break;
-	case PW_AMMOREGEN:
-		clientNum = other->client->ps.clientNum;
-		trap_GetUserinfo( clientNum, userinfo, sizeof(userinfo) );
-		handicap = atof( Info_ValueForKey( userinfo, "handicap" ) );
-		if( handicap<=0.0f || handicap>100.0f) {
-			handicap = 100.0f;
-		}
-		other->client->pers.maxHealth = handicap;
-		memset(other->client->ammoTimes, 0, sizeof(other->client->ammoTimes));
-		break;
-	default:
-		clientNum = other->client->ps.clientNum;
-		trap_GetUserinfo( clientNum, userinfo, sizeof(userinfo) );
-		handicap = atof( Info_ValueForKey( userinfo, "handicap" ) );
-		if( handicap<=0.0f || handicap>100.0f) {
-			handicap = 100.0f;
-		}
-		other->client->pers.maxHealth = handicap;
-		break;
-	}
+        case PW_DOUBLER:
+                other->client->pers.maxHealth = other->client->car.maxHealth;
+                other->client->ps.stats[STAT_MAX_HEALTH] = other->client->pers.maxHealth;
+                break;
+        case PW_AMMOREGEN:
+                other->client->pers.maxHealth = other->client->car.maxHealth;
+                other->client->ps.stats[STAT_MAX_HEALTH] = other->client->pers.maxHealth;
+                memset(other->client->ammoTimes, 0, sizeof(other->client->ammoTimes));
+                break;
+        default:
+                other->client->pers.maxHealth = other->client->car.maxHealth;
+                other->client->ps.stats[STAT_MAX_HEALTH] = other->client->pers.maxHealth;
+                break;
+        }
 
-	return -1;
+        return -1;
 }
 
 //======================================================================
@@ -315,16 +288,16 @@ int Pickup_Health (gentity_t *ent, gentity_t *other) {
 
 	// small and mega healths will go over the max
 #ifdef MISSIONPACK
-	if( bg_itemlist[other->client->ps.stats[STAT_PERSISTANT_POWERUP]].giTag == PW_GUARD ) {
-		max = other->client->ps.stats[STAT_MAX_HEALTH];
-	}
-	else
+        if( bg_itemlist[other->client->ps.stats[STAT_PERSISTANT_POWERUP]].giTag == PW_GUARD ) {
+                max = other->client->car.maxHealth;
+        }
+        else
 #endif
-	if ( ent->item->quantity != 5 && ent->item->quantity != 100 ) {
-		max = other->client->ps.stats[STAT_MAX_HEALTH];
-	} else {
-		max = other->client->ps.stats[STAT_MAX_HEALTH] * 2;
-	}
+        if ( ent->item->quantity != 5 && ent->item->quantity != 100 ) {
+                max = other->client->car.maxHealth;
+        } else {
+                max = other->client->car.maxHealth * 2;
+        }
 
 	if ( ent->count ) {
 		quantity = ent->count;
@@ -338,10 +311,10 @@ int Pickup_Health (gentity_t *ent, gentity_t *other) {
 		other->health = max;
 	}
 	other->client->ps.stats[STAT_HEALTH] = other->health;
-	if ( other->client->car.fuelLeak &&
-		other->health > g_vehicleHealth.integer / 2 ) {
-		other->client->car.fuelLeak = qfalse;
-	}
+        if ( other->client->car.fuelLeak &&
+                other->health > other->client->car.maxHealth / 2 ) {
+                other->client->car.fuelLeak = qfalse;
+        }
 
 
 	if ( ent->item->quantity == 100 ) {		// mega health respawns slow
@@ -359,21 +332,21 @@ int Pickup_Armor( gentity_t *ent, gentity_t *other ) {
 
 	other->client->ps.stats[STAT_ARMOR] += ent->item->quantity;
 
-	if( other->client && bg_itemlist[other->client->ps.stats[STAT_PERSISTANT_POWERUP]].giTag == PW_GUARD ) {
-		upperBound = other->client->ps.stats[STAT_MAX_HEALTH];
-	}
-	else {
-		upperBound = other->client->ps.stats[STAT_MAX_HEALTH] * 2;
-	}
+        if( other->client && bg_itemlist[other->client->ps.stats[STAT_PERSISTANT_POWERUP]].giTag == PW_GUARD ) {
+                upperBound = other->client->car.maxHealth;
+        }
+        else {
+                upperBound = other->client->car.maxHealth * 2;
+        }
 
 	if ( other->client->ps.stats[STAT_ARMOR] > upperBound ) {
 		other->client->ps.stats[STAT_ARMOR] = upperBound;
 	}
 #else
-	other->client->ps.stats[STAT_ARMOR] += ent->item->quantity;
-	if ( other->client->ps.stats[STAT_ARMOR] > other->client->ps.stats[STAT_MAX_HEALTH] * 2 ) {
-		other->client->ps.stats[STAT_ARMOR] = other->client->ps.stats[STAT_MAX_HEALTH] * 2;
-	}
+        other->client->ps.stats[STAT_ARMOR] += ent->item->quantity;
+        if ( other->client->ps.stats[STAT_ARMOR] > other->client->car.maxHealth * 2 ) {
+                other->client->ps.stats[STAT_ARMOR] = other->client->car.maxHealth * 2;
+        }
 #endif
 
 	return RESPAWN_ARMOR;


### PR DESCRIPTION
## Summary
- add `maxHealth` field to `car_t` so vehicles track their own durability
- initialize `pers.maxHealth` and player health from the vehicle's `maxHealth`
- base damage scaling, repairs and armor limits on `car->maxHealth`

## Testing
- `make` *(fails: SDL_version.h: No such file or directory)*


------
https://chatgpt.com/codex/tasks/task_e_68c6fe1ef410832490fe99d88229924b