### PR TITLE
Add vehicle attribute configuration and syncing

### DIFF
--- a/baseq3r/models/players/alpine/vehicle.cfg
+++ b/baseq3r/models/players/alpine/vehicle.cfg
@@ -1,0 +1,4 @@
+frameMass 300
+wheelMass 50
+torque 400
+fuelConsumption 1

--- a/baseq3r/models/players/camaro/vehicle.cfg
+++ b/baseq3r/models/players/camaro/vehicle.cfg
@@ -1,0 +1,4 @@
+frameMass 300
+wheelMass 50
+torque 400
+fuelConsumption 1

--- a/baseq3r/models/players/gravelord/vehicle.cfg
+++ b/baseq3r/models/players/gravelord/vehicle.cfg
@@ -1,0 +1,4 @@
+frameMass 300
+wheelMass 50
+torque 400
+fuelConsumption 1

--- a/baseq3r/models/players/gremlin/vehicle.cfg
+++ b/baseq3r/models/players/gremlin/vehicle.cfg
@@ -1,0 +1,4 @@
+frameMass 300
+wheelMass 50
+torque 400
+fuelConsumption 1

--- a/baseq3r/models/players/macdaddy/vehicle.cfg
+++ b/baseq3r/models/players/macdaddy/vehicle.cfg
@@ -1,0 +1,4 @@
+frameMass 300
+wheelMass 50
+torque 400
+fuelConsumption 1

--- a/baseq3r/models/players/mini/vehicle.cfg
+++ b/baseq3r/models/players/mini/vehicle.cfg
@@ -1,0 +1,4 @@
+frameMass 300
+wheelMass 50
+torque 400
+fuelConsumption 1

--- a/baseq3r/models/players/murcielago/vehicle.cfg
+++ b/baseq3r/models/players/murcielago/vehicle.cfg
@@ -1,0 +1,4 @@
+frameMass 300
+wheelMass 50
+torque 400
+fuelConsumption 1

--- a/baseq3r/models/players/raptor/vehicle.cfg
+++ b/baseq3r/models/players/raptor/vehicle.cfg
@@ -1,0 +1,4 @@
+frameMass 300
+wheelMass 50
+torque 400
+fuelConsumption 1

--- a/baseq3r/models/players/reaper/vehicle.cfg
+++ b/baseq3r/models/players/reaper/vehicle.cfg
@@ -1,0 +1,4 @@
+frameMass 300
+wheelMass 50
+torque 400
+fuelConsumption 1

--- a/baseq3r/models/players/roadster/vehicle.cfg
+++ b/baseq3r/models/players/roadster/vehicle.cfg
@@ -1,0 +1,4 @@
+frameMass 300
+wheelMass 50
+torque 400
+fuelConsumption 1

--- a/baseq3r/models/players/sidepipe/vehicle.cfg
+++ b/baseq3r/models/players/sidepipe/vehicle.cfg
@@ -1,0 +1,4 @@
+frameMass 300
+wheelMass 50
+torque 400
+fuelConsumption 1

--- a/baseq3r/models/players/slingshot/vehicle.cfg
+++ b/baseq3r/models/players/slingshot/vehicle.cfg
@@ -1,0 +1,4 @@
+frameMass 300
+wheelMass 50
+torque 400
+fuelConsumption 1

--- a/baseq3r/models/players/viper/vehicle.cfg
+++ b/baseq3r/models/players/viper/vehicle.cfg
@@ -1,0 +1,4 @@
+frameMass 300
+wheelMass 50
+torque 400
+fuelConsumption 1

--- a/engine/code/cgame/cg_local.h
+++ b/engine/code/cgame/cg_local.h
@@ -524,6 +524,11 @@ typedef struct {
 	qboolean		oppositeRoll;
 
 	int				position;
+	// vehicle attributes
+	float			 frameMass;
+	float			 wheelMass;
+	float			 fuelConsumption;
+	float			 torque;
 // Q3Rally Code END
 } clientInfo_t;
 
@@ -1455,6 +1460,11 @@ extern	vmCvar_t		cg_mmap_size;
 extern	vmCvar_t		cg_mmap_renderLevel;
 extern	vmCvar_t		cg_checkpointArrowMode;
 extern      vmCvar_t                cg_distanceFormat;
+extern  vmCvar_t                cg_vehicleMass;
+extern  vmCvar_t                cg_wheelMass;
+extern  vmCvar_t                cg_fuelConsumption;
+extern  vmCvar_t                cg_torque;
+
 
 extern	vmCvar_t		cg_atmosphericLevel;
 extern	vmCvar_t		cg_developer;

--- a/engine/code/cgame/cg_main.c
+++ b/engine/code/cgame/cg_main.c
@@ -257,6 +257,10 @@ vmCvar_t	cg_minSkidLength;
 vmCvar_t	cg_drawRearView;
 vmCvar_t        cg_checkpointArrowMode;
 vmCvar_t        cg_distanceFormat;
+vmCvar_t        cg_vehicleMass;
+vmCvar_t        cg_wheelMass;
+vmCvar_t        cg_fuelConsumption;
+vmCvar_t        cg_torque;
 vmCvar_t        cg_drawMMap;	//TBB - minimap cvar
 vmCvar_t	cg_mmap_fov;
 vmCvar_t	cg_mmap_size;
@@ -371,6 +375,10 @@ static cvarTable_t cvarTable[] = {
 	{ &cg_manualShift, "cg_manualShift", "0", CVAR_ARCHIVE | CVAR_USERINFO },
 	{ &cg_checkpointArrowMode, "cg_checkpointArrowMode", "1", CVAR_ARCHIVE },
         { &cg_distanceFormat, "cg_distanceFormat", "0", CVAR_ARCHIVE },
+        { &cg_vehicleMass, "cg_vehicleMass", "0", CVAR_USERINFO | CVAR_ROM },
+        { &cg_wheelMass, "cg_wheelMass", "0", CVAR_USERINFO | CVAR_ROM },
+        { &cg_fuelConsumption, "cg_fuelConsumption", "0", CVAR_USERINFO | CVAR_ROM },
+        { &cg_torque, "cg_torque", "0", CVAR_USERINFO | CVAR_ROM },
 
         { &cg_developer, "developer", "0", 0 },
 

--- a/engine/code/cgame/cg_players.c
+++ b/engine/code/cgame/cg_players.c
@@ -184,6 +184,72 @@ static qboolean	CG_ParseAnimationFile( const char *filename, clientInfo_t *ci ) 
 // END
 #endif
 
+static void CG_ParseVehicleFile( const char *filename, clientInfo_t *ci ) {
+    char    *text_p;
+    char    *token;
+    char    text[20000];
+    fileHandle_t f;
+    int     len;
+
+    // defaults
+    ci->frameMass = 300.0f;
+    ci->wheelMass = 50.0f;
+    ci->fuelConsumption = 1.0f;
+    ci->torque = 400.0f;
+
+    len = trap_FS_FOpenFile( filename, &f, FS_READ );
+    if ( len <= 0 ) {
+        return;
+    }
+    if ( len >= sizeof( text ) - 1 ) {
+        trap_FS_FCloseFile( f );
+        return;
+    }
+    trap_FS_Read( text, len, f );
+    text[len] = 0;
+    trap_FS_FCloseFile( f );
+
+    text_p = text;
+    while ( 1 ) {
+        token = COM_Parse( &text_p );
+        if ( !token || !token[0] ) {
+            break;
+        }
+        if ( !Q_stricmp( token, "frameMass" ) ) {
+            token = COM_Parse( &text_p );
+            if ( token && token[0] ) {
+                ci->frameMass = atof( token );
+            }
+        } else if ( !Q_stricmp( token, "wheelMass" ) ) {
+            token = COM_Parse( &text_p );
+            if ( token && token[0] ) {
+                ci->wheelMass = atof( token );
+            }
+        } else if ( !Q_stricmp( token, "fuelConsumption" ) ) {
+            token = COM_Parse( &text_p );
+            if ( token && token[0] ) {
+                ci->fuelConsumption = atof( token );
+            }
+        } else if ( !Q_stricmp( token, "torque" ) ) {
+            token = COM_Parse( &text_p );
+            if ( token && token[0] ) {
+                ci->torque = atof( token );
+            }
+        }
+    }
+
+    if ( ci->clientNum == cg.clientNum ) {
+        trap_Cvar_Set( "cg_vehicleMass", va( "%f", ci->frameMass ) );
+        trap_Cvar_Set( "cg_wheelMass", va( "%f", ci->wheelMass ) );
+        trap_Cvar_Set( "cg_fuelConsumption", va( "%f", ci->fuelConsumption ) );
+        trap_Cvar_Set( "cg_torque", va( "%f", ci->torque ) );
+        cg.car.frameMass = ci->frameMass;
+        cg.car.wheelMass = ci->wheelMass;
+        cg.car.fuelConsumption = ci->fuelConsumption;
+        cg.car.torquePeak = ci->torque;
+    }
+}
+
 // SKWID( removed function )
 /*
 static qboolean	CG_ParseAnimationFile( const char *filename, clientInfo_t *ci ) {
@@ -905,6 +971,8 @@ static qboolean CG_RegisterClientModelname( clientInfo_t *ci, const char *modelN
 	}
 // END
 
+	Com_sprintf( filename, sizeof( filename ), "models/players/%s/vehicle.cfg", modelName );
+	CG_ParseVehicleFile( filename, ci );
 	return qtrue;
 }
 

--- a/engine/code/game/g_client.c
+++ b/engine/code/game/g_client.c
@@ -1032,13 +1032,30 @@ void ClientUserinfoChanged( int clientNum ) {
 		client->pers.controlMode = atoi( s );
 	}
 
-	s = Info_ValueForKey( userinfo, "cg_manualShift" );
-	if ( *s ) {
-		client->pers.manualShift = atoi( s );
-	}
+        s = Info_ValueForKey( userinfo, "cg_manualShift" );
+        if ( *s ) {
+                client->pers.manualShift = atoi( s );
+        }
 
-	// team task (0 = none, 1 = offence, 2 = defence)
-	teamTask = atoi(Info_ValueForKey(userinfo, "teamtask"));
+        s = Info_ValueForKey( userinfo, "cg_vehicleMass" );
+        if ( *s ) {
+                client->car.frameMass = atof( s );
+        }
+        s = Info_ValueForKey( userinfo, "cg_wheelMass" );
+        if ( *s ) {
+                client->car.wheelMass = atof( s );
+        }
+        s = Info_ValueForKey( userinfo, "cg_fuelConsumption" );
+        if ( *s ) {
+                client->car.fuelConsumption = atof( s );
+        }
+        s = Info_ValueForKey( userinfo, "cg_torque" );
+        if ( *s ) {
+                client->car.torquePeak = atof( s );
+        }
+
+        // team task (0 = none, 1 = offence, 2 = defence)
+        teamTask = atoi(Info_ValueForKey(userinfo, "teamtask"));
 	// team Leader (1 = leader, 0 is normal player)
 	teamLeader = client->sess.teamLeader;
 


### PR DESCRIPTION
## Summary
- add `vehicle.cfg` files for each car with mass, wheel mass, torque and fuel consumption
- parse `vehicle.cfg` on the client and send values to the server via userinfo
- populate server `car_t` fields from userinfo with sensible defaults

## Testing
- `cd engine && make` *(fails: SDL_version.h missing)*

------
https://chatgpt.com/codex/tasks/task_e_68c700687c208324a0fbd0e67ab58dca