### PR TITLE
Add elimination means of death

### DIFF
--- a/engine/code/cgame/cg_event.c
+++ b/engine/code/cgame/cg_event.c
@@ -219,6 +219,9 @@ static void CG_Obituary( entityState_t *ent ) {
 	case MOD_HIGH_FORCES:
 		message = "put a little too much stress on his car";
 		break;
+	case MOD_ELIMINATION:
+		message = "was eliminated";
+		break;
 // Q3Rally Code END
 	default:
 		message = NULL;

--- a/engine/code/game/bg_public.h
+++ b/engine/code/game/bg_public.h
@@ -772,6 +772,7 @@ typedef enum {
         MOD_POISON,
         MOD_FIRE,
         MOD_GRAPPLE,
+        MOD_ELIMINATION,
         MOD_BREAKABLE_SPLASH
 } meansOfDeath_t;
 

--- a/engine/code/game/g_combat.c
+++ b/engine/code/game/g_combat.c
@@ -366,9 +366,10 @@ char	*modNames[] = {
 	"MOD_MINE",
 	"MOD_POISON",
 	"MOD_FIRE",
-	"MOD_FLAME_THROWER",
+	"MOD_GRAPPLE",
+	"MOD_ELIMINATION",
+	"MOD_BREAKABLE_SPLASH"
 // Q3Rally Code END
-	"MOD_GRAPPLE"
 };
 
 #ifdef MISSIONPACK
@@ -582,7 +583,9 @@ void player_die( gentity_t *self, gentity_t *inflictor, gentity_t *attacker, int
 		attacker->client->lastkilled_client = self->s.number;
 
 		if ( attacker == self || OnSameTeam (self, attacker ) ) {
-			AddScore( attacker, self->r.currentOrigin, -1 );
+			if ( meansOfDeath != MOD_ELIMINATION ) {
+				AddScore( attacker, self->r.currentOrigin, -1 );
+			}
 		} else {
 			AddScore( attacker, self->r.currentOrigin, 1 );
 
@@ -620,9 +623,9 @@ void player_die( gentity_t *self, gentity_t *inflictor, gentity_t *attacker, int
                         attacker->client->ps.stats[STAT_FUEL] = (int)attacker->client->car.fuel;
 
                 }
-        } else {
-                AddScore( self, self->r.currentOrigin, -1 );
-        }
+	} else if ( meansOfDeath != MOD_ELIMINATION ) {
+		AddScore( self, self->r.currentOrigin, -1 );
+	}
 
 	// Add team bonuses
 	Team_FragBonuses(self, inflictor, attacker);

--- a/engine/code/game/g_main.c
+++ b/engine/code/game/g_main.c
@@ -2183,7 +2183,7 @@ static void G_ForceEliminationDeath( gentity_t *victim ) {
 
         victim->flags &= ~FL_GODMODE;
         victim->client->ps.stats[STAT_HEALTH] = victim->health = -999;
-        player_die( victim, NULL, NULL, 100000, MOD_SUICIDE );
+	player_die( victim, NULL, NULL, 100000, MOD_ELIMINATION );
 }
 
 static void G_RunEliminationTimers( void ) {


### PR DESCRIPTION
## Summary
- add a dedicated MOD_ELIMINATION means-of-death constant and register it for logging
- use MOD_ELIMINATION for forced eliminations without awarding penalties or suicide handling
- show a client obituary that says players "were eliminated" instead of a generic suicide line

## Testing
- not run (not available in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68ccdfba80f88324b06fff41363cd236