### PR TITLE
Broadcast rally sound events

### DIFF
--- a/engine/code/game/g_utils.c
+++ b/engine/code/game/g_utils.c
@@ -630,6 +630,7 @@ void Rally_Sound( gentity_t *ent, int event, int channel, int soundIndex ) {
 	gentity_t	*te;
 
 	te = G_TempEntity( ent->r.currentOrigin, event );
+	te->r.svFlags |= SVF_BROADCAST;
 	te->s.eventParm = soundIndex;
 }
 // END


### PR DESCRIPTION
## Summary
- ensure rally sound temp entities set SVF_BROADCAST so rally announcer cues reach all clients

## Testing
- make BUILD_CLIENT=0 -j4

------
https://chatgpt.com/codex/tasks/task_e_68caecb3af808324a27b0395c5eef157