### PR TITLE
Fix elimination driver selection for warning and elimination

### DIFF
--- a/engine/code/game/g_main.c
+++ b/engine/code/game/g_main.c
@@ -2179,10 +2179,7 @@ static void G_RunEliminationTimers( void ) {
         }
 
         if ( level.eliminationWarning > 0 && !level.eliminationWarningSent && level.eliminationWarningTime > 0 && level.time >= level.eliminationWarningTime ) {
-                target = G_GetEliminationDriverByPosition( level.eliminationRemainingPlayers );
-                if ( !target ) {
-                        target = G_GetLastEliminationDriver();
-                }
+                target = G_GetLastEliminationDriver();
 
                 if ( target ) {
                         msLeft = level.eliminationNextTriggerTime - level.time;
@@ -2206,10 +2203,7 @@ static void G_RunEliminationTimers( void ) {
                 return;
         }
 
-        target = G_GetEliminationDriverByPosition( level.eliminationRemainingPlayers );
-        if ( !target ) {
-                target = G_GetLastEliminationDriver();
-        }
+        target = G_GetLastEliminationDriver();
 
         if ( !target ) {
                 level.eliminationActive = 0;


### PR DESCRIPTION
## Summary
- update the elimination warning and execution logic to select the trailing driver via `G_GetLastEliminationDriver`
- remove the redundant position-based fallback now that the trailing driver scan is used directly

## Testing
- make -j4 *(fails: SDL_version.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68cb940081308324a41525709e750d4a