### PR TITLE
Fix checkpoint to finish distance calculation

### DIFF
--- a/engine/code/game/g_active.c
+++ b/engine/code/game/g_active.c
@@ -1590,7 +1590,7 @@ void ClientThink_real( gentity_t *ent ) {
                                float dist, segs;
                                VectorSubtract( cp->s.origin, client->ps.origin, v );
                                dist = VectorLength( v );
-                               segs = level.cpDist[level.numCheckpoints-1] - level.cpDist[next-1];
+                               segs = level.trackLength - level.cpDist[next-1];
                                dist += segs;
                                if ( level.numberOfLaps && ent->currentLap < level.numberOfLaps ) {
                                        int lapsRemaining = level.numberOfLaps - ent->currentLap;


### PR DESCRIPTION
## Summary
- update the remaining distance calculation to use the total track length when measuring from the final checkpoint to the finish line

## Testing
- make -C engine release BUILD_GAME_SO=0 BUILD_SERVER=0 *(fails: missing SDL_version.h dependency in build environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c8e28056b883249b00951d7e742331