### PR TITLE
Ensure CG_ParseEliminationInfo prototype declared without MISSIONPACK

### DIFF
--- a/engine/code/cgame/cg_servercmds.c
+++ b/engine/code/cgame/cg_servercmds.c
@@ -48,8 +48,6 @@ static const orderTask_t validOrders[] = {
 
 static const int numValidOrders = ARRAY_LEN(validOrders);
 
-static void CG_ParseEliminationInfo( void );
-
 static int CG_ValidOrder(const char *p) {
 	int i;
 	for (i = 0; i < numValidOrders; i++) {
@@ -60,6 +58,8 @@ static int CG_ValidOrder(const char *p) {
 	return -1;
 }
 #endif
+
+static void CG_ParseEliminationInfo( void );
 
 /*
 =================


### PR DESCRIPTION
## Summary
- move the CG_ParseEliminationInfo forward declaration outside the MISSIONPACK guard so it is always available

## Testing
- `make -C engine` *(fails: missing SDL_version.h dependency in the container)*


------
https://chatgpt.com/codex/tasks/task_e_68cc75fac8048324928c06deb37bf230