### PR TITLE
Prevent elimination respawn after finish

### DIFF
--- a/engine/code/game/g_active.c
+++ b/engine/code/game/g_active.c
@@ -1631,7 +1631,10 @@ void ClientThink_real( gentity_t *ent ) {
 			if ( g_forcerespawn.integer > 0 && 
 				( level.time - client->respawnTime ) > g_forcerespawn.integer * 1000 ) {
 // STONELANCE
-				if ((g_gametype.integer != GT_DERBY && g_gametype.integer != GT_LCS) || !ent->client->finishRaceTime)
+				if ( (g_gametype.integer != GT_DERBY
+					&& g_gametype.integer != GT_LCS
+					&& g_gametype.integer != GT_ELIMINATION)
+					|| !ent->client->finishRaceTime )
 // END
 				ClientRespawn( ent );
 				return;
@@ -1640,7 +1643,10 @@ void ClientThink_real( gentity_t *ent ) {
 			// pressing attack or use is the normal respawn method
 			if ( ucmd->buttons & ( BUTTON_ATTACK | BUTTON_USE_HOLDABLE ) ) {
 // STONELANCE
-				if ((g_gametype.integer != GT_DERBY && g_gametype.integer != GT_LCS) || !ent->client->finishRaceTime)
+				if ( (g_gametype.integer != GT_DERBY
+					&& g_gametype.integer != GT_LCS
+					&& g_gametype.integer != GT_ELIMINATION)
+					|| !ent->client->finishRaceTime )
 // END
 				ClientRespawn( ent );
 			}


### PR DESCRIPTION
## Summary
- guard ClientRespawn from running in elimination races once a racer has a finishRaceTime
- extend the existing forcerespawn and manual respawn shortcuts to include the elimination gametype

## Testing
- make -j4 *(fails: missing SDL_version.h dependency in container)*

------
https://chatgpt.com/codex/tasks/task_e_68ccdc4763bc83249ade2ac00f301314