### PR TITLE
Normalize empty arena metadata placeholders

### DIFF
--- a/baseq3r/scripts/q3r_a_to_b_test.arena
+++ b/baseq3r/scripts/q3r_a_to_b_test.arena
@@ -21,7 +21,7 @@ starts "4"
 laps "1"
 
 //LAPTIME
-laptime " "
+laptime ""
 
 //CHECKPOINTS
 checkpoints "2"
@@ -36,10 +36,10 @@ weapons "0"
 powerups "0"
 
 //REVERSABLE
-reversable " "
+reversable ""
 
 //TRACK LENGTHS
-tracklengths " "
+tracklengths ""
 
 //BOT SUPPORTS
 botsupport "Bad"

--- a/baseq3r/scripts/q3r_babel.arena
+++ b/baseq3r/scripts/q3r_babel.arena
@@ -18,7 +18,7 @@ bots "Dean Minori Vlad Emma Tobias Alexandra Sam"
 starts "16"
 
 //LAPTIME
-laptime " "
+laptime ""
 
 //CHECKPOINTS
 checkpoints "20"
@@ -33,10 +33,10 @@ weapons "SG,RG,PG,RL,BFG"
 powerups "0"
 
 //REVERSABLE
-reversable " "
+reversable ""
 
 //TRACK LENGTHS
-tracklengths " "
+tracklengths ""
 
 //BOT SUPPORTS
 botsupport "Bad"

--- a/baseq3r/scripts/q3r_battlecanyon.arena
+++ b/baseq3r/scripts/q3r_battlecanyon.arena
@@ -18,10 +18,10 @@ bots "Kuro Tobias Vlad Samuel Chloe Tony"
 starts "8"
 
 //LAPTIME
-laptime " "
+laptime ""
 
 //CHECKPOINTS
-checkpoints " "
+checkpoints ""
 
 //OBSERVER SPOTS
 observerspots "1"
@@ -33,13 +33,13 @@ weapons "RL,PG,RG,SG,LG"
 powerups "2 & Mines"
 
 //REVERSABLE
-reversable " "
+reversable ""
 
 //TRACK LENGTHS
-tracklengths " "
+tracklengths ""
 
 //BOT SUPPORTS
-botsupport " "
+botsupport ""
 
 //TEAMS
 teams "All"

--- a/baseq3r/scripts/q3r_citydom.arena
+++ b/baseq3r/scripts/q3r_citydom.arena
@@ -18,7 +18,7 @@ bots "Ivan Tanya Kuro Alexandra Bobby Samuel Jennifer"
 starts "8"
 
 //LAPTIME
-laptime " "
+laptime ""
 
 //CHECKPOINTS
 checkpoints "20"
@@ -33,10 +33,10 @@ weapons "All"
 powerups "All"
 
 //REVERSABLE
-reversable " "
+reversable ""
 
 //TRACK LENGTHS
-tracklengths " "
+tracklengths ""
 
 //BOT SUPPORTS
 botsupport "Very Bad"

--- a/baseq3r/scripts/q3r_ctf4_01.arena
+++ b/baseq3r/scripts/q3r_ctf4_01.arena
@@ -18,13 +18,13 @@ type "q3r_ctf4"
 starts "8"
 
 //LAPTIME
-laptime " "
+laptime ""
 
 //CHECKPOINTS
-checkpoints " "
+checkpoints ""
 
 //OBSERVER SPOTS
-observerspots " "
+observerspots ""
 
 //WEAPONS
 weapons ""
@@ -33,10 +33,10 @@ weapons ""
 powerups ""
 
 //REVERSABLE
-reversable " "
+reversable ""
 
 //TRACK LENGTHS
-tracklengths " "
+tracklengths ""
 
 //BOT SUPPORTS
 botsupport ""

--- a/baseq3r/scripts/q3r_ctf_01.arena
+++ b/baseq3r/scripts/q3r_ctf_01.arena
@@ -18,13 +18,13 @@ bots "Chloe Jim Zack Paul Tobias Josh Tony"
 starts "8"
 
 //LAPTIME
-laptime " "
+laptime ""
 
 //CHECKPOINTS
-checkpoints " "
+checkpoints ""
 
 //OBSERVER SPOTS
-observerspots " "
+observerspots ""
 
 //WEAPONS
 weapons "FT,PG,RL,SG,RG"
@@ -33,10 +33,10 @@ weapons "FT,PG,RL,SG,RG"
 powerups "8"
 
 //REVERSABLE
-reversable " "
+reversable ""
 
 //TRACK LENGTHS
-tracklengths " "
+tracklengths ""
 
 //BOT SUPPORTS
 botsupport "Very Bad"

--- a/baseq3r/scripts/q3r_david4.arena
+++ b/baseq3r/scripts/q3r_david4.arena
@@ -18,10 +18,10 @@ bots "Sam Dean Minori Vlad Kuro Emma Bee"
 starts "15"
 
 //LAPTIME
-laptime " "
+laptime ""
 
 //CHECKPOINTS
-checkpoints " "
+checkpoints ""
 
 //OBSERVER SPOTS
 observerspots "5"
@@ -33,10 +33,10 @@ weapons "BFG,GL,FT,RL,LG"
 powerups "2"
 
 //REVERSABLE
-reversable " "
+reversable ""
 
 //TRACK LENGTHS
-tracklengths " "
+tracklengths ""
 
 //BOT SUPPORTS
 botsupport "Good"

--- a/baseq3r/scripts/q3r_david5.arena
+++ b/baseq3r/scripts/q3r_david5.arena
@@ -18,13 +18,13 @@ bots "Jim Bobby Sam Tobias"
 starts "4"
 
 //LAPTIME
-laptime " "
+laptime ""
 
 //CHECKPOINTS
-checkpoints " "
+checkpoints ""
 
 //OBSERVER SPOTS
-observerspots " "
+observerspots ""
 
 //WEAPONS
 weapons "RL,PG"
@@ -33,10 +33,10 @@ weapons "RL,PG"
 powerups "0"
 
 //REVERSABLE
-reversable " "
+reversable ""
 
 //TRACK LENGTHS
-tracklengths " "
+tracklengths ""
 
 //BOT SUPPORTS
 botsupport "Good"

--- a/baseq3r/scripts/q3r_demobowl.arena
+++ b/baseq3r/scripts/q3r_demobowl.arena
@@ -18,13 +18,13 @@ bots "Jennifer Jim Vlad Zack"
 starts "17"
 
 //LAPTIME
-laptime " "
+laptime ""
 
 //CHECKPOINTS
-checkpoints " "
+checkpoints ""
 
 //OBSERVER SPOTS
-observerspots " "
+observerspots ""
 
 //WEAPONS
 weapons "LG,RL,RG"
@@ -33,10 +33,10 @@ weapons "LG,RL,RG"
 powerups "0"
 
 //REVERSABLE
-reversable " "
+reversable ""
 
 //TRACK LENGTHS
-tracklengths " "
+tracklengths ""
 
 //BOT SUPPORTS
 botsupport "Good"

--- a/baseq3r/scripts/q3r_dm02.arena
+++ b/baseq3r/scripts/q3r_dm02.arena
@@ -18,10 +18,10 @@ bots "Emma Ivan Paul Steve"
 starts "8"
 
 //LAPTIME
-laptime " "
+laptime ""
 
 //CHECKPOINTS
-checkpoints " "
+checkpoints ""
 
 //OBSERVER SPOTS
 observerspots "1"
@@ -33,10 +33,10 @@ weapons "RL,PG,SG"
 powerups "1"
 
 //REVERSABLE
-reversable " "
+reversable ""
 
 //TRACK LENGTHS
-tracklengths " "
+tracklengths ""
 
 //BOT SUPPORTS
 botsupport "Good"

--- a/baseq3r/scripts/q3r_lcs1.arena
+++ b/baseq3r/scripts/q3r_lcs1.arena
@@ -18,13 +18,13 @@ bots "Chloe Jim Zack Paul Tobias Josh Tony Steve Paul Tanya Kuro"
 starts "Too many"
 
 //LAPTIME
-laptime " "
+laptime ""
 
 //CHECKPOINTS
-checkpoints " "
+checkpoints ""
 
 //OBSERVER SPOTS
-observerspots " "
+observerspots ""
 
 //WEAPONS
 weapons "All"
@@ -33,10 +33,10 @@ weapons "All"
 powerups "No"
 
 //REVERSABLE
-reversable " "
+reversable ""
 
 //TRACK LENGTHS
-tracklengths " "
+tracklengths ""
 
 //BOT SUPPORTS
 botsupport "Bad"

--- a/baseq3r/scripts/q3r_mk.arena
+++ b/baseq3r/scripts/q3r_mk.arena
@@ -18,10 +18,10 @@ bots "Tony Steve Tanya Zack Jennifer Ivan Tobias"
 starts "8"
 
 //LAPTIME
-laptime " "
+laptime ""
 
 //CHECKPOINTS
-checkpoints " "
+checkpoints ""
 
 //OBSERVER SPOTS
 observerspots "1"
@@ -33,10 +33,10 @@ weapons "All"
 powerups "All"
 
 //REVERSABLE
-reversable " "
+reversable ""
 
 //TRACK LENGTHS
-tracklengths " "
+tracklengths ""
 
 //BOT SUPPORTS
 botsupport "Good"

--- a/baseq3r/scripts/test.arena
+++ b/baseq3r/scripts/test.arena
@@ -18,13 +18,13 @@ bots ""
 starts "1"
 
 //LAPTIME
-laptime " "
+laptime ""
 
 //CHECKPOINTS
-checkpoints " "
+checkpoints ""
 
 //OBSERVER SPOTS
-observerspots " "
+observerspots ""
 
 //WEAPONS
 weapons "RL,PG,SG"
@@ -33,10 +33,10 @@ weapons "RL,PG,SG"
 powerups "1"
 
 //REVERSABLE
-reversable " "
+reversable ""
 
 //TRACK LENGTHS
-tracklengths " "
+tracklengths ""
 
 //BOT SUPPORTS
 botsupport "Good"


### PR DESCRIPTION
## Summary
- replace placeholder `" "` metadata entries in the affected arena definitions with explicit empty strings so the UI treats missing information correctly
- ensure the edited arena files terminate with newlines instead of concatenated EOF markers

## Testing
- not run (start server menu requires the game client)


------
https://chatgpt.com/codex/tasks/task_e_68cadee7bb508324b1d8269060475bd3