### PR TITLE
Show finish distance after last checkpoint

### DIFF
--- a/engine/code/game/g_active.c
+++ b/engine/code/game/g_active.c
@@ -1598,6 +1598,9 @@ void ClientThink_real( gentity_t *ent ) {
                                }
                                client->ps.stats[STAT_DISTANCE_REMAIN] = (int)( dist / CP_M_2_QU );
                        }
+               } else if ( level.hasFinish ) {
+                       float dist = Distance( level.finishOrigin, client->ps.origin );
+                       client->ps.stats[STAT_DISTANCE_REMAIN] = (int)( dist / CP_M_2_QU );
                } else {
                        client->ps.stats[STAT_DISTANCE_REMAIN] = 0;
                }


### PR DESCRIPTION
## Summary
- extend ClientThink to compute the remaining distance from the finish line once all checkpoints have been passed

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68c87bfe394c8324a83654c9c7b87b08