### PR TITLE
Sync fuel consumption values with server on respawn

### DIFF
--- a/engine/code/cgame/cg_players.c
+++ b/engine/code/cgame/cg_players.c
@@ -242,6 +242,7 @@ static void CG_ParseVehicleFile( const char *filename, clientInfo_t *ci ) {
         trap_Cvar_Set( "cg_vehicleMass", va( "%f", ci->frameMass ) );
         trap_Cvar_Set( "cg_wheelMass", va( "%f", ci->wheelMass ) );
         trap_Cvar_Set( "cg_fuelConsumption", va( "%f", ci->fuelConsumption ) );
+        trap_SendConsoleCommand( va( "setu cg_fuelConsumption %f\n", ci->fuelConsumption ) );
         trap_Cvar_Set( "cg_torque", va( "%f", ci->torque ) );
         cg.car.frameMass = ci->frameMass;
         cg.car.wheelMass = ci->wheelMass;

--- a/engine/code/game/g_client.c
+++ b/engine/code/game/g_client.c
@@ -1497,8 +1497,9 @@ void ClientSpawn(gentity_t *ent) {
 	for ( i = 0 ; i < MAX_PERSISTANT ; i++ ) {
 		client->ps.persistant[i] = persistant[i];
 	}
-	client->ps.eventSequence = eventSequence;
-	// increment the spawncount so the client will detect the respawn
+        client->ps.eventSequence = eventSequence;
+        ClientUserinfoChanged( index );
+        // increment the spawncount so the client will detect the respawn
 	client->ps.persistant[PERS_SPAWN_COUNT]++;
 	client->ps.persistant[PERS_TEAM] = client->sess.sessionTeam;
 


### PR DESCRIPTION
## Summary
- forward updated cg_fuelConsumption to server when player info loads
- refresh userinfo after respawn so car fuel consumption stays in sync

## Testing
- `make` *(fails: SDL_version.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68c72442de688324854a12902ba816be