### PR TITLE
Add elimination runtime state tracking

### DIFF
--- a/engine/code/game/g_client.c
+++ b/engine/code/game/g_client.c
@@ -1331,6 +1331,7 @@ void ClientBegin( int clientNum ) {
 
 	// count current clients and rank for scoreboard
 	CalculateRanks();
+	G_UpdateEliminationPlayerCount();
 }
 
 /*
@@ -1862,6 +1863,7 @@ void ClientDisconnect( int clientNum ) {
 	trap_SetConfigstring( CS_PLAYERS + clientNum, "");
 
 	CalculateRanks();
+	G_UpdateEliminationPlayerCount();
 
 	if ( ent->r.svFlags & SVF_BOT ) {
 		BotAIShutdownClient( clientNum, qfalse );

--- a/engine/code/game/g_combat.c
+++ b/engine/code/game/g_combat.c
@@ -536,6 +536,10 @@ void player_die( gentity_t *self, gentity_t *inflictor, gentity_t *attacker, int
 	}
 // END
 
+	if ( g_gametype.integer == GT_ELIMINATION && level.startRaceTime ) {
+		G_RegisterEliminationDeath( self );
+	}
+
 	if ( attacker ) {
 		killer = attacker->s.number;
 		if ( attacker->client ) {

--- a/engine/code/game/g_local.h
+++ b/engine/code/game/g_local.h
@@ -521,6 +521,11 @@ typedef struct {
 	int			eliminationStartDelay;
 	int			eliminationInterval;
 	int			eliminationWarning;
+	int			eliminationNextTriggerTime;
+	int			eliminationWarningTime;
+	int			eliminationActive;
+	int			eliminationRemainingPlayers;
+	int			eliminationRound;
 
 	// map variables
 	int			numCheckpoints;
@@ -862,6 +867,11 @@ void QDECL G_DebugLogPrintf( const char *fmt, ... ) __attribute__ ((format (prin
 void SendScoreboardMessageToAllClients( void );
 void QDECL G_Printf( const char *fmt, ... ) __attribute__ ((format (printf, 1, 2)));
 void QDECL G_Error( const char *fmt, ... ) __attribute__ ((noreturn, format (printf, 1, 2)));
+void G_ResetEliminationState( void );
+void G_StartEliminationMode( void );
+void G_UpdateEliminationPlayerCount( void );
+void G_RegisterEliminationDeath( gentity_t *victim );
+
 
 //
 // g_client.c

--- a/engine/code/game/g_main.c
+++ b/engine/code/game/g_main.c
@@ -587,6 +587,7 @@ void G_InitGame( int levelTime, int randomSeed, int restart ) {
 	level.eliminationStartDelay = trap_Cvar_VariableIntegerValue( "g_eliminationStartDelay" );
 	level.eliminationInterval = trap_Cvar_VariableIntegerValue( "g_eliminationInterval" );
 	level.eliminationWarning = trap_Cvar_VariableIntegerValue( "g_eliminationWarning" );
+	G_ResetEliminationState();
 
 	level.snd_fry = G_SoundIndex("sound/player/fry.wav");	// FIXME standing in lava / slime
 
@@ -1754,6 +1755,10 @@ void CheckExitRules( void ) {
 	if ((g_gametype.integer == GT_LCS || g_gametype.integer == GT_ELIMINATION) && level.startRaceTime && !level.finishRaceTime) {
 		gclient_t	*winner = NULL;
 
+		if ( g_gametype.integer == GT_ELIMINATION ) {
+			G_UpdateEliminationPlayerCount();
+		}
+
 		for ( i=0, count = 0 ; i< g_maxclients.integer ; i++ ) {
 			cl = level.clients + i;
 			if ( cl->pers.connected != CON_CONNECTED ) continue;
@@ -1774,6 +1779,10 @@ void CheckExitRules( void ) {
 				trap_SendServerCommand( level.winnerNumber, "cp \"You won the last car standing!\n\"");
 			}
 			else {
+				level.eliminationActive = 0;
+				level.eliminationNextTriggerTime = 0;
+				level.eliminationWarningTime = 0;
+				G_UpdateEliminationPlayerCount();
 				trap_SendServerCommand( -1, va("print \"%s won the elimination race!\n\"", winner->pers.netname ));
 				trap_SendServerCommand( level.winnerNumber, "cp \"You won the elimination race!\n\"");
 			}
@@ -1912,6 +1921,127 @@ void CheckExitRules( void ) {
 	}
 }
 
+
+
+static void G_SetEliminationSchedule( int referenceTime, int interval ) {
+        int nextTime;
+        int warningTime;
+
+        if ( interval < 0 ) {
+                interval = 0;
+        }
+
+        nextTime = referenceTime + interval;
+        level.eliminationNextTriggerTime = nextTime;
+
+        if ( level.eliminationWarning <= 0 ) {
+                level.eliminationWarningTime = referenceTime;
+                return;
+        }
+
+        warningTime = nextTime - level.eliminationWarning;
+        if ( warningTime < referenceTime ) {
+                warningTime = referenceTime;
+        }
+        if ( warningTime > nextTime ) {
+                warningTime = nextTime;
+        }
+
+        level.eliminationWarningTime = warningTime;
+}
+
+void G_ResetEliminationState( void ) {
+        level.eliminationActive = 0;
+        level.eliminationRound = 0;
+        level.eliminationRemainingPlayers = 0;
+        level.eliminationNextTriggerTime = 0;
+        level.eliminationWarningTime = 0;
+
+        if ( g_gametype.integer == GT_ELIMINATION ) {
+                G_SetEliminationSchedule( level.time, level.eliminationStartDelay );
+        }
+}
+
+void G_StartEliminationMode( void ) {
+        if ( g_gametype.integer != GT_ELIMINATION ) {
+                return;
+        }
+
+        level.eliminationActive = 1;
+        level.eliminationRound = 0;
+        G_UpdateEliminationPlayerCount();
+        G_SetEliminationSchedule( level.startRaceTime ? level.startRaceTime : level.time, level.eliminationStartDelay );
+}
+
+void G_UpdateEliminationPlayerCount( void ) {
+        int i;
+        int count;
+
+        if ( g_gametype.integer != GT_ELIMINATION ) {
+                level.eliminationRemainingPlayers = 0;
+                return;
+        }
+
+        count = 0;
+        for ( i = 0 ; i < level.maxclients ; i++ ) {
+                gclient_t *cl = level.clients + i;
+
+                if ( cl->pers.connected != CON_CONNECTED ) {
+                        continue;
+                }
+                if ( cl->sess.sessionTeam == TEAM_SPECTATOR ) {
+                        continue;
+                }
+                if ( isRaceObserver( i ) ) {
+                        continue;
+                }
+                if ( level.startRaceTime ) {
+                        if ( cl->finishRaceTime ) {
+                                continue;
+                        }
+                        if ( cl->ps.stats[STAT_HEALTH] <= 0 ) {
+                                continue;
+                        }
+                }
+
+                count++;
+        }
+
+        level.eliminationRemainingPlayers = count;
+}
+
+void G_RegisterEliminationDeath( gentity_t *victim ) {
+        if ( g_gametype.integer != GT_ELIMINATION ) {
+                return;
+        }
+
+        if ( !level.eliminationActive || !level.startRaceTime ) {
+                return;
+        }
+
+        if ( !victim || !victim->client ) {
+                return;
+        }
+
+        if ( victim->client->sess.sessionTeam == TEAM_SPECTATOR ) {
+                return;
+        }
+
+        if ( isRaceObserver( victim->s.number ) ) {
+                return;
+        }
+
+        level.eliminationRound++;
+        G_UpdateEliminationPlayerCount();
+
+        if ( level.eliminationRemainingPlayers > 1 ) {
+                G_SetEliminationSchedule( level.time, level.eliminationInterval );
+        } else {
+                level.eliminationActive = 0;
+                level.eliminationNextTriggerTime = 0;
+                level.eliminationWarningTime = 0;
+        }
+}
 
 
 /*

--- a/engine/code/game/g_rally_racetools.c
+++ b/engine/code/game/g_rally_racetools.c
@@ -376,6 +376,7 @@ void RallyStarter_Think( gentity_t *ent ){
 			level.startRaceTime = level.time;
 			trap_SendServerCommand( -1, va("raceTime %i", level.startRaceTime) );
 			CenterPrint_All("GO..");
+			G_StartEliminationMode();
 
 			G_FreeEntity( ent );
 			return;
@@ -435,6 +436,7 @@ void RallyStarter_Think( gentity_t *ent ){
 		RaceCountdown("GO!", 0);
 
 		Rally_Sound( ent, EV_GLOBAL_SOUND, CHAN_ANNOUNCER, G_SoundIndex("sound/rally/race/go.wav") );
+		G_StartEliminationMode();
 
 		if (g_gametype.integer != GT_DERBY)
 			ent->think = RallyRace_Think;


### PR DESCRIPTION
## Summary
- add elimination timer and participant fields to the level state and expose helper APIs
- initialize elimination timers during game init and race start while updating elimination state on deaths and roster changes
- hook rally race start and player connect/disconnect flows to keep elimination counts current

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68cb17c6de608324b1c257e41a3568e5