### PR TITLE
Declare userinfo array in ClientUserinfoChanged

### DIFF
--- a/engine/code/game/g_client.c
+++ b/engine/code/game/g_client.c
@@ -875,6 +875,7 @@ void ClientUserinfoChanged( int clientNum ) {
 	char	*s;
 	char	model[MAX_QPATH];
 	char	headModel[MAX_QPATH];
+	char	userinfo[MAX_INFO_STRING];
 // STONELANCE
 	char	rim[MAX_QPATH];
 	char	plate[MAX_QPATH];


### PR DESCRIPTION
## Summary
- Fix undeclared variable error by declaring `userinfo` in `ClientUserinfoChanged`.

## Testing
- `cd engine && make BUILD_CLIENT=0`


------
https://chatgpt.com/codex/tasks/task_e_68c70a0947b8832484d18373d66ec26c