### PR TITLE
Add server-side vehicle balancing controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,21 @@ Q3Rally is a standalone game based on ioquake3.
 
 For compiling, see [engine/README.md](engine/README.md).
 
+## Vehicle balancing
+
+Servers can enforce basic balancing rules for custom vehicles. Two cvars
+control the allowed spread of key vehicle attributes:
+
+* `g_vehicleHpMaxRatio` – maximum allowed ratio between the highest and
+  lowest horsepower peak among all cars (default `1.2`).
+* `g_vehicleHealthMaxRatio` – maximum allowed ratio between the highest
+  and lowest maximum health (default `1.5`).
+
+Typical vehicles ship with an `hpPeak` around 320 and `maxHealth` near 100.
+Allowing a ratio between `1.0`–`1.5` for horsepower and `1.0`–`2.0` for
+health keeps racing competitive while still permitting variety. Admins are
+free to tweak these cvars to fit their custom vehicle sets.
+
 ## Resources
 
 * [Q3Rally Website](http://www.q3rally.com)

--- a/engine/code/game/g_client.c
+++ b/engine/code/game/g_client.c
@@ -1100,6 +1100,7 @@ void ClientUserinfoChanged( int clientNum ) {
 
 	// this is not the userinfo, more like the configstring actually
 	G_LogPrintf( "ClientUserinfoChanged: %i %s\n", clientNum, s );
+	G_BalanceVehicleStats();
 }
 
 
@@ -1740,12 +1741,14 @@ if (client->ps.stats[STAT_WEAPONS] & (1u << i)) {
 	ClientThink( ent-g_entities );
 	// run the presend to set anything else, follow spectators wait
 	// until all clients have been reconnected after map_restart
-	if ( ent->client->sess.spectatorState != SPECTATOR_FOLLOW ) {
-		ClientEndFrame( ent );
-	}
+        if ( ent->client->sess.spectatorState != SPECTATOR_FOLLOW ) {
+                ClientEndFrame( ent );
+        }
 
-	// clear entity state values
-	BG_PlayerStateToEntityState( &client->ps, &ent->s, qtrue );
+        G_BalanceVehicleStats();
+
+        // clear entity state values
+        BG_PlayerStateToEntityState( &client->ps, &ent->s, qtrue );
 }
 
 

--- a/engine/code/game/g_local.h
+++ b/engine/code/game/g_local.h
@@ -807,6 +807,7 @@ void Cmd_RacePositions_f( void );
 void Cmd_Times_f( gentity_t *ent );
 gentity_t *SelectLastMarkerForSpawn( gentity_t *ent, vec3_t origin, vec3_t angles, qboolean isbot );
 gentity_t *SelectGridPositionSpawn( gentity_t *ent, vec3_t origin, vec3_t angles, qboolean isbot );
+void G_BalanceVehicleStats( void );
 
 //
 // g_rally_rearweapon.c
@@ -1009,6 +1010,8 @@ extern	vmCvar_t	g_damageScale;
 extern	vmCvar_t	g_vehicleDamageScale;
 extern  vmCvar_t        g_vehicleDamageOffset;
 extern	vmCvar_t	g_vehicleHealth;
+extern	vmCvar_t	g_vehicleHpMaxRatio;
+extern	vmCvar_t	g_vehicleHealthMaxRatio;
 extern  vmCvar_t        g_derbyDamageFactor;
 extern  vmCvar_t        g_derbyRammerDamageRatio;
 extern  vmCvar_t        g_derbyIgnoreDamageScale;

--- a/engine/code/game/g_main.c
+++ b/engine/code/game/g_main.c
@@ -114,6 +114,8 @@ vmCvar_t	g_damageScale;
 vmCvar_t	g_vehicleDamageScale;
 vmCvar_t        g_vehicleDamageOffset;
 vmCvar_t	g_vehicleHealth;
+vmCvar_t	g_vehicleHpMaxRatio;
+vmCvar_t	g_vehicleHealthMaxRatio;
 vmCvar_t        g_derbyDamageFactor;
 vmCvar_t        g_derbyRammerDamageRatio;
 vmCvar_t        g_derbyIgnoreDamageScale;
@@ -273,6 +275,8 @@ static cvarTable_t		gameCvarTable[] = {
         { &g_vehicleDamageScale, "g_vehicleDamageScale", "5.0", CVAR_ARCHIVE, 0, qfalse },
         { &g_vehicleDamageOffset, "g_vehicleDamageOffset", "0", CVAR_ARCHIVE, 0, qfalse },
         { &g_vehicleHealth, "g_vehicleHealth", "100", CVAR_ARCHIVE, 0, qfalse },
+        { &g_vehicleHpMaxRatio, "g_vehicleHpMaxRatio", "1.2", CVAR_ARCHIVE, 0, qfalse },
+        { &g_vehicleHealthMaxRatio, "g_vehicleHealthMaxRatio", "1.5", CVAR_ARCHIVE, 0, qfalse },
         { &g_derbyDamageFactor, "g_derbyDamageFactor", "1.0", CVAR_ARCHIVE, 0, qfalse },
         { &g_derbyRammerDamageRatio, "g_derbyRammerDamageRatio", "1.0", CVAR_ARCHIVE, 0, qfalse },
         { &g_derbyIgnoreDamageScale, "g_derbyIgnoreDamageScale", "0", CVAR_ARCHIVE, 0, qfalse },


### PR DESCRIPTION
## Summary
- add balancing routine to normalize vehicle horsepower and health
- expose `g_vehicleHpMaxRatio` and `g_vehicleHealthMaxRatio` cvars for tuning
- document recommended ranges for custom vehicle sets

## Testing
- `make` *(fails: SDL_version.h missing)*
- `apt-get update` *(fails: repository 403)*

------
https://chatgpt.com/codex/tasks/task_e_68c70409709c8324b3d3a14d48a80bb4