### PR TITLE
Avoid vehicle reinitialization during noclip

### DIFF
--- a/engine/code/game/bg_pmove.c
+++ b/engine/code/game/bg_pmove.c
@@ -961,8 +961,13 @@ static void PM_NoclipMove( void ) {
 	VectorMA (pm->ps->origin, pml.frametime, pm->ps->velocity, pm->ps->origin);
 
 // STONELANCE
-	pm->ps->viewangles[YAW] = pm->ps->damageAngles[YAW];
-	PM_InitializeVehicle(pm->car, pm->ps->origin, pm->ps->viewangles, pm->ps->velocity /* , pm->car_frontweight_dist */ );
+       pm->ps->viewangles[YAW] = pm->ps->damageAngles[YAW];
+       // PM_InitializeVehicle resets the entire car state, including fuel.
+       // Calling it every frame while noclipping prevented fuel usage from
+       // persisting between frames. The vehicle should only be fully
+       // reinitialized when a reset is explicitly requested, so avoid calling
+       // it here.
+       // PM_InitializeVehicle(pm->car, pm->ps->origin, pm->ps->viewangles, pm->ps->velocity);
 // END
 }
 


### PR DESCRIPTION
## Summary
- Avoid resetting the car every frame during noclip movement

## Testing
- `make -C engine release BUILD_GAME_SO=0 BUILD_SERVER=0` *(fails: SDL_version.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68c71a5ba5ac832495d02f11fc556208