### PR TITLE
Ensure finish checkpoint updates weapon index

### DIFF
--- a/engine/code/game/g_rally_mapents.c
+++ b/engine/code/game/g_rally_mapents.c
@@ -366,6 +366,7 @@ void Think_StartFinish( gentity_t *self ){
 void Think_Finish( gentity_t *self ){
 Think_StartFinish( self );
 self->number++;
+self->s.weapon = self->number;
 }
 
 


### PR DESCRIPTION
## Summary
- reapply the weapon index update after the finish entity increments its checkpoint counter so the published checkpoint number stays in sync

## Testing
- make -C engine BUILD_GAME_QVM=1 BUILD_BASEGAME=1 BUILD_CLIENT=0 BUILD_SERVER=0 BUILD_GAME_SO=0


------
https://chatgpt.com/codex/tasks/task_e_68ca3b220e088324b3a0d7037b049ec8