### PR TITLE
Use checkpoint entity data for HUD distance

### DIFF
--- a/engine/code/cgame/cg_rally_hud.c
+++ b/engine/code/cgame/cg_rally_hud.c
@@ -564,16 +564,48 @@ static float CG_DrawDistanceToFinish( float y ) {
 
        // for multi-lap races show distance to next checkpoint instead of finish
        if ( cgs.laplimit > 1 ) {
-               int     nextCP;
-               vec3_t  diff;
+               int             nextCP;
+               centity_t       *checkpoint = NULL;
+               vec3_t          diff;
+               vec3_t          checkpointOrigin;
+               int             i;
 
                nextCP = cg.snap->ps.stats[STAT_NEXT_CHECKPOINT];
                if ( nextCP <= 0 ) {
                        return y;
                }
 
-               // checkpoints are stored 0-based in cgs.checkpoints
-               VectorSubtract( cgs.checkpoints[nextCP - 1], cg.snap->ps.origin, diff );
+               for ( i = 0; i < MAX_GENTITIES; i++ ) {
+                       centity_t *cent = &cg_entities[i];
+
+                       if ( cent->currentState.eType != ET_CHECKPOINT ) {
+                               continue;
+                       }
+
+                       if ( cent->currentState.weapon != nextCP ) {
+                               continue;
+                       }
+
+                       checkpoint = cent;
+                       break;
+               }
+
+               if ( !checkpoint ) {
+                       return y;
+               }
+
+               VectorCopy( checkpoint->lerpOrigin, checkpointOrigin );
+
+               if ( checkpoint->currentState.solid == SOLID_BMODEL &&
+                        checkpoint->currentState.modelindex > 0 &&
+                        checkpoint->currentState.modelindex < MAX_MODELS ) {
+                       VectorAdd( checkpointOrigin,
+                               cgs.inlineModelMidpoints[ checkpoint->currentState.modelindex ],
+                               checkpointOrigin );
+               }
+
+               VectorSubtract( checkpointOrigin, cg.snap->ps.origin, diff );
+
                dist = VectorLength( diff );
                Com_sprintf( s, sizeof( s ), "CP: %dm", (int)dist );
        }


### PR DESCRIPTION
## Summary
- search cg_entities for the checkpoint matching STAT_NEXT_CHECKPOINT when drawing the HUD distance
- derive the player-to-checkpoint vector from the entity origin (or brush midpoint) and keep the CP distance formatting

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c83d6c31cc8324b73539f42d22e493