### PR TITLE
Fix elimination helpers for Q3 VM builds

### DIFF
--- a/engine/code/cgame/cg_local.h
+++ b/engine/code/cgame/cg_local.h
@@ -1491,6 +1491,10 @@ extern  vmCvar_t                cg_fuelWarningLevel;
 extern	vmCvar_t		cg_drawBotPaths;
 // Q3Rally Code END
 
+#ifdef Q3_VM
+int CG_EliminationMsLeft( void );
+int CG_EliminationDisplayRound( void );
+#else
 static ID_INLINE int CG_EliminationMsLeft( void ) {
     int msLeft;
 
@@ -1524,6 +1528,7 @@ static ID_INLINE int CG_EliminationDisplayRound( void ) {
 
     return round;
 }
+#endif
 
 //
 // cg_main.c

--- a/engine/code/cgame/cg_servercmds.c
+++ b/engine/code/cgame/cg_servercmds.c
@@ -26,6 +26,43 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 // be a valid snapshot this frame
 
 #include "cg_local.h"
+
+#ifdef Q3_VM
+int CG_EliminationMsLeft( void ) {
+    int msLeft;
+
+    if ( cgs.eliminationMsRemaining <= 0 ) {
+        return 0;
+    }
+
+    if ( cgs.eliminationLastUpdateTime <= 0 ) {
+        return cgs.eliminationMsRemaining;
+    }
+
+    msLeft = cgs.eliminationMsRemaining - ( cg.time - cgs.eliminationLastUpdateTime );
+    if ( msLeft < 0 ) {
+        msLeft = 0;
+    }
+
+    return msLeft;
+}
+
+int CG_EliminationDisplayRound( void ) {
+    int round;
+
+    round = cgs.eliminationRound;
+    if ( round < 0 ) {
+        round = 0;
+    }
+
+    if ( cgs.eliminationActive && cgs.eliminationRemainingPlayers > 1 ) {
+        round++;
+    }
+
+    return round;
+}
+#endif
+
 #ifdef MISSIONPACK
 #include "../../ui/menudef.h"
 


### PR DESCRIPTION
## Summary
- guard CG_EliminationMsLeft and CG_EliminationDisplayRound so they are only emitted from a single object when building Q3 VMs
- provide shared Q3_VM implementations in cg_servercmds.c so both VM and native builds reuse the same logic

## Testing
- make -C engine *(fails: missing SDL_version.h in container)*
- make -C engine release *(fails: missing SDL_version.h in container)*
- make -C engine BUILD_CLIENT=0

------
https://chatgpt.com/codex/tasks/task_e_68ccd739dbcc8324b3793a53694a7ca7