### PR TITLE
feat: add vehicle damage tolerance

### DIFF
--- a/baseq3r/models/players/alpine/vehicle.cfg
+++ b/baseq3r/models/players/alpine/vehicle.cfg
@@ -2,3 +2,4 @@ frameMass 300
 wheelMass 50
 torque 400
 fuelConsumption 1
+damageTolerance 1

--- a/baseq3r/models/players/camaro/vehicle.cfg
+++ b/baseq3r/models/players/camaro/vehicle.cfg
@@ -2,3 +2,4 @@ frameMass 300
 wheelMass 50
 torque 400
 fuelConsumption 1
+damageTolerance 1

--- a/baseq3r/models/players/gravelord/vehicle.cfg
+++ b/baseq3r/models/players/gravelord/vehicle.cfg
@@ -2,3 +2,4 @@ frameMass 300
 wheelMass 50
 torque 400
 fuelConsumption 1
+damageTolerance 1

--- a/baseq3r/models/players/gremlin/vehicle.cfg
+++ b/baseq3r/models/players/gremlin/vehicle.cfg
@@ -2,3 +2,4 @@ frameMass 300
 wheelMass 50
 torque 400
 fuelConsumption 1
+damageTolerance 1

--- a/baseq3r/models/players/macdaddy/vehicle.cfg
+++ b/baseq3r/models/players/macdaddy/vehicle.cfg
@@ -2,3 +2,4 @@ frameMass 300
 wheelMass 50
 torque 400
 fuelConsumption 1
+damageTolerance 1

--- a/baseq3r/models/players/mini/vehicle.cfg
+++ b/baseq3r/models/players/mini/vehicle.cfg
@@ -2,3 +2,4 @@ frameMass 300
 wheelMass 50
 torque 400
 fuelConsumption 1
+damageTolerance 1

--- a/baseq3r/models/players/murcielago/vehicle.cfg
+++ b/baseq3r/models/players/murcielago/vehicle.cfg
@@ -2,3 +2,4 @@ frameMass 300
 wheelMass 50
 torque 400
 fuelConsumption 1
+damageTolerance 1

--- a/baseq3r/models/players/raptor/vehicle.cfg
+++ b/baseq3r/models/players/raptor/vehicle.cfg
@@ -2,3 +2,4 @@ frameMass 300
 wheelMass 50
 torque 400
 fuelConsumption 1
+damageTolerance 1

--- a/baseq3r/models/players/reaper/vehicle.cfg
+++ b/baseq3r/models/players/reaper/vehicle.cfg
@@ -2,3 +2,4 @@ frameMass 300
 wheelMass 50
 torque 400
 fuelConsumption 1
+damageTolerance 1

--- a/baseq3r/models/players/roadster/vehicle.cfg
+++ b/baseq3r/models/players/roadster/vehicle.cfg
@@ -2,3 +2,4 @@ frameMass 300
 wheelMass 50
 torque 400
 fuelConsumption 1
+damageTolerance 1

--- a/baseq3r/models/players/sidepipe/vehicle.cfg
+++ b/baseq3r/models/players/sidepipe/vehicle.cfg
@@ -2,3 +2,4 @@ frameMass 300
 wheelMass 50
 torque 400
 fuelConsumption 1
+damageTolerance 1

--- a/baseq3r/models/players/slingshot/vehicle.cfg
+++ b/baseq3r/models/players/slingshot/vehicle.cfg
@@ -2,3 +2,4 @@ frameMass 300
 wheelMass 50
 torque 400
 fuelConsumption 1
+damageTolerance 1

--- a/baseq3r/models/players/viper/vehicle.cfg
+++ b/baseq3r/models/players/viper/vehicle.cfg
@@ -2,3 +2,4 @@ frameMass 300
 wheelMass 50
 torque 400
 fuelConsumption 1
+damageTolerance 1

--- a/engine/code/cgame/cg_local.h
+++ b/engine/code/cgame/cg_local.h
@@ -529,6 +529,7 @@ typedef struct {
 	float			 wheelMass;
 	float			 fuelConsumption;
 	float			 torque;
+        float                    damageTolerance;
 // Q3Rally Code END
 } clientInfo_t;
 
@@ -1464,6 +1465,7 @@ extern  vmCvar_t                cg_vehicleMass;
 extern  vmCvar_t                cg_wheelMass;
 extern  vmCvar_t                cg_fuelConsumption;
 extern  vmCvar_t                cg_torque;
+extern	vmCvar_t		cg_damageTolerance;
 
 
 extern	vmCvar_t		cg_atmosphericLevel;

--- a/engine/code/cgame/cg_main.c
+++ b/engine/code/cgame/cg_main.c
@@ -261,6 +261,7 @@ vmCvar_t        cg_vehicleMass;
 vmCvar_t        cg_wheelMass;
 vmCvar_t        cg_fuelConsumption;
 vmCvar_t        cg_torque;
+vmCvar_t        cg_damageTolerance;
 vmCvar_t        cg_drawMMap;	//TBB - minimap cvar
 vmCvar_t	cg_mmap_fov;
 vmCvar_t	cg_mmap_size;
@@ -379,6 +380,7 @@ static cvarTable_t cvarTable[] = {
         { &cg_wheelMass, "cg_wheelMass", "0", CVAR_USERINFO | CVAR_ROM },
         { &cg_fuelConsumption, "cg_fuelConsumption", "0", CVAR_USERINFO | CVAR_ROM },
         { &cg_torque, "cg_torque", "0", CVAR_USERINFO | CVAR_ROM },
+        { &cg_damageTolerance, "cg_damageTolerance", "1", CVAR_USERINFO | CVAR_ROM },
 
         { &cg_developer, "developer", "0", 0 },
 

--- a/engine/code/cgame/cg_players.c
+++ b/engine/code/cgame/cg_players.c
@@ -196,6 +196,7 @@ static void CG_ParseVehicleFile( const char *filename, clientInfo_t *ci ) {
     ci->wheelMass = 50.0f;
     ci->fuelConsumption = 1.0f;
     ci->torque = 400.0f;
+    ci->damageTolerance = 1.0f;
 
     len = trap_FS_FOpenFile( filename, &f, FS_READ );
     if ( len <= 0 ) {
@@ -235,6 +236,11 @@ static void CG_ParseVehicleFile( const char *filename, clientInfo_t *ci ) {
             if ( token && token[0] ) {
                 ci->torque = atof( token );
             }
+        } else if ( !Q_stricmp( token, "damageTolerance" ) ) {
+            token = COM_Parse( &text_p );
+            if ( token && token[0] ) {
+                ci->damageTolerance = atof( token );
+            }
         }
     }
 
@@ -244,10 +250,12 @@ static void CG_ParseVehicleFile( const char *filename, clientInfo_t *ci ) {
         trap_Cvar_Set( "cg_fuelConsumption", va( "%f", ci->fuelConsumption ) );
         trap_SendConsoleCommand( va( "setu cg_fuelConsumption %f\n", ci->fuelConsumption ) );
         trap_Cvar_Set( "cg_torque", va( "%f", ci->torque ) );
+        trap_Cvar_Set( "cg_damageTolerance", va( "%f", ci->damageTolerance ) );
         cg.car.frameMass = ci->frameMass;
         cg.car.wheelMass = ci->wheelMass;
         cg.car.fuelConsumption = ci->fuelConsumption;
         cg.car.torquePeak = ci->torque;
+        cg.car.damageTolerance = ci->damageTolerance;
     }
 }
 

--- a/engine/code/game/bg_physics.c
+++ b/engine/code/game/bg_physics.c
@@ -452,6 +452,7 @@ void PM_InitializeVehicle( car_t *car, vec3_t origin, vec3_t angles, vec3_t velo
         if (!car->hpPeak) car->hpPeak = 320.0f;
         if (!car->rpmHpPeak) car->rpmHpPeak = 5000.0f;
         if (!car->fuelConsumption) car->fuelConsumption = 1.0f;
+        if (!car->damageTolerance) car->damageTolerance = 1.0f;
 
 	VectorCopy(origin, car->sBody.r);
 	AnglesToOrientation(angles, car->sBody.t);

--- a/engine/code/game/bg_physics.h
+++ b/engine/code/game/bg_physics.h
@@ -280,6 +280,7 @@ typedef struct {
         float   hpPeak;
         float   rpmHpPeak;
         float   fuelConsumption;
+        float   damageTolerance;
 
         // FIXME: remove these to save memory if i can
 

--- a/engine/code/game/g_active.c
+++ b/engine/code/game/g_active.c
@@ -1526,17 +1526,19 @@ void ClientThink_real( gentity_t *ent ) {
 	ClientEvents( ent, oldEventSequence );
 
 // STONELANCE - do damage from pmove
-	if (pm.damage.damage)
-	{
-		if( !(pm.damage.dflags & DAMAGE_NO_PROTECTION) )
-			pm.damage.damage *= g_damageScale.value;
-		if ( g_gametype.integer == GT_DERBY && g_derbyIgnoreDamageScale.integer && g_damageScale.value )
-			pm.damage.damage /= g_damageScale.value;
+        if (pm.damage.damage)
+        {
+                if( !(pm.damage.dflags & DAMAGE_NO_PROTECTION) )
+                        pm.damage.damage *= g_damageScale.value;
+                if ( g_gametype.integer == GT_DERBY && g_derbyIgnoreDamageScale.integer && g_damageScale.value )
+                        pm.damage.damage /= g_damageScale.value;
 
-		if( pm.damage.damage > 0 )
-		{
-			if (pm.damage.otherEnt >= 0){
-				G_Damage(ent, NULL, &g_entities[pm.damage.otherEnt], pm.damage.dir, pm.damage.origin, pm.damage.damage, pm.damage.dflags, pm.damage.mod);
+                pm.damage.damage *= ent->client->car.damageTolerance;
+
+                if( pm.damage.damage > 0 )
+                {
+                        if (pm.damage.otherEnt >= 0){
+                                G_Damage(ent, NULL, &g_entities[pm.damage.otherEnt], pm.damage.dir, pm.damage.origin, pm.damage.damage, pm.damage.dflags, pm.damage.mod);
 				VectorInverse(pm.damage.dir);
 				G_Damage(&g_entities[pm.damage.otherEnt], NULL, ent, pm.damage.dir, pm.damage.origin, pm.damage.damage, pm.damage.dflags, pm.damage.mod);
 			}

--- a/engine/code/game/g_client.c
+++ b/engine/code/game/g_client.c
@@ -1054,6 +1054,10 @@ void ClientUserinfoChanged( int clientNum ) {
         if ( *s ) {
                 client->car.torquePeak = atof( s );
         }
+        s = Info_ValueForKey( userinfo, "cg_damageTolerance" );
+        if ( *s ) {
+                client->car.damageTolerance = atof( s );
+        }
 
         // team task (0 = none, 1 = offence, 2 = defence)
         teamTask = atoi(Info_ValueForKey(userinfo, "teamtask"));


### PR DESCRIPTION
## Summary
- parse `damageTolerance` from vehicle configs and propagate to car data and cvar
- add `damageTolerance` to player and car structs with server-side defaults
- scale collision damage based on each vehicle's `damageTolerance`
- expose `damageTolerance` config option for all vehicles

## Testing
- `make` *(fails: SDL_version.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68c72fb129ac83248e4eebc113f50919