### PR TITLE
Fix G_RegisterCvars comment banner

### DIFF
--- a/engine/code/game/g_main.c
+++ b/engine/code/game/g_main.c
@@ -480,6 +480,7 @@ void G_RemapTeamShaders( void ) {
 #endif
 }
 
+/*
 =================
 G_RegisterCvars
 =================


### PR DESCRIPTION
## Summary
- add the missing opening comment marker so the G_RegisterCvars banner uses a complete block comment

## Testing
- `make -j4` *(fails: missing SDL_version.h header in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cb8dba8240832496714b913cfcec08