### PR TITLE
Fix UI elimination lap notice color

### DIFF
--- a/engine/code/q3_ui/ui_rally_startserver.c
+++ b/engine/code/q3_ui/ui_rally_startserver.c
@@ -1648,7 +1648,7 @@ static void ServerOptions_MenuInit( qboolean multiplayer ) {
 			s_serveroptions.laplimitNotice.generic.y		= y;
 			s_serveroptions.laplimitNotice.string		= s_serveroptions.laplimitNoticeBuffer;
 			s_serveroptions.laplimitNotice.style		= UI_LEFT|UI_SMALLFONT;
-			s_serveroptions.laplimitNotice.color		= text_color_dim;
+			s_serveroptions.laplimitNotice.color		= text_color_disabled;
 			if ( s_startserver.hasDefaultLaps && s_startserver.defaultLaps > 0 ) {
 				Com_sprintf( s_serveroptions.laplimitNoticeBuffer, sizeof( s_serveroptions.laplimitNoticeBuffer ), "Laps: automatic (map default: %i)", s_startserver.defaultLaps );
 			} else {


### PR DESCRIPTION
## Summary
- replace the elimination lap-limit notice color with the existing disabled-text palette entry to avoid missing symbol errors

## Testing
- make release BUILD_CLIENT=0

------
https://chatgpt.com/codex/tasks/task_e_68cb0baff7748324b9a1e108f87d26fa