### PR TITLE
Store rally start and finish data

### DIFF
--- a/engine/code/game/g_active.c
+++ b/engine/code/game/g_active.c
@@ -1601,6 +1601,9 @@ void ClientThink_real( gentity_t *ent ) {
                } else {
                        client->ps.stats[STAT_DISTANCE_REMAIN] = 0;
                }
+       } else if ( level.hasFinish ) {
+               float dist = VectorDistance( level.finishOrigin, client->ps.origin );
+               client->ps.stats[STAT_DISTANCE_REMAIN] = (int)( dist / CP_M_2_QU );
        } else {
                client->ps.stats[STAT_DISTANCE_REMAIN] = 0;
        }

--- a/engine/code/game/g_local.h
+++ b/engine/code/game/g_local.h
@@ -525,6 +525,10 @@ typedef struct {
         float                   cpDist[MAX_GENTITIES];
         gentity_t       *checkpoints[MAX_GENTITIES];
         float                   trackLength;
+        vec3_t                  startOrigin;
+        vec3_t                  finishOrigin;
+        qboolean                hasStart;
+        qboolean                hasFinish;
 
         int                     testModelID;
 // END

--- a/engine/code/game/g_rally_mapents.c
+++ b/engine/code/game/g_rally_mapents.c
@@ -317,6 +317,17 @@ void Think_StartFinish( gentity_t *self ){
                }
        }
 
+       if ( level.hasFinish ) {
+               if ( level.numCheckpoints > 0 ) {
+                       gentity_t *last = level.checkpoints[level.numCheckpoints - 1];
+                       if ( last ) {
+                               level.trackLength += VectorDistance( last->s.origin, level.finishOrigin );
+                       }
+               } else {
+                       level.trackLength = VectorDistance( level.startOrigin, level.finishOrigin );
+               }
+       }
+
        trap_SetConfigstring( CS_TRACKLENGTH, va( "%i", (int)( level.trackLength / CP_M_2_QU ) ) );
 
        self->number = level.numCheckpoints;
@@ -368,6 +379,9 @@ ent->think = Think_StartFinish;
 ent->nextthink = level.time + 100;
 ent->s.frame = 0;
 
+VectorCopy( ent->s.origin, level.startOrigin );
+level.hasStart = qtrue;
+
 trap_LinkEntity (ent);
 }
 
@@ -381,6 +395,9 @@ ent->touch = Touch_Finish;
 ent->think = Think_Finish;
 ent->nextthink = level.time + 100;
 ent->s.frame = 0;
+
+VectorCopy( ent->s.origin, level.finishOrigin );
+level.hasFinish = qtrue;
 
 trap_LinkEntity (ent);
 }


### PR DESCRIPTION
## Summary
- extend the level state with start and finish origin information
- capture start and finish origins when map entities spawn and fold them into track length calculations
- fall back to finish distance when checkpoints are exhausted so clients still get remaining distance updates

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c86f9e99108324a953f19dc5bae86a