### PR TITLE
Fix elimination countdown declarations for C89

### DIFF
--- a/engine/code/cgame/cg_rally_hud.c
+++ b/engine/code/cgame/cg_rally_hud.c
@@ -1220,15 +1220,15 @@ static float CG_DrawEliminationStatus( float y ) {
         CG_FillRect( x, y, 176, 18, bgColor );
         showCountdown = ( cgs.eliminationActive && drivers > 1 );
         if ( showCountdown ) {
+                const char *label = "ELIMINATION IN";
+                const float labelX = x + 10.0f;
+                const float valueX = labelX + ( CG_DrawStrlen( label ) + 1 ) * tinyCharWidth;
+
                 msLeft = CG_EliminationMsLeft();
                 secondsLeft = ( msLeft + 999 ) / 1000;
                 if ( secondsLeft < 0 ) {
                         secondsLeft = 0;
                 }
-
-                const char *label = "ELIMINATION IN";
-                const float labelX = x + 10.0f;
-                const float valueX = labelX + ( CG_DrawStrlen( label ) + 1 ) * tinyCharWidth;
 
                 Vector4Copy( colorWhite, countdownColor );
                 if ( secondsLeft <= 5 ) {

--- a/engine/code/cgame/cg_rally_hud2.c
+++ b/engine/code/cgame/cg_rally_hud2.c
@@ -249,15 +249,15 @@ static void CG_DrawHUD_EliminationStatus(float x, float y)
         CG_FillRect(x, y, 196, 18, bgColor);
         showCountdown = ( cgs.eliminationActive && drivers > 1 );
         if ( showCountdown ) {
+                const char *label = "ELIMINATION IN";
+                const float labelX = x + 10.0f;
+                const float valueX = labelX + ( CG_DrawStrlen( label ) + 1 ) * tinyCharWidth;
+
                 msLeft = CG_EliminationMsLeft();
                 secondsLeft = ( msLeft + 999 ) / 1000;
                 if ( secondsLeft < 0 ) {
                         secondsLeft = 0;
                 }
-
-                const char *label = "ELIMINATION IN";
-                const float labelX = x + 10.0f;
-                const float valueX = labelX + ( CG_DrawStrlen( label ) + 1 ) * tinyCharWidth;
 
                 Vector4Copy(colorWhite, countdownColor);
                 if ( secondsLeft <= 5 ) {


### PR DESCRIPTION
## Summary
- ensure countdown label, labelX, and valueX declarations appear before statements in cg_rally_hud.c and cg_rally_hud2.c to satisfy C89 rules

## Testing
- make BUILD_GAME_SO=1 BUILD_BASEGAME=1 BUILD_CLIENT=0 BUILD_SERVER=0 BUILD_GAME_QVM=0 release

------
https://chatgpt.com/codex/tasks/task_e_68cdcb491ffc8324952e9016bb82ada5