### PR TITLE
Use standard tiny font for rally HUD readouts

### DIFF
--- a/engine/code/cgame/cg_rally_hud.c
+++ b/engine/code/cgame/cg_rally_hud.c
@@ -474,7 +474,7 @@ static float CG_DrawTimes( float y ) {
 
 		CG_FillRect( boxX, y, boxWidth, boxHeight, bgColor );
 		CG_DrawTinyStringColor( labelX, drawY, label, colorWhite );
-		CG_DrawTinyDigitalStringColor( valueX, drawY, time, colorWhite );
+		CG_DrawTinyStringColor( valueX, drawY, time, colorWhite );
 		y += lineAdvance;
 	}
 
@@ -492,7 +492,7 @@ static float CG_DrawTimes( float y ) {
 
 		CG_FillRect( boxX, y, boxWidth, boxHeight, bgColor );
 		CG_DrawTinyStringColor( labelX, drawY, label, colorWhite );
-		CG_DrawTinyDigitalStringColor( valueX, drawY, time, colorWhite );
+		CG_DrawTinyStringColor( valueX, drawY, time, colorWhite );
 		y += lineAdvance;
 	}
 
@@ -510,7 +510,7 @@ static float CG_DrawTimes( float y ) {
 
 		CG_FillRect( boxX, y, boxWidth, boxHeight, bgColor );
 		CG_DrawTinyStringColor( labelX, drawY, label, colorWhite );
-		CG_DrawTinyDigitalStringColor( valueX, drawY, time, colorWhite );
+		CG_DrawTinyStringColor( valueX, drawY, time, colorWhite );
 		y += lineAdvance;
 	}
 
@@ -563,7 +563,7 @@ static float CG_DrawLaps( float y ) {
 		const float drawY = y + labelOffsetY;
 
 		CG_DrawTinyStringColor( labelX, drawY, label, colorWhite );
-		CG_DrawTinyDigitalStringColor( valueX, drawY, value, colorWhite );
+		CG_DrawTinyStringColor( valueX, drawY, value, colorWhite );
 	}
 	y += lineAdvance;
 
@@ -688,7 +688,7 @@ static float CG_DrawDistanceToFinish( float y ) {
 
 		CG_FillRect( boxX, y, boxWidth, boxHeight, bgColor );
 		CG_DrawTinyStringColor( labelX, drawY, label, colorWhite );
-		CG_DrawTinyDigitalStringColor( valueX, drawY, numericValue, colorWhite );
+		CG_DrawTinyStringColor( valueX, drawY, numericValue, colorWhite );
 		if ( unit[0] != '\0' ) {
 			const float unitX = valueX + CG_DrawStrlen( numericValue ) * tinyCharWidth;
 			CG_DrawTinyStringColor( unitX, drawY, unit, colorWhite );
@@ -733,7 +733,7 @@ static float CG_DrawCurrentPosition( float y ) {
 		const float	valueX = labelX + ( CG_DrawStrlen( label ) + 1 ) * tinyCharWidth;
 
 		CG_DrawTinyStringColor( labelX, drawY, label, colorWhite );
-		CG_DrawTinyDigitalStringColor( valueX, drawY, va( "%i/%i", pos, cgs.numRacers ), colorWhite );
+		CG_DrawTinyStringColor( valueX, drawY, va( "%i/%i", pos, cgs.numRacers ), colorWhite );
 	}
 
 	y += 20;
@@ -806,7 +806,7 @@ static float CG_DrawCarAheadAndBehind( float y ) {
 			Com_sprintf( positionLabel, sizeof( positionLabel ), "%i", cg_entities[num].currentPosition );
 		}
 
-		CG_DrawTinyDigitalStringColor( numberX, y, positionLabel, colorWhite );
+		CG_DrawTinyStringColor( numberX, y, positionLabel, colorWhite );
 
 		if ( player[0] != '\0' ) {
 			CG_DrawTinyStringColor( nameX, y, player, colorWhite );
@@ -1201,7 +1201,7 @@ CG_DrawGear
  static float CG_DrawGear( float y ) {
 	CG_DrawSmallDigitalStringColor( 560, y, va("Gear: %d", cg.predictedPlayerState.stats[STAT_GEAR]), colors[0]);
 	y -= SMALLCHAR_HEIGHT;
-	CG_DrawTinyDigitalStringColor( 560, y, va("RPM: %d", cg.predictedPlayerState.stats[STAT_RPM]), colorWhite);
+	CG_DrawTinyStringColor( 560, y, va("RPM: %d", cg.predictedPlayerState.stats[STAT_RPM]), colorWhite);
 	y -= SMALLCHAR_HEIGHT;
 	return y;
 }
@@ -1253,7 +1253,7 @@ static float CG_DrawEliminationStatus( float y ) {
                 } else {
                         Q_strncpyz( text, "--", sizeof( text ) );
                 }
-                CG_DrawTinyDigitalStringColor( valueX, y + 4, text, colorWhite );
+                CG_DrawTinyStringColor( valueX, y + 4, text, colorWhite );
         }
         y += lineAdvance;
 
@@ -1270,7 +1270,7 @@ static float CG_DrawEliminationStatus( float y ) {
                 } else {
                         Q_strncpyz( text, "--", sizeof( text ) );
                 }
-                CG_DrawTinyDigitalStringColor( valueX, y + 4, text, colorWhite );
+                CG_DrawTinyStringColor( valueX, y + 4, text, colorWhite );
         }
         y += lineAdvance;
 
@@ -1296,7 +1296,7 @@ static float CG_DrawEliminationStatus( float y ) {
 
                 Com_sprintf( text, sizeof( text ), "%i", secondsLeft );
                 CG_DrawTinyStringColor( labelX, y + 4, label, countdownColor );
-                CG_DrawTinyDigitalStringColor( valueX, y + 4, text, countdownColor );
+                CG_DrawTinyStringColor( valueX, y + 4, text, countdownColor );
                 CG_DrawTinyStringColor( valueX + CG_DrawStrlen( text ) * tinyCharWidth, y + 4, "S", countdownColor );
         } else if ( cgs.eliminationActive && drivers <= 1 ) {
                 CG_DrawTinyStringColor( x + 10.0f, y + 4, "FINAL DRIVER!", colorWhite );
@@ -1307,7 +1307,7 @@ static float CG_DrawEliminationStatus( float y ) {
 
                 CG_DrawTinyStringColor( labelX, y + 4, label, colorWhite );
                 Q_strncpyz( text, "--", sizeof( text ) );
-                CG_DrawTinyDigitalStringColor( valueX, y + 4, text, colorWhite );
+                CG_DrawTinyStringColor( valueX, y + 4, text, colorWhite );
                 CG_DrawTinyStringColor( valueX + CG_DrawStrlen( text ) * tinyCharWidth, y + 4, " S", colorWhite );
         }
         y += lineAdvance;

--- a/engine/code/cgame/cg_rally_hud2.c
+++ b/engine/code/cgame/cg_rally_hud2.c
@@ -225,7 +225,7 @@ static void CG_DrawHUD_EliminationStatus(float y)
                 } else {
                         Q_strncpyz( text, "--", sizeof( text ) );
                 }
-                CG_DrawTinyDigitalStringColor( valueX, y + 4, text, colorWhite );
+                CG_DrawTinyStringColor( valueX, y + 4, text, colorWhite );
         }
 
         y += lineAdvance;
@@ -243,7 +243,7 @@ static void CG_DrawHUD_EliminationStatus(float y)
                 } else {
                         Q_strncpyz( text, "--", sizeof( text ) );
                 }
-                CG_DrawTinyDigitalStringColor( valueX, y + 4, text, colorWhite );
+                CG_DrawTinyStringColor( valueX, y + 4, text, colorWhite );
         }
 
         y += lineAdvance;
@@ -270,7 +270,7 @@ static void CG_DrawHUD_EliminationStatus(float y)
 
                 Com_sprintf( text, sizeof( text ), "%i", secondsLeft );
                 CG_DrawTinyStringColor( labelX, y + 4, label, countdownColor );
-                CG_DrawTinyDigitalStringColor( valueX, y + 4, text, countdownColor );
+                CG_DrawTinyStringColor( valueX, y + 4, text, countdownColor );
                 CG_DrawTinyStringColor( valueX + CG_DrawStrlen( text ) * tinyCharWidth, y + 4, "S", countdownColor );
         } else if ( cgs.eliminationActive && drivers <= 1 ) {
                 CG_DrawTinyStringColor( baseX + 10.0f, y + 4, "FINAL DRIVER!", colorWhite );
@@ -281,7 +281,7 @@ static void CG_DrawHUD_EliminationStatus(float y)
 
                 CG_DrawTinyStringColor( labelX, y + 4, label, colorWhite );
                 Q_strncpyz( text, "--", sizeof( text ) );
-                CG_DrawTinyDigitalStringColor( valueX, y + 4, text, colorWhite );
+                CG_DrawTinyStringColor( valueX, y + 4, text, colorWhite );
                 CG_DrawTinyStringColor( valueX + CG_DrawStrlen( text ) * tinyCharWidth, y + 4, " S", colorWhite );
         }
 }
@@ -499,16 +499,16 @@ void CG_DrawHUD_DerbyList(float x, float y){
 	CG_FillRect(x, y, 120, 18, bgColor);
 
 	// name
-	CG_DrawTinyDigitalStringColor( x + 16, y, "P:", colorWhite);
+	CG_DrawTinyStringColor( x + 16, y, "P:", colorWhite);
 
 	// time
 //	CG_DrawTinyStringColor( x + 70, y, "TIME:", colorWhite);
 
 	// dmg dealt
-	CG_DrawTinyDigitalStringColor( x + 70, y, "DD:", colorWhite);
+	CG_DrawTinyStringColor( x + 70, y, "DD:", colorWhite);
 
 	// dmg taken
-	CG_DrawTinyDigitalStringColor( x + 100, y, "DT:", colorWhite);
+	CG_DrawTinyStringColor( x + 100, y, "DT:", colorWhite);
 
 	y += 20;
 
@@ -540,19 +540,19 @@ void CG_DrawHUD_DerbyList(float x, float y){
 		time = getStringForTime(playTime);
 
 		// num
-		CG_DrawTinyDigitalStringColor( x + 2, y, va("%i", (i+1)), color);
+		CG_DrawTinyStringColor( x + 2, y, va("%i", (i+1)), color);
 
 		// name
-		CG_DrawTinyDigitalStringColor( x + 16, y, cgs.clientinfo[cg.scores[i].client].name, color);
+		CG_DrawTinyStringColor( x + 16, y, cgs.clientinfo[cg.scores[i].client].name, color);
 
 		// time
 //		CG_DrawTinyStringColor( x + 70, y, time, color);
 
 		// dmg dealt
-		CG_DrawTinyDigitalStringColor( x + 75, y, va("%i", cg.scores[i].damageDealt), color);
+		CG_DrawTinyStringColor( x + 75, y, va("%i", cg.scores[i].damageDealt), color);
 
 		// dmg taken
-		CG_DrawTinyDigitalStringColor( x + 105, y, va("%i", cg.scores[i].damageTaken), color);
+		CG_DrawTinyStringColor( x + 105, y, va("%i", cg.scores[i].damageTaken), color);
 
 		y += 20;
 	}


### PR DESCRIPTION
## Summary
- replace rally HUD digital font draw calls with the standard tiny font in both HUD codepaths so timers, positions, and elimination panels share a consistent look

## Testing
- make *(fails: missing SDL_version.h header in container image)*

------
https://chatgpt.com/codex/tasks/task_e_68ce502e41008324b65e3badd106b1cf