### PR TITLE
Handle finish markers in race distance checks

### DIFF
--- a/engine/code/game/g_local.h
+++ b/engine/code/game/g_local.h
@@ -535,6 +535,7 @@ typedef struct {
         float                   trackLength;
         vec3_t                  startOrigin;
         vec3_t                  finishOrigin;
+        gentity_t       *finishLine;
         qboolean                hasStart;
         qboolean                hasFinish;
 

--- a/engine/code/game/g_rally_mapents.c
+++ b/engine/code/game/g_rally_mapents.c
@@ -423,6 +423,10 @@ ent->think = Think_Finish;
 ent->nextthink = level.time + 300;
 ent->s.frame = 0;
 
+level.finishLine = ent;
+VectorCopy( ent->s.origin, level.finishOrigin );
+level.hasFinish = qtrue;
+
 trap_LinkEntity (ent);
 }
 

--- a/engine/code/game/g_rally_racetools.c
+++ b/engine/code/game/g_rally_racetools.c
@@ -164,23 +164,59 @@ float GetDistanceToMarker( gentity_t *player, float markerNumber )
 {
 	gentity_t		*ent = NULL;
 	vec3_t			dist;
+	vec3_t			targetOrigin;
+	qboolean			haveTarget = qfalse;
+	int			markerId;
 
-	if ( !markerNumber )
+	if ( markerNumber <= 0.0f )
 		return 1<<30;
 
-	while ( (ent = G_Find (ent, FOFS(classname), "rally_checkpoint")) != NULL )
-	{
-		if( ent->number == markerNumber )
-			break;
+	markerId = (int)markerNumber;
+
+	if ( markerId > level.numCheckpoints ) {
+		if ( level.finishLine && level.finishLine->inuse ) {
+			VectorCopy( level.finishLine->s.origin, targetOrigin );
+			haveTarget = qtrue;
+		} else if ( level.hasFinish ) {
+			VectorCopy( level.finishOrigin, targetOrigin );
+			haveTarget = qtrue;
+		}
+
+		if ( !haveTarget ) {
+			while ( ( ent = G_Find (ent, FOFS(classname), "rally_finish" ) ) != NULL ) {
+				if ( ent->number == markerId || ent->number == 0 ) {
+					level.finishLine = ent;
+					VectorCopy( ent->s.origin, level.finishOrigin );
+					level.hasFinish = qtrue;
+					VectorCopy( ent->s.origin, targetOrigin );
+					haveTarget = qtrue;
+					break;
+				}
+			}
+		}
+	} else if ( markerId > 0 && markerId <= level.numCheckpoints ) {
+		if ( level.checkpoints[ markerId - 1 ] && level.checkpoints[ markerId - 1 ]->inuse ) {
+			VectorCopy( level.checkpoints[ markerId - 1 ]->s.origin, targetOrigin );
+			haveTarget = qtrue;
+		}
+
+		if ( !haveTarget ) {
+			while ( ( ent = G_Find (ent, FOFS(classname), "rally_checkpoint")) != NULL ) {
+				if ( ent->number == markerId ) {
+					VectorCopy( ent->s.origin, targetOrigin );
+					haveTarget = qtrue;
+					break;
+				}
+			}
+		}
 	}
 
-	if ( ent )
-	{
-		VectorSubtract(player->r.currentOrigin, ent->s.origin, dist);
-		return VectorLength(dist);
+	if ( haveTarget ) {
+		VectorSubtract( player->r.currentOrigin, targetOrigin, dist );
+		return VectorLength( dist );
 	}
-	else
-		return 1<<30;
+
+	return 1<<30;
 }
 
 /*


### PR DESCRIPTION
## Summary
- extend `GetDistanceToMarker` to resolve finish markers via cached finish origin or entity lookup before falling back to a large distance
- cache the finish trigger entity and origin during `SP_rally_finish` so finish data is available immediately after map initialization
- store the finish trigger pointer on the level state for quick access during distance calculations

## Testing
- not run (not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68cb81477b188324ac2c141df5c4cb11