### PR TITLE
Add elimination timing cvars and UI controls

### DIFF
--- a/engine/code/game/g_local.h
+++ b/engine/code/game/g_local.h
@@ -518,6 +518,9 @@ typedef struct {
 	int			winnerNumber;
 	qboolean	trackIsReversable;
 	int			numberOfLaps;
+	int			eliminationStartDelay;
+	int			eliminationInterval;
+	int			eliminationWarning;
 
 	// map variables
 	int			numCheckpoints;
@@ -1007,6 +1010,9 @@ extern  vmCvar_t	g_humanplayers;
 // STONELANCE
 extern	vmCvar_t	g_forceEngineStart;
 extern	vmCvar_t	g_finishRaceDelay;
+extern	vmCvar_t	g_eliminationStartDelay;
+extern	vmCvar_t	g_eliminationInterval;
+extern	vmCvar_t	g_eliminationWarning;
 extern	vmCvar_t	g_trackReversed;
 extern	vmCvar_t	g_trackLength;
 extern	vmCvar_t	g_developer;

--- a/engine/code/game/g_main.c
+++ b/engine/code/game/g_main.c
@@ -106,6 +106,9 @@ vmCvar_t	g_proxMineTimeout;
 // STONELANCE
 vmCvar_t	g_forceEngineStart;
 vmCvar_t	g_finishRaceDelay;
+vmCvar_t	g_eliminationStartDelay;
+vmCvar_t	g_eliminationInterval;
+vmCvar_t	g_eliminationWarning;
 vmCvar_t	g_trackReversed;
 vmCvar_t	g_trackLength;
 vmCvar_t	g_developer;
@@ -247,6 +250,9 @@ static cvarTable_t		gameCvarTable[] = {
 
 	{ &g_forceEngineStart, "g_forceEngineStart", "60", CVAR_ARCHIVE, 0, qfalse },
 	{ &g_finishRaceDelay, "g_finishRaceDelay", "30", CVAR_ARCHIVE, 0, qfalse },
+	{ &g_eliminationStartDelay, "g_eliminationStartDelay", "30000", CVAR_ARCHIVE, 0, qfalse },
+	{ &g_eliminationInterval, "g_eliminationInterval", "15000", CVAR_ARCHIVE, 0, qfalse },
+	{ &g_eliminationWarning, "g_eliminationWarning", "5000", CVAR_ARCHIVE, 0, qfalse },
 
 	{ &g_developer, "developer", "0", 0, 0, qfalse },
 	{ &g_humanplayers, "g_humanplayers", "0", CVAR_ROM | CVAR_NORESTART, 0, qfalse },
@@ -574,6 +580,13 @@ void G_InitGame( int levelTime, int randomSeed, int restart ) {
 	memset( &level, 0, sizeof( level ) );
 	level.time = levelTime;
 	level.startTime = levelTime;
+
+	trap_Cvar_Update( &g_eliminationStartDelay );
+	trap_Cvar_Update( &g_eliminationInterval );
+	trap_Cvar_Update( &g_eliminationWarning );
+	level.eliminationStartDelay = trap_Cvar_VariableIntegerValue( "g_eliminationStartDelay" );
+	level.eliminationInterval = trap_Cvar_VariableIntegerValue( "g_eliminationInterval" );
+	level.eliminationWarning = trap_Cvar_VariableIntegerValue( "g_eliminationWarning" );
 
 	level.snd_fry = G_SoundIndex("sound/player/fry.wav");	// FIXME standing in lava / slime
 

--- a/engine/code/q3_ui/ui_rally_startserver.c
+++ b/engine/code/q3_ui/ui_rally_startserver.c
@@ -851,6 +851,9 @@ typedef struct {
 	menuradiobutton_s   sigillocator;
 	menufield_s			dominationScoreInterval;
 	menufield_s			dominationCaptureDelay;
+	menufield_s			eliminationStartDelay;
+	menufield_s			eliminationInterval;
+	menufield_s			eliminationWarning;
 	menulist_s			trackLength;
 	menulist_s			reversed;
 	menuradiobutton_s	pure;
@@ -965,6 +968,9 @@ static void ServerOptions_Start( void ) {
     int     dominationSpawnStyle;
 	int		dominationScoreInterval;
 	int		dominationCaptureDelay;
+	int		eliminationStartDelay;
+	int		eliminationInterval;
+	int		eliminationWarning;
 	int     sigillocator;
 	int		maxclients;
 	int		dedicated;
@@ -995,6 +1001,9 @@ static void ServerOptions_Start( void ) {
 	flaglimit	 = atoi( s_serveroptions.flaglimit.field.buffer );
 	dominationScoreInterval = atoi( s_serveroptions.dominationScoreInterval.field.buffer );
 	dominationCaptureDelay = atoi( s_serveroptions.dominationCaptureDelay.field.buffer );
+	eliminationStartDelay = atoi( s_serveroptions.eliminationStartDelay.field.buffer );
+	eliminationInterval = atoi( s_serveroptions.eliminationInterval.field.buffer );
+	eliminationWarning = atoi( s_serveroptions.eliminationWarning.field.buffer );
 	dedicated	 = s_serveroptions.dedicated.curvalue;
 	friendlyfire = s_serveroptions.friendlyfire.curvalue;
 	pure		 = s_serveroptions.pure.curvalue;
@@ -1017,9 +1026,16 @@ static void ServerOptions_Start( void ) {
 
 	switch( s_serveroptions.gametype ) {
 
+        case GT_ELIMINATION:
+                trap_Cvar_SetValue( "g_eliminationStartDelay", Com_Clamp( 0, 99999, eliminationStartDelay ) * 1000 );
+                trap_Cvar_SetValue( "g_eliminationInterval", Com_Clamp( 0, 99999, eliminationInterval ) * 1000 );
+                trap_Cvar_SetValue( "g_eliminationWarning", Com_Clamp( 0, 99999, eliminationWarning ) * 1000 );
+                trap_Cvar_SetValue( "ui_racing_laplimit", fraglimit );
+                trap_Cvar_SetValue( "ui_racing_timelimit", timelimit );
+                break;
+
         case GT_RACING:
         case GT_RACING_DM:
-        case GT_ELIMINATION:
         default:
                 trap_Cvar_SetValue( "ui_racing_laplimit", fraglimit );
                 trap_Cvar_SetValue( "ui_racing_timelimit", timelimit );
@@ -1466,16 +1482,25 @@ static void ServerOptions_SetMenuItems( void ) {
 
 	switch( s_serveroptions.gametype ) {
 
+        case GT_ELIMINATION:
+                Com_sprintf( s_serveroptions.eliminationStartDelay.field.buffer, 6, "%i", (int)Com_Clamp( 0, 99999, trap_Cvar_VariableValue( "g_eliminationStartDelay" ) ) / 1000 );
+                Com_sprintf( s_serveroptions.eliminationInterval.field.buffer, 6, "%i", (int)Com_Clamp( 0, 99999, trap_Cvar_VariableValue( "g_eliminationInterval" ) ) / 1000 );
+                Com_sprintf( s_serveroptions.eliminationWarning.field.buffer, 5, "%i", (int)Com_Clamp( 0, 99999, trap_Cvar_VariableValue( "g_eliminationWarning" ) ) / 1000 );
+                if( !s_serveroptions.pointToPoint ) {
+                        Com_sprintf( s_serveroptions.fraglimit.field.buffer, 4, "%i", (int)Com_Clamp( 0, 999, trap_Cvar_VariableValue( "ui_racing_laplimit" ) ) );
+                }
+                Com_sprintf( s_serveroptions.timelimit.field.buffer, 4, "%i", (int)Com_Clamp( 0, 999, trap_Cvar_VariableValue( "ui_racing_timelimit" ) ) );
+                break;
+
         case GT_RACING:
 
         case GT_RACING_DM:
-        case GT_ELIMINATION:
         default:
                 if( !s_serveroptions.pointToPoint ) {
                         Com_sprintf( s_serveroptions.fraglimit.field.buffer, 4, "%i", (int)Com_Clamp( 0, 999, trap_Cvar_VariableValue( "ui_racing_laplimit" ) ) );
                 }
-		Com_sprintf( s_serveroptions.timelimit.field.buffer, 4, "%i", (int)Com_Clamp( 0, 999, trap_Cvar_VariableValue( "ui_racing_timelimit" ) ) );
-		break;
+                Com_sprintf( s_serveroptions.timelimit.field.buffer, 4, "%i", (int)Com_Clamp( 0, 999, trap_Cvar_VariableValue( "ui_racing_timelimit" ) ) );
+                break;
 
 	case GT_TEAM_RACING:
 	case GT_TEAM_RACING_DM:
@@ -1780,6 +1805,36 @@ static void ServerOptions_MenuInit( qboolean multiplayer ) {
 		s_serveroptions.hostname.field.maxchars     = 64;
 	}
 
+	if (s_serveroptions.gametype == GT_ELIMINATION) {
+		y += BIGCHAR_HEIGHT+2;
+		s_serveroptions.eliminationStartDelay.generic.type       = MTYPE_FIELD;
+		s_serveroptions.eliminationStartDelay.generic.name       = "Start Delay (s):";
+		s_serveroptions.eliminationStartDelay.generic.flags      = QMF_NUMBERSONLY|QMF_PULSEIFFOCUS|QMF_SMALLFONT;
+		s_serveroptions.eliminationStartDelay.generic.x          = OPTIONS_X;
+		s_serveroptions.eliminationStartDelay.generic.y          = y;
+		s_serveroptions.eliminationStartDelay.field.widthInChars = 5;
+		s_serveroptions.eliminationStartDelay.field.maxchars     = 5;
+
+		y += BIGCHAR_HEIGHT+2;
+		s_serveroptions.eliminationInterval.generic.type       = MTYPE_FIELD;
+		s_serveroptions.eliminationInterval.generic.name       = "Elimination Interval (s):";
+		s_serveroptions.eliminationInterval.generic.flags      = QMF_NUMBERSONLY|QMF_PULSEIFFOCUS|QMF_SMALLFONT;
+		s_serveroptions.eliminationInterval.generic.x          = OPTIONS_X;
+		s_serveroptions.eliminationInterval.generic.y          = y;
+		s_serveroptions.eliminationInterval.field.widthInChars = 5;
+		s_serveroptions.eliminationInterval.field.maxchars     = 5;
+
+		y += BIGCHAR_HEIGHT+2;
+		s_serveroptions.eliminationWarning.generic.type       = MTYPE_FIELD;
+		s_serveroptions.eliminationWarning.generic.name       = "Warning Time (s):";
+		s_serveroptions.eliminationWarning.generic.flags      = QMF_NUMBERSONLY|QMF_PULSEIFFOCUS|QMF_SMALLFONT;
+		s_serveroptions.eliminationWarning.generic.x          = OPTIONS_X;
+		s_serveroptions.eliminationWarning.generic.y          = y;
+		s_serveroptions.eliminationWarning.field.widthInChars = 5;
+		s_serveroptions.eliminationWarning.field.maxchars     = 5;
+
+	}
+
 if (s_serveroptions.gametype == GT_DOMINATION) {
     s_serveroptions.dominationScoreInterval.generic.type       = MTYPE_FIELD;
     s_serveroptions.dominationScoreInterval.generic.name       = "Score Interval (s):";
@@ -1936,6 +1991,12 @@ if (s_serveroptions.gametype == GT_DOMINATION) {
 
 	if( s_serveroptions.multiplayer ) {
 		Menu_AddItem( &s_serveroptions.menu, &s_serveroptions.hostname );
+	}
+
+	if (s_serveroptions.gametype == GT_ELIMINATION) {
+		Menu_AddItem( &s_serveroptions.menu, &s_serveroptions.eliminationStartDelay );
+		Menu_AddItem( &s_serveroptions.menu, &s_serveroptions.eliminationInterval );
+		Menu_AddItem( &s_serveroptions.menu, &s_serveroptions.eliminationWarning );
 	}
 
 	if (s_serveroptions.gametype == GT_DOMINATION) {


### PR DESCRIPTION
## Summary
- register elimination delay, interval, and warning cvars alongside the existing race settings and cache their values on map start
- extend the start server menu with elimination timing fields that read and write the new cvars

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cb111e323083249f515670e200dda0