### PR TITLE
Validate rally checkpoints before race

### DIFF
--- a/engine/code/game/g_active.c
+++ b/engine/code/game/g_active.c
@@ -1563,29 +1563,47 @@ void ClientThink_real( gentity_t *ent ) {
 	// touch other objects
 	ClientImpacts( ent, &pm );
 
-        if ( level.trackLength > 0.0f && level.numCheckpoints > 0 ) {
-                int next = client->ps.stats[STAT_NEXT_CHECKPOINT];
-                if ( next > 0 && next <= level.numCheckpoints ) {
-                        gentity_t *cp = level.checkpoints[next-1];
-                        if ( cp ) {
-                                vec3_t v;
-                                float dist, segs;
-                                VectorSubtract( cp->s.origin, client->ps.origin, v );
-                                dist = VectorLength( v );
-                                segs = level.cpDist[level.numCheckpoints-1] - level.cpDist[next-1];
-                                dist += segs;
-                                if ( level.numberOfLaps && ent->currentLap < level.numberOfLaps ) {
-                                        int lapsRemaining = level.numberOfLaps - ent->currentLap;
-                                        dist += lapsRemaining * level.trackLength;
-                                }
-                                client->ps.stats[STAT_DISTANCE_REMAIN] = (int)( dist / CP_M_2_QU );
-                        }
-                } else {
-                        client->ps.stats[STAT_DISTANCE_REMAIN] = 0;
-                }
-        } else {
-                client->ps.stats[STAT_DISTANCE_REMAIN] = 0;
-        }
+       if ( level.trackLength > 0.0f && level.numCheckpoints > 0 ) {
+               int next = client->ps.stats[STAT_NEXT_CHECKPOINT];
+
+               if ( next <= 0 ) {
+                       // STAT_NEXT_CHECKPOINT should never be zero.  If it is,
+                       // fall back to the entity's notion of the next checkpoint
+                       // (default to 1) so distance remaining calculations do not
+                       // break.
+                       if ( ent->number > 0 ) {
+                               next = ent->number;
+                       } else {
+                               next = 1;
+                       }
+                       client->ps.stats[STAT_NEXT_CHECKPOINT] = next;
+                       if ( g_developer.integer ) {
+                               G_Printf( "Client %i STAT_NEXT_CHECKPOINT was 0, forcing to %i\n",
+                                       ent->s.clientNum, next );
+                       }
+               }
+
+               if ( next > 0 && next <= level.numCheckpoints ) {
+                       gentity_t *cp = level.checkpoints[next-1];
+                       if ( cp ) {
+                               vec3_t v;
+                               float dist, segs;
+                               VectorSubtract( cp->s.origin, client->ps.origin, v );
+                               dist = VectorLength( v );
+                               segs = level.cpDist[level.numCheckpoints-1] - level.cpDist[next-1];
+                               dist += segs;
+                               if ( level.numberOfLaps && ent->currentLap < level.numberOfLaps ) {
+                                       int lapsRemaining = level.numberOfLaps - ent->currentLap;
+                                       dist += lapsRemaining * level.trackLength;
+                               }
+                               client->ps.stats[STAT_DISTANCE_REMAIN] = (int)( dist / CP_M_2_QU );
+                       }
+               } else {
+                       client->ps.stats[STAT_DISTANCE_REMAIN] = 0;
+               }
+       } else {
+               client->ps.stats[STAT_DISTANCE_REMAIN] = 0;
+       }
 
 	// save results of triggers and client events
 	if (ent->client->ps.eventSequence != oldEventSequence) {


### PR DESCRIPTION
## Summary
- Ensure `STAT_NEXT_CHECKPOINT` never remains zero and fall back to a valid checkpoint in client processing
- Verify rally checkpoints when loading map entities and log missing checkpoints or bad distances

## Testing
- `make BUILD_CLIENT=0`

------
https://chatgpt.com/codex/tasks/task_e_68c798c19d688324accc2c20dc22ccf1