### PR TITLE
Skip lap HUD when lap limit is single

### DIFF
--- a/engine/code/cgame/cg_rally_hud.c
+++ b/engine/code/cgame/cg_rally_hud.c
@@ -538,6 +538,10 @@ static float CG_DrawLaps( float y ) {
 	//ps = &cg.snap->ps;
 	cent = &cg_entities[cg.snap->ps.clientNum];
 
+	if ( cgs.laplimit <= 1 ) {
+		return y;
+	}
+
 	curLap = cent->currentLap;
 	numLaps = cgs.laplimit;
 


### PR DESCRIPTION
## Summary
- add an early guard in the lap HUD drawing to skip rendering when the map has only one lap

## Testing
- `make release BUILD_CLIENT=0 -j4`


------
https://chatgpt.com/codex/tasks/task_e_68c9914eb7a48324a70dc7e323852282