### PR TITLE
Convert checkpoint HUD distance to meters

### DIFF
--- a/engine/code/cgame/cg_rally_hud.c
+++ b/engine/code/cgame/cg_rally_hud.c
@@ -606,7 +606,7 @@ static float CG_DrawDistanceToFinish( float y ) {
 
                VectorSubtract( checkpointOrigin, cg.snap->ps.origin, diff );
 
-               dist = VectorLength( diff );
+               dist = VectorLength( diff ) / CP_M_2_QU;
                Com_sprintf( s, sizeof( s ), "CP: %dm", (int)dist );
        }
        else {


### PR DESCRIPTION
## Summary
- convert the checkpoint HUD distance to meters by normalizing against `CP_M_2_QU`

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c83f4983c08324a41a67c44922e9c5