### PR TITLE
Expose elimination status to HUD and scoreboard

### DIFF
--- a/engine/code/cgame/cg_local.h
+++ b/engine/code/cgame/cg_local.h
@@ -1313,6 +1313,11 @@ typedef struct {
 // Q3Rally Code Start
 	int				numRacers;
         float                   trackLength;
+	int				eliminationActive;
+	int				eliminationRemainingPlayers;
+	int				eliminationRound;
+	int				eliminationMsRemaining;
+	int				eliminationLastUpdateTime;
 // Q3Rally Code END
 
 } cgs_t;
@@ -1485,6 +1490,40 @@ extern	vmCvar_t		cg_engineSounds;
 extern  vmCvar_t                cg_fuelWarningLevel;
 extern	vmCvar_t		cg_drawBotPaths;
 // Q3Rally Code END
+
+static ID_INLINE int CG_EliminationMsLeft( void ) {
+    int msLeft;
+
+    if ( cgs.eliminationMsRemaining <= 0 ) {
+        return 0;
+    }
+
+    if ( cgs.eliminationLastUpdateTime <= 0 ) {
+        return cgs.eliminationMsRemaining;
+    }
+
+    msLeft = cgs.eliminationMsRemaining - ( cg.time - cgs.eliminationLastUpdateTime );
+    if ( msLeft < 0 ) {
+        msLeft = 0;
+    }
+
+    return msLeft;
+}
+
+static ID_INLINE int CG_EliminationDisplayRound( void ) {
+    int round;
+
+    round = cgs.eliminationRound;
+    if ( round < 0 ) {
+        round = 0;
+    }
+
+    if ( cgs.eliminationActive && cgs.eliminationRemainingPlayers > 1 ) {
+        round++;
+    }
+
+    return round;
+}
 
 //
 // cg_main.c

--- a/engine/code/cgame/cg_rally_hud.c
+++ b/engine/code/cgame/cg_rally_hud.c
@@ -1161,6 +1161,74 @@ CG_DrawGear
 	VectorMA(pointOnPlane, -(planedist / viewdist) * DotProduct(dir, cg.refdef.viewaxis[2]), cg.refdef.viewaxis[2], pointOnPlane);
 */
 
+static float CG_DrawEliminationStatus( float y ) {
+        float x;
+        char text[64];
+        vec4_t countdownColor;
+        int drivers;
+        int displayRound;
+        int msLeft;
+        int secondsLeft;
+        qboolean showCountdown;
+
+        if ( cgs.gametype != GT_ELIMINATION ) {
+                return y;
+        }
+
+        drivers = cgs.eliminationRemainingPlayers;
+        if ( drivers < 0 ) {
+                drivers = 0;
+        }
+
+        x = 636 - 176;
+
+        CG_FillRect( x, y, 176, 18, bgColor );
+        if ( drivers > 0 ) {
+                Com_sprintf( text, sizeof( text ), "Drivers left: %i", drivers );
+        } else {
+                Q_strncpyz( text, "Drivers left: --", sizeof( text ) );
+        }
+        CG_DrawSmallDigitalStringColor( x + 10, y + 4, text, colorWhite );
+        y += TINYCHAR_HEIGHT + 4;
+
+        CG_FillRect( x, y, 176, 18, bgColor );
+        displayRound = CG_EliminationDisplayRound();
+        if ( displayRound > 0 ) {
+                Com_sprintf( text, sizeof( text ), "Round: %i", displayRound );
+        } else {
+                Q_strncpyz( text, "Round: --", sizeof( text ) );
+        }
+        CG_DrawSmallDigitalStringColor( x + 10, y + 4, text, colorWhite );
+        y += TINYCHAR_HEIGHT + 4;
+
+        CG_FillRect( x, y, 176, 18, bgColor );
+        showCountdown = ( cgs.eliminationActive && drivers > 1 );
+        if ( showCountdown ) {
+                msLeft = CG_EliminationMsLeft();
+                secondsLeft = ( msLeft + 999 ) / 1000;
+                if ( secondsLeft < 0 ) {
+                        secondsLeft = 0;
+                }
+
+                Vector4Copy( colorWhite, countdownColor );
+                if ( secondsLeft <= 5 ) {
+                        Vector4Copy( colorRed, countdownColor );
+                } else if ( secondsLeft <= 10 ) {
+                        Vector4Copy( colorYellow, countdownColor );
+                }
+
+                Com_sprintf( text, sizeof( text ), "Elimination in %is", secondsLeft );
+                CG_DrawSmallDigitalStringColor( x + 10, y + 4, text, countdownColor );
+        } else if ( cgs.eliminationActive && drivers <= 1 ) {
+                CG_DrawSmallDigitalStringColor( x + 10, y + 4, "Final driver!", colorWhite );
+        } else {
+                CG_DrawSmallDigitalStringColor( x + 10, y + 4, "Elimination in -- s", colorWhite );
+        }
+        y += TINYCHAR_HEIGHT + 4;
+
+        return y;
+}
+
 float CG_DrawUpperRightHUD( float y ) {
 	int		i;
 
@@ -1172,6 +1240,10 @@ float CG_DrawUpperRightHUD( float y ) {
 		if (cg.scores[i].ping == -1) continue;
 
 		cgs.numRacers++;
+	}
+
+	if ( cgs.gametype == GT_ELIMINATION ) {
+		y = CG_DrawEliminationStatus( y );
 	}
 
 	if (cgs.clientinfo[cg.snap->ps.clientNum].team != TEAM_SPECTATOR){

--- a/engine/code/cgame/cg_rally_hud2.c
+++ b/engine/code/cgame/cg_rally_hud2.c
@@ -190,6 +190,71 @@ void CG_DrawHUD_Positions(float x, float y){
 	}
 }
 
+static void CG_DrawHUD_EliminationStatus(float x, float y)
+{
+	char text[64];
+	vec4_t countdownColor;
+	int drivers;
+	int displayRound;
+	int msLeft;
+	int secondsLeft;
+	qboolean showCountdown;
+
+	if ( cgs.gametype != GT_ELIMINATION ) {
+		return;
+	}
+
+	drivers = cgs.eliminationRemainingPlayers;
+	if ( drivers < 0 ) {
+		drivers = 0;
+	}
+
+	CG_FillRect(x, y, 196, 18, bgColor);
+	if ( drivers > 0 ) {
+		Com_sprintf(text, sizeof(text), "Drivers left: %i", drivers);
+	} else {
+		Q_strncpyz(text, "Drivers left: --", sizeof(text));
+	}
+	CG_DrawSmallDigitalStringColor(x + 10, y + 4, text, colorWhite);
+
+	y += 20;
+
+	CG_FillRect(x, y, 196, 18, bgColor);
+	displayRound = CG_EliminationDisplayRound();
+	if ( displayRound > 0 ) {
+		Com_sprintf(text, sizeof(text), "Round: %i", displayRound);
+	} else {
+		Q_strncpyz(text, "Round: --", sizeof(text));
+	}
+	CG_DrawSmallDigitalStringColor(x + 10, y + 4, text, colorWhite);
+
+	y += 20;
+
+	CG_FillRect(x, y, 196, 18, bgColor);
+	showCountdown = ( cgs.eliminationActive && drivers > 1 );
+	if ( showCountdown ) {
+		msLeft = CG_EliminationMsLeft();
+		secondsLeft = ( msLeft + 999 ) / 1000;
+		if ( secondsLeft < 0 ) {
+			secondsLeft = 0;
+		}
+
+		Vector4Copy(colorWhite, countdownColor);
+		if ( secondsLeft <= 5 ) {
+			Vector4Copy(colorRed, countdownColor);
+		} else if ( secondsLeft <= 10 ) {
+			Vector4Copy(colorYellow, countdownColor);
+		}
+
+		Com_sprintf(text, sizeof(text), "Elimination in %is", secondsLeft);
+		CG_DrawSmallDigitalStringColor(x + 10, y + 4, text, countdownColor);
+	} else if ( cgs.eliminationActive && drivers <= 1 ) {
+		CG_DrawSmallDigitalStringColor(x + 10, y + 4, "Final driver!", colorWhite);
+	} else {
+		CG_DrawSmallDigitalStringColor(x + 10, y + 4, "Elimination in -- s", colorWhite);
+	}
+}
+
 /*
 ===============
 CG_DrawHUD_Laps
@@ -450,9 +515,12 @@ qboolean CG_DrawHUD( void ) {
                 CG_DrawHUD_Times(0, 112);
                 CG_DrawHUD_Positions(0, 228);
                 CG_DrawHUD_Laps(0, 304);
+                if (cgs.gametype == GT_ELIMINATION) {
+                        CG_DrawHUD_EliminationStatus(440, 72);
+                }
                 CG_DrawHUD_OpponentList(440, 130);
 
-		break;
+                break;
 
 	case GT_RACING_DM:
 	case GT_TEAM_RACING_DM:

--- a/engine/code/cgame/cg_scoreboard.c
+++ b/engine/code/cgame/cg_scoreboard.c
@@ -703,36 +703,47 @@ Draw game information header with gametype-specific info
 =================
 */
 static void CG_DrawModernGameInfo(int y, float fade) {
-    char *gameInfo;
+    char mainInfo[128];
+    char eliminationInfo[128];
+    char combinedInfo[256];
+    char driversText[8];
+    char roundText[8];
     int x, w;
     int leadingTeam;
-    char *teamName;
+    const char *teamName;
     vec4_t titleColor;
     qboolean isRacing;
-    
+    int drivers;
+    int displayRound;
+    int msLeft;
+    qboolean showCountdown;
+
     /* Initialize title color */
     titleColor[0] = 1.0f; titleColor[1] = 1.0f; titleColor[2] = 1.0f; titleColor[3] = fade;
-    
+
     isRacing = CG_IsRacingGametype();
-    
+
+    mainInfo[0] = '\0';
+    eliminationInfo[0] = '\0';
+
     /* Draw current rank/status */
     if (!CG_IsTeamGametype()) {
         if (cg.snap->ps.persistant[PERS_TEAM] != TEAM_SPECTATOR) {
             if (isRacing) {
-                gameInfo = va("Position %s",
-                             CG_PlaceString(cg.snap->ps.persistant[PERS_RANK] + 1));
+                Com_sprintf(mainInfo, sizeof(mainInfo), "Position %s",
+                            CG_PlaceString(cg.snap->ps.persistant[PERS_RANK] + 1));
             } else {
-                gameInfo = va("%s place with %d frags",
-                             CG_PlaceString(cg.snap->ps.persistant[PERS_RANK] + 1),
-                             cg.snap->ps.persistant[PERS_SCORE]);
+                Com_sprintf(mainInfo, sizeof(mainInfo), "%s place with %d frags",
+                            CG_PlaceString(cg.snap->ps.persistant[PERS_RANK] + 1),
+                            cg.snap->ps.persistant[PERS_SCORE]);
             }
         } else {
-            gameInfo = "Spectating";
+            Q_strncpyz(mainInfo, "Spectating", sizeof(mainInfo));
         }
     } else {
         /* Team game info */
         leadingTeam = GetTeamAtRank(1);
-        
+
         switch (leadingTeam) {
             case TEAM_RED:    teamName = "Red Team"; break;
             case TEAM_BLUE:   teamName = "Blue Team"; break;
@@ -740,17 +751,66 @@ static void CG_DrawModernGameInfo(int y, float fade) {
             case TEAM_YELLOW: teamName = "Yellow Team"; break;
             default:          teamName = "Unknown Team"; break;
         }
-        
+
         if (TiedWinner()) {
-            gameInfo = va("Teams tied");
+            Q_strncpyz(mainInfo, "Teams tied", sizeof(mainInfo));
         } else {
-            gameInfo = va("%s in lead", teamName);
+            Com_sprintf(mainInfo, sizeof(mainInfo), "%s in lead", teamName);
         }
     }
-    
-    w = CG_DrawStrlen(gameInfo) * BIGCHAR_WIDTH;
+
+    if (cgs.gametype == GT_ELIMINATION) {
+        drivers = cgs.eliminationRemainingPlayers;
+        if (drivers < 0) {
+            drivers = 0;
+        }
+
+        displayRound = CG_EliminationDisplayRound();
+        msLeft = CG_EliminationMsLeft();
+        showCountdown = (cgs.eliminationActive && drivers > 1 && msLeft > 0);
+
+        if (drivers > 0) {
+            Com_sprintf(driversText, sizeof(driversText), "%i", drivers);
+        } else {
+            Q_strncpyz(driversText, "--", sizeof(driversText));
+        }
+
+        if (displayRound > 0) {
+            Com_sprintf(roundText, sizeof(roundText), "%i", displayRound);
+        } else {
+            Q_strncpyz(roundText, "--", sizeof(roundText));
+        }
+
+        if (showCountdown) {
+            int secondsLeft = (msLeft + 999) / 1000;
+            Com_sprintf(eliminationInfo, sizeof(eliminationInfo),
+                        "Drivers: %s  Round: %s  Elim in %is",
+                        driversText, roundText, secondsLeft);
+        } else {
+            Com_sprintf(eliminationInfo, sizeof(eliminationInfo),
+                        "Drivers: %s  Round: %s",
+                        driversText, roundText);
+        }
+    }
+
+    if (eliminationInfo[0]) {
+        if (mainInfo[0]) {
+            Com_sprintf(combinedInfo, sizeof(combinedInfo), "%s - %s",
+                        mainInfo, eliminationInfo);
+        } else {
+            Q_strncpyz(combinedInfo, eliminationInfo, sizeof(combinedInfo));
+        }
+    } else {
+        Q_strncpyz(combinedInfo, mainInfo, sizeof(combinedInfo));
+    }
+
+    if (!combinedInfo[0]) {
+        Q_strncpyz(combinedInfo, " ", sizeof(combinedInfo));
+    }
+
+    w = CG_DrawStrlen(combinedInfo) * BIGCHAR_WIDTH;
     x = (SCREEN_WIDTH - w) / 2;
-    CG_DrawBigStringColor(x, y, gameInfo, titleColor);
+    CG_DrawBigStringColor(x, y, combinedInfo, titleColor);
 }
 
 /*

--- a/engine/code/cgame/cg_servercmds.c
+++ b/engine/code/cgame/cg_servercmds.c
@@ -48,6 +48,8 @@ static const orderTask_t validOrders[] = {
 
 static const int numValidOrders = ARRAY_LEN(validOrders);
 
+static void CG_ParseEliminationInfo( void );
+
 static int CG_ValidOrder(const char *p) {
 	int i;
 	for (i = 0; i < numValidOrders; i++) {
@@ -210,6 +212,8 @@ void CG_ParseServerinfo( void ) {
 	trap_Cvar_Set("g_redTeam", cgs.redTeam);
 	Q_strncpyz( cgs.blueTeam, Info_ValueForKey( info, "g_blueTeam" ), sizeof(cgs.blueTeam) );
 	trap_Cvar_Set("g_blueTeam", cgs.blueTeam);
+
+	CG_ParseEliminationInfo();
 }
 
 /*
@@ -264,6 +268,50 @@ static void CG_ParseSigilStatus( void ) {
 	}
 }
 
+static void CG_ParseEliminationInfo( void ) {
+	const char *str;
+	int active = 0;
+	int remaining = 0;
+	int round = 0;
+	int msLeft = 0;
+	int parsed;
+
+	str = CG_ConfigString( CS_ELIMINATION_INFO );
+
+	if ( str && *str ) {
+		parsed = sscanf( str, "%i %i %i %i", &active, &remaining, &round, &msLeft );
+		if ( parsed < 4 ) {
+		active = 0;
+		remaining = 0;
+		round = 0;
+		msLeft = 0;
+		}
+	}
+
+	if ( active < 0 ) {
+		active = 0;
+	}
+	if ( remaining < 0 ) {
+		remaining = 0;
+	}
+	if ( round < 0 ) {
+		round = 0;
+	}
+	if ( msLeft < 0 ) {
+		msLeft = 0;
+	}
+
+	if ( cgs.gametype != GT_ELIMINATION ) {
+		active = 0;
+	}
+
+	cgs.eliminationActive = active;
+	cgs.eliminationRemainingPlayers = remaining;
+	cgs.eliminationRound = round;
+	cgs.eliminationMsRemaining = msLeft;
+	cgs.eliminationLastUpdateTime = active ? cg.time : 0;
+}
+
 /*
 ===============================================================
 CG_SetConfigValues
@@ -281,7 +329,8 @@ cgs.scores3 = atoi( CG_ConfigString( CS_SCORES3 ) );
 cgs.scores4 = atoi( CG_ConfigString( CS_SCORES4 ) );
 // END
 cgs.levelStartTime = atoi( CG_ConfigString( CS_LEVEL_START_TIME ) );
-cgs.trackLength = atof( CG_ConfigString( CS_TRACKLENGTH ) );
+	cgs.trackLength = atof( CG_ConfigString( CS_TRACKLENGTH ) );
+	CG_ParseEliminationInfo();
 if( cgs.gametype == GT_CTF ) {
 		s = CG_ConfigString( CS_FLAGSTATUS );
 		cgs.redflag = s[0] - '0';
@@ -376,15 +425,17 @@ static void CG_ConfigStringModified( void ) {
 	} else if ( num == CS_SCORES2 ) {
 		cgs.scores2 = atoi( str );
 // Q3Rally Code Start
-	} else if ( num == CS_SCORES3 ) {
-		cgs.scores3 = atoi( str );
-	} else if ( num == CS_SCORES4 ) {
-		cgs.scores4 = atoi( str );
+        } else if ( num == CS_SCORES3 ) {
+                cgs.scores3 = atoi( str );
+        } else if ( num == CS_SCORES4 ) {
+                cgs.scores4 = atoi( str );
 // END
-	} else if ( num == CS_TRACKLENGTH ) {
-		cgs.trackLength = atof( str );
-	} else if ( num == CS_LEVEL_START_TIME ) {
-		cgs.levelStartTime = atoi( str );
+        } else if ( num == CS_ELIMINATION_INFO ) {
+                CG_ParseEliminationInfo();
+        } else if ( num == CS_TRACKLENGTH ) {
+                cgs.trackLength = atof( str );
+        } else if ( num == CS_LEVEL_START_TIME ) {
+                cgs.levelStartTime = atoi( str );
 	} else if ( num == CS_VOTE_TIME ) {
 		cgs.voteTime = atoi( str );
 		cgs.voteModified = qtrue;

--- a/engine/code/game/bg_public.h
+++ b/engine/code/game/bg_public.h
@@ -105,9 +105,10 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #define CS_REFLECTION_IMAGE             29
 #define CS_SIGILSTATUS                  30
 #define CS_TRACKLENGTH                  31
+#define CS_ELIMINATION_INFO             32
 // Q3Rally Code END
 
-#define CS_MODELS                               32
+#define CS_MODELS                               (CS_ELIMINATION_INFO+1)
 #define CS_SOUNDS                               (CS_MODELS+MAX_MODELS)
 // STONELANCE
 //#define       CS_PLAYERS                              (CS_SOUNDS+MAX_SOUNDS)

--- a/engine/code/game/g_main.c
+++ b/engine/code/game/g_main.c
@@ -308,6 +308,7 @@ void G_RunFrame( int levelTime );
 void G_ShutdownGame( int restart );
 void CheckExitRules( void );
 static void G_RunEliminationTimers( void );
+static void G_UpdateEliminationInfoConfigString( void );
 
 
 /*
@@ -1924,6 +1925,53 @@ void CheckExitRules( void ) {
 
 
 
+static void G_UpdateEliminationInfoConfigString( void ) {
+        static int lastActive = -1;
+        static int lastRemaining = -1;
+        static int lastRound = -1;
+        static int lastMsLeft = -1;
+        int active;
+        int remaining;
+        int round;
+        int msLeft;
+
+        if ( g_gametype.integer != GT_ELIMINATION ) {
+                active = 0;
+                remaining = 0;
+                round = 0;
+                msLeft = 0;
+        } else {
+                active = ( level.eliminationActive && level.startRaceTime && !level.finishRaceTime ) ? 1 : 0;
+                remaining = level.eliminationRemainingPlayers;
+                if ( remaining < 0 ) {
+                        remaining = 0;
+                }
+                round = level.eliminationRound;
+                if ( round < 0 ) {
+                        round = 0;
+                }
+
+                if ( active && level.eliminationNextTriggerTime > level.time && remaining > 1 ) {
+                        msLeft = level.eliminationNextTriggerTime - level.time;
+                } else {
+                        msLeft = 0;
+                }
+
+                if ( msLeft < 0 ) {
+                        msLeft = 0;
+                }
+        }
+
+        if ( lastActive != active || lastRemaining != remaining || lastRound != round || lastMsLeft != msLeft ) {
+                trap_SetConfigstring( CS_ELIMINATION_INFO,
+                        va( "%i %i %i %i", active, remaining, round, msLeft ) );
+                lastActive = active;
+                lastRemaining = remaining;
+                lastRound = round;
+                lastMsLeft = msLeft;
+        }
+}
+
 static void G_SetEliminationSchedule( int referenceTime, int interval ) {
         int nextTime;
         int warningTime;
@@ -1950,6 +1998,8 @@ static void G_SetEliminationSchedule( int referenceTime, int interval ) {
         }
 
         level.eliminationWarningTime = warningTime;
+
+        G_UpdateEliminationInfoConfigString();
 }
 
 void G_ResetEliminationState( void ) {
@@ -1963,6 +2013,8 @@ void G_ResetEliminationState( void ) {
         if ( g_gametype.integer == GT_ELIMINATION ) {
                 G_SetEliminationSchedule( level.time, level.eliminationStartDelay );
         }
+
+        G_UpdateEliminationInfoConfigString();
 }
 
 void G_StartEliminationMode( void ) {
@@ -1982,6 +2034,7 @@ void G_UpdateEliminationPlayerCount( void ) {
 
         if ( g_gametype.integer != GT_ELIMINATION ) {
                 level.eliminationRemainingPlayers = 0;
+                G_UpdateEliminationInfoConfigString();
                 return;
         }
 
@@ -2011,6 +2064,8 @@ void G_UpdateEliminationPlayerCount( void ) {
         }
 
         level.eliminationRemainingPlayers = count;
+
+        G_UpdateEliminationInfoConfigString();
 }
 
 void G_RegisterEliminationDeath( gentity_t *victim ) {
@@ -2044,6 +2099,8 @@ void G_RegisterEliminationDeath( gentity_t *victim ) {
                 level.eliminationNextTriggerTime = 0;
                 level.eliminationWarningTime = 0;
                 level.eliminationWarningSent = qfalse;
+
+                G_UpdateEliminationInfoConfigString();
         }
 }
 
@@ -2188,6 +2245,7 @@ static void G_RunEliminationTimers( void ) {
                 level.eliminationNextTriggerTime = 0;
                 level.eliminationWarningTime = 0;
                 level.eliminationWarningSent = qfalse;
+                G_UpdateEliminationInfoConfigString();
                 return;
         }
 


### PR DESCRIPTION
## Summary
- add a CS_ELIMINATION_INFO configstring broadcast so clients receive live elimination status
- parse the new data into shared helpers and render elimination countdown/driver info on both rally HUD variants
- surface remaining drivers and round data in the modern scoreboard header for GT_ELIMINATION

## Testing
- `make -C engine` *(fails: missing SDL headers in the container build environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cc6a4d4d34832488fe121a651b1bb9