### PR TITLE
Add elimination support to HUD and scoreboard displays

### DIFF
--- a/engine/code/cgame/cg_draw.c
+++ b/engine/code/cgame/cg_draw.c
@@ -2992,7 +2992,7 @@ static void CG_DrawAmmoWarning( void ) {
 	int			w;
 
 // Q3Rally Code Start
-	if (isRallyNonDMRace() || cgs.gametype == GT_DERBY){
+	if (isRallyNonDMRace() || cgs.gametype == GT_DERBY || cgs.gametype == GT_ELIMINATION){
 		return;
 	}
 // Q3Rally Code END

--- a/engine/code/cgame/cg_info.c
+++ b/engine/code/cgame/cg_info.c
@@ -288,7 +288,7 @@ void CG_DrawInformation( void ) {
                 s = "Racing Deathmatch";
                 break;
         case GT_ELIMINATION:
-                s = "Elimination";
+                s = "Elimination Race - stay ahead to survive";
                 break;
         case GT_DERBY:
                 s = "Demolition Derby";

--- a/engine/code/cgame/cg_predict.c
+++ b/engine/code/cgame/cg_predict.c
@@ -983,7 +983,7 @@ void CG_PredictPlayerState( void ) {
 
 
 // Q3Rally Code Start
-		if ((isRallyRace() || cgs.gametype == GT_DERBY || cgs.gametype == GT_LCS) && !cg_entities[cg.snap->ps.clientNum].startRaceTime){
+		if ((isRallyRace() || cgs.gametype == GT_DERBY || cgs.gametype == GT_LCS || cgs.gametype == GT_ELIMINATION) && !cg_entities[cg.snap->ps.clientNum].startRaceTime){
 			cg_pmove.cmd.buttons = BUTTON_HANDBRAKE;
 
 			cg_pmove.cmd.forwardmove = 0;
@@ -1005,7 +1005,7 @@ void CG_PredictPlayerState( void ) {
 			cg_pmove.cmd.upmove = 0;
 		}
 
-               if (isRallyNonDMRace() || cgs.gametype == GT_DERBY){
+		if (isRallyNonDMRace() || cgs.gametype == GT_DERBY || cgs.gametype == GT_ELIMINATION){
                        cg_pmove.cmd.weapon = cg.predictedPlayerState.weapon = WP_NONE;
                }
 // END

--- a/engine/code/cgame/cg_rally_hud.c
+++ b/engine/code/cgame/cg_rally_hud.c
@@ -1183,16 +1183,16 @@ float CG_DrawUpperRightHUD( float y ) {
                         y = CG_DrawCurrentPosition( y );
 			y = CG_DrawCarAheadAndBehind( y );
 		}
-		else if (cgs.gametype == GT_DERBY || cgs.gametype == GT_LCS )
-			y = CG_DrawTimes( y );
+                else if (cgs.gametype == GT_DERBY || cgs.gametype == GT_LCS || cgs.gametype == GT_ELIMINATION )
+                        y = CG_DrawTimes( y );
 // 0.5
 //			CG_DrawHUD_DerbyList(44, 130);
 			
 	}
 
-	if (!isRallyNonDMRace() && cgs.gametype != GT_DERBY && cgs.gametype != GT_LCS){
-		y = CG_DrawScores( 636, y );
-	}
+        if (!isRallyNonDMRace() && cgs.gametype != GT_DERBY && cgs.gametype != GT_LCS && cgs.gametype != GT_ELIMINATION){
+                y = CG_DrawScores( 636, y );
+        }
 
 	return y;
 }

--- a/engine/code/cgame/cg_scoreboard.c
+++ b/engine/code/cgame/cg_scoreboard.c
@@ -143,9 +143,11 @@ static void CG_InitScoreboardColumns(void) {
     
     switch (cgs.gametype) {
         case GT_RACING:
-        case GT_ELIMINATION:
         case GT_TEAM_RACING:
-            /* Pure racing - only times matter */
+        case GT_ELIMINATION:
+            /* Pure racing - only positions and times matter */
+            showScore = qfalse;
+            showDeaths = qfalse;
             showTimes = qtrue;
             showLapTimes = qtrue;
             break;

--- a/engine/code/cgame/cg_weapons.c
+++ b/engine/code/cgame/cg_weapons.c
@@ -1212,7 +1212,7 @@ void CG_AddPlayerWeapon( refEntity_t *parent, playerState_t *ps, centity_t *cent
                 return;
         }
 
-        if (!isRallyNonDMRace() && cgs.gametype != GT_DERBY){
+        if (!isRallyNonDMRace() && cgs.gametype != GT_DERBY && cgs.gametype != GT_ELIMINATION){
                 CG_RegisterWeapon( weaponNum );
         }
 


### PR DESCRIPTION
## Summary
- add a descriptive loading screen label for Elimination
- treat Elimination like the other race modes on the modern scoreboard
- update HUD, prediction, and weapon logic so Elimination follows the same UI rules as race modes

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cb064df8388324a59cb76a7c5c3bc1