### PR TITLE
Use tiny font for elimination HUD panels

### DIFF
--- a/engine/code/cgame/cg_rally_hud.c
+++ b/engine/code/cgame/cg_rally_hud.c
@@ -1170,6 +1170,7 @@ static float CG_DrawEliminationStatus( float y ) {
         int msLeft;
         int secondsLeft;
         qboolean showCountdown;
+        const float lineAdvance = TINYCHAR_HEIGHT + 8.0f;
 
         if ( cgs.gametype != GT_ELIMINATION ) {
                 return y;
@@ -1188,8 +1189,8 @@ static float CG_DrawEliminationStatus( float y ) {
         } else {
                 Q_strncpyz( text, "DRIVERS LEFT: --", sizeof( text ) );
         }
-        CG_DrawSmallDigitalStringColor( x + 10, y + 4, text, colorWhite );
-        y += TINYCHAR_HEIGHT + 4;
+        CG_DrawTinyDigitalStringColor( x + 10, y + 4, text, colorWhite );
+        y += lineAdvance;
 
         CG_FillRect( x, y, 176, 18, bgColor );
         displayRound = CG_EliminationDisplayRound();
@@ -1198,8 +1199,8 @@ static float CG_DrawEliminationStatus( float y ) {
         } else {
                 Q_strncpyz( text, "ROUND: --", sizeof( text ) );
         }
-        CG_DrawSmallDigitalStringColor( x + 10, y + 4, text, colorWhite );
-        y += TINYCHAR_HEIGHT + 4;
+        CG_DrawTinyDigitalStringColor( x + 10, y + 4, text, colorWhite );
+        y += lineAdvance;
 
         CG_FillRect( x, y, 176, 18, bgColor );
         showCountdown = ( cgs.eliminationActive && drivers > 1 );
@@ -1218,13 +1219,13 @@ static float CG_DrawEliminationStatus( float y ) {
                 }
 
                 Com_sprintf( text, sizeof( text ), "ELIMINATION IN %iS", secondsLeft );
-                CG_DrawSmallDigitalStringColor( x + 10, y + 4, text, countdownColor );
+                CG_DrawTinyDigitalStringColor( x + 10, y + 4, text, countdownColor );
         } else if ( cgs.eliminationActive && drivers <= 1 ) {
-                CG_DrawSmallDigitalStringColor( x + 10, y + 4, "FINAL DRIVER!", colorWhite );
+                CG_DrawTinyDigitalStringColor( x + 10, y + 4, "FINAL DRIVER!", colorWhite );
         } else {
-                CG_DrawSmallDigitalStringColor( x + 10, y + 4, "ELIMINATION IN -- S", colorWhite );
+                CG_DrawTinyDigitalStringColor( x + 10, y + 4, "ELIMINATION IN -- S", colorWhite );
         }
-        y += TINYCHAR_HEIGHT + 4;
+        y += lineAdvance;
 
         return y;
 }

--- a/engine/code/cgame/cg_rally_hud2.c
+++ b/engine/code/cgame/cg_rally_hud2.c
@@ -199,6 +199,7 @@ static void CG_DrawHUD_EliminationStatus(float x, float y)
 	int msLeft;
 	int secondsLeft;
 	qboolean showCountdown;
+	const float lineAdvance = TINYCHAR_HEIGHT + 8.0f;
 
 	if ( cgs.gametype != GT_ELIMINATION ) {
 		return;
@@ -215,9 +216,9 @@ static void CG_DrawHUD_EliminationStatus(float x, float y)
         } else {
                 Q_strncpyz(text, "DRIVERS LEFT: --", sizeof(text));
         }
-        CG_DrawSmallDigitalStringColor(x + 10, y + 4, text, colorWhite);
+        CG_DrawTinyDigitalStringColor(x + 10, y + 4, text, colorWhite);
 
-        y += 20;
+        y += lineAdvance;
 
         CG_FillRect(x, y, 196, 18, bgColor);
         displayRound = CG_EliminationDisplayRound();
@@ -226,9 +227,9 @@ static void CG_DrawHUD_EliminationStatus(float x, float y)
         } else {
                 Q_strncpyz(text, "ROUND: --", sizeof(text));
         }
-        CG_DrawSmallDigitalStringColor(x + 10, y + 4, text, colorWhite);
+        CG_DrawTinyDigitalStringColor(x + 10, y + 4, text, colorWhite);
 
-        y += 20;
+        y += lineAdvance;
 
 	CG_FillRect(x, y, 196, 18, bgColor);
 	showCountdown = ( cgs.eliminationActive && drivers > 1 );
@@ -247,11 +248,11 @@ static void CG_DrawHUD_EliminationStatus(float x, float y)
 		}
 
                 Com_sprintf(text, sizeof(text), "ELIMINATION IN %iS", secondsLeft);
-                CG_DrawSmallDigitalStringColor(x + 10, y + 4, text, countdownColor);
+                CG_DrawTinyDigitalStringColor(x + 10, y + 4, text, countdownColor);
         } else if ( cgs.eliminationActive && drivers <= 1 ) {
-                CG_DrawSmallDigitalStringColor(x + 10, y + 4, "FINAL DRIVER!", colorWhite);
+                CG_DrawTinyDigitalStringColor(x + 10, y + 4, "FINAL DRIVER!", colorWhite);
         } else {
-                CG_DrawSmallDigitalStringColor(x + 10, y + 4, "ELIMINATION IN -- S", colorWhite);
+                CG_DrawTinyDigitalStringColor(x + 10, y + 4, "ELIMINATION IN -- S", colorWhite);
         }
 }
 


### PR DESCRIPTION
## Summary
- switch the elimination status panel in cg_rally_hud.c to the tiny digital font and reuse a shared line advance to keep the 18px cadence within the 176px box
- mirror the tiny font and spacing change in the alternate HUD implementation so both panels match the times/laps module

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cd70e8a3108324aa16972a8aaef828