### PR TITLE
Ensure elimination configstring updates for zero warning

### DIFF
--- a/engine/code/game/g_main.c
+++ b/engine/code/game/g_main.c
@@ -1986,18 +1986,17 @@ static void G_SetEliminationSchedule( int referenceTime, int interval ) {
 
         if ( level.eliminationWarning <= 0 ) {
                 level.eliminationWarningTime = referenceTime;
-                return;
-        }
+        } else {
+                warningTime = nextTime - level.eliminationWarning;
+                if ( warningTime < referenceTime ) {
+                        warningTime = referenceTime;
+                }
+                if ( warningTime > nextTime ) {
+                        warningTime = nextTime;
+                }
 
-        warningTime = nextTime - level.eliminationWarning;
-        if ( warningTime < referenceTime ) {
-                warningTime = referenceTime;
+                level.eliminationWarningTime = warningTime;
         }
-        if ( warningTime > nextTime ) {
-                warningTime = nextTime;
-        }
-
-        level.eliminationWarningTime = warningTime;
 
         G_UpdateEliminationInfoConfigString();
 }


### PR DESCRIPTION
## Summary
- always refresh the elimination info configstring when scheduling updates so the HUD sees countdown changes even if warnings are disabled

## Testing
- make -C engine release BUILD_GAME_SO=0 BUILD_SERVER=0 *(fails: missing SDL_version.h dependency in container)*
- make -C engine release BUILD_GAME_SO=0 BUILD_SERVER=0 BUILD_CLIENT=0
- make -C engine release BUILD_GAME_SO=0 BUILD_SERVER=1 BUILD_CLIENT=0
- engine/build/release-linux-x86_64/q3rally-server.x86_64 +set fs_basepath . +set dedicated 1 +set g_gametype 5 +set g_eliminationWarning 0 +map q3r_elimination *(fails: q3r_elimination map unavailable in repo data)*

------
https://chatgpt.com/codex/tasks/task_e_68ce4b30e8448324816f1c65c69c381b