### PR TITLE
Handle checkpoints without brush models

### DIFF
--- a/engine/code/cgame/cg_rally_hud.c
+++ b/engine/code/cgame/cg_rally_hud.c
@@ -282,29 +282,34 @@ static float CG_DrawArrowToCheckpoint( float y ) {
 //	VectorSubtract(cent->currentState.origin, cg.predictedPlayerState.origin, dir);
 //	angle2 = vectoyaw(dir);
 
-	// find the distance from the edge of the bounding box
-	trap_R_ModelBounds( cgs.inlineDrawModel[cent->currentState.modelindex], mins, maxs );
+	if ( cent->currentState.modelindex == 0 ) {
+		VectorSubtract( cent->currentState.origin2, cg.predictedPlayerState.origin, v );
+		angle2 = vectoyaw( v );
+	} else {
+		// find the distance from the edge of the bounding box
+		trap_R_ModelBounds( cgs.inlineDrawModel[cent->currentState.modelindex], mins, maxs );
 
-	// if the checkpoint was one with no target then mins and maxs are relative to the origin
-	if( cent->currentState.frame == 0 )
-	{
-		VectorAdd( mins, cent->currentState.origin, mins );
-		VectorAdd( maxs, cent->currentState.origin, maxs );
-	}
-
-	for ( i = 0 ; i < 3 ; i++ ) {
-		if ( cg.predictedPlayerState.origin[i] < mins[i] ) {
-			v[i] = mins[i] - cg.predictedPlayerState.origin[i];
-		} else if ( cg.predictedPlayerState.origin[i] > maxs[i] ) {
-			v[i] = maxs[i] - cg.predictedPlayerState.origin[i];
-		} else {
-			v[i] = 0;
+		// if the checkpoint was one with no target then mins and maxs are relative to the origin
+		if( cent->currentState.frame == 0 )
+		{
+			VectorAdd( mins, cent->currentState.origin, mins );
+			VectorAdd( maxs, cent->currentState.origin, maxs );
 		}
+
+		for ( i = 0 ; i < 3 ; i++ ) {
+			if ( cg.predictedPlayerState.origin[i] < mins[i] ) {
+				v[i] = mins[i] - cg.predictedPlayerState.origin[i];
+			} else if ( cg.predictedPlayerState.origin[i] > maxs[i] ) {
+				v[i] = maxs[i] - cg.predictedPlayerState.origin[i];
+			} else {
+				v[i] = 0;
+			}
+		}
+		if( v[0] == 0 && v[1] == 0 && v[2] == 0 )
+			angle2 = cg.predictedPlayerState.viewangles[YAW];
+		else
+			angle2 = vectoyaw(v);
 	}
-	if( v[0] == 0 && v[1] == 0 && v[2] == 0 )
-		angle2 = cg.predictedPlayerState.viewangles[YAW];
-	else
-		angle2 = vectoyaw(v);
 
 	if (cg_checkpointArrowMode.integer == 1){
 		AngleVectors(cg.refdefViewAngles, forward, NULL, NULL);

--- a/engine/code/game/g_rally_mapents.c
+++ b/engine/code/game/g_rally_mapents.c
@@ -495,6 +495,7 @@ void Think_Checkpoint( gentity_t *self ){
 //	spawnflag 1 enable messages, spawn flag 2 enable sound, 3 is enable both
 void SP_rally_checkpoint( gentity_t *ent ) {
 	trap_SetBrushModel( ent, ent->model );
+	G_SetOrigin( ent, ent->s.origin );
 
 // STONELANCE - April 23, 2002 temp for testing bezier curve stuff
 	ent->r.svFlags |= SVF_BROADCAST;


### PR DESCRIPTION
## Summary
- add a direction fallback in `CG_DrawArrowToCheckpoint` when a checkpoint lacks a brush model
- keep checkpoint entities' `s.origin` synchronized after setting the brush model
- rebuild the gameplay modules so the updated logic is compiled

## Testing
- make -C engine BUILD_CLIENT=0 -j4


------
https://chatgpt.com/codex/tasks/task_e_68c878af446c8324bba20b39f98511f6