### PR TITLE
Align elimination rankings across HUD and scoreboard

### DIFF
--- a/engine/code/cgame/cg_rally_hud.c
+++ b/engine/code/cgame/cg_rally_hud.c
@@ -731,9 +731,43 @@ static float CG_DrawCurrentPosition( float y ) {
 		const float	labelX = x + labelOffsetX;
 		const float	drawY = y + labelOffsetY;
 		const float	valueX = labelX + ( CG_DrawStrlen( label ) + 1 ) * tinyCharWidth;
+		vec4_t	 posColor;
+		char	 valueText[32];
+		qboolean	 isEliminationMode;
+		qboolean	 isEliminated;
+
+		isEliminationMode = ( cgs.gametype == GT_ELIMINATION );
+		isEliminated = qfalse;
+
+		Vector4Copy( colorWhite, posColor );
+
+		if ( isEliminationMode ) {
+			if ( pos > 0 ) {
+				Com_sprintf( valueText, sizeof( valueText ), "%i/%i", pos, cgs.numRacers );
+			} else {
+				Q_strncpyz( valueText, "--", sizeof( valueText ) );
+			}
+
+			if ( pos > 0 && cgs.eliminationRemainingPlayers > 0 &&
+				pos > cgs.eliminationRemainingPlayers ) {
+				isEliminated = qtrue;
+			}
+
+			if ( isEliminated ) {
+				posColor[0] = 0.6f;
+				posColor[1] = 0.6f;
+				posColor[2] = 0.6f;
+			}
+		} else {
+			if ( pos > 0 ) {
+				Com_sprintf( valueText, sizeof( valueText ), "%i/%i", pos, cgs.numRacers );
+			} else {
+				Q_strncpyz( valueText, "--", sizeof( valueText ) );
+			}
+		}
 
 		CG_DrawTinyStringColor( labelX, drawY, label, colorWhite );
-		CG_DrawTinyStringColor( valueX, drawY, va( "%i/%i", pos, cgs.numRacers ), colorWhite );
+		CG_DrawTinyStringColor( valueX, drawY, valueText, posColor );
 	}
 
 	y += 20;
@@ -756,15 +790,19 @@ static float CG_DrawCarAheadAndBehind( float y ) {
 	char		positionLabel[16];
 	float		background[4] = { 0, 0, 0, 0.5 };
 	float		selected[4] = { 0.75, 0.0, 0.0, 0.5 };
+	float		eliminatedBackground[4] = { 0.25f, 0.25f, 0.25f, 0.5f };
+	vec4_t	eliminatedTextColor = { 0.7f, 0.7f, 0.7f, 1.0f };
 	const float	numberOffsetX = 4.0f;
 	const float	columnSpacing = 4.0f;
 	const float	tinyCharWidth = TINYCHAR_WIDTH + 2.0f;
 	float		numberX;
 	float		nameX;
 	char		maxPositionLabel[16];
+	qboolean	isEliminationMode;
 
 	//ps = &cg.snap->ps;
 	cent = &cg_entities[cg.snap->ps.clientNum];
+	isEliminationMode = ( cgs.gametype == GT_ELIMINATION );
 
 	startPos = cent->currentPosition - 4 < 1 ? 1 : cent->currentPosition - 4;
 	endPos = startPos + 8 > cgs.numRacers ? cgs.numRacers : startPos + 8;
@@ -791,28 +829,54 @@ static float CG_DrawCarAheadAndBehind( float y ) {
 
 		if (num < 0 || num > cgs.maxclients) continue;
 
-		if (num == cent->currentState.clientNum){
-			CG_FillRect( x, y, width, height, selected );
-		}
-		else {
-			CG_FillRect( x, y, width, height, background );
-		}
+		{
+			int otherPos;
+			qboolean entryEliminated;
+			const float *numberColor;
+			const float *nameColor;
 
-		Q_strncpyz(player, cgs.clientinfo[num].name, 16 );
-		if ( player[0] != '\0' ) {
-			Com_sprintf( positionLabel, sizeof( positionLabel ), "%i-", cg_entities[num].currentPosition );
-		}
-		else {
-			Com_sprintf( positionLabel, sizeof( positionLabel ), "%i", cg_entities[num].currentPosition );
-		}
+			otherPos = cg_entities[num].currentPosition;
+			entryEliminated = qfalse;
+			numberColor = colorWhite;
+			nameColor = colorWhite;
 
-		CG_DrawTinyStringColor( numberX, y, positionLabel, colorWhite );
+			if ( isEliminationMode && otherPos > 0 && cgs.eliminationRemainingPlayers > 0 &&
+				otherPos > cgs.eliminationRemainingPlayers ) {
+				entryEliminated = qtrue;
+			}
 
-		if ( player[0] != '\0' ) {
-			CG_DrawTinyStringColor( nameX, y, player, colorWhite );
+			if ( num == cent->currentState.clientNum ) {
+				CG_FillRect( x, y, width, height, selected );
+			} else if ( entryEliminated ) {
+				CG_FillRect( x, y, width, height, eliminatedBackground );
+			} else {
+				CG_FillRect( x, y, width, height, background );
+			}
+
+			if ( entryEliminated ) {
+				numberColor = eliminatedTextColor;
+				nameColor = eliminatedTextColor;
+			}
+
+			Q_strncpyz(player, cgs.clientinfo[num].name, 16 );
+			if ( otherPos > 0 ) {
+				if ( player[0] != '\0' ) {
+					Com_sprintf( positionLabel, sizeof( positionLabel ), "%i-", otherPos );
+				} else {
+					Com_sprintf( positionLabel, sizeof( positionLabel ), "%i", otherPos );
+				}
+			} else {
+				Q_strncpyz( positionLabel, "--", sizeof( positionLabel ) );
+			}
+
+			CG_DrawTinyStringColor( numberX, y, positionLabel, numberColor );
+
+			if ( player[0] != '\0' ) {
+				CG_DrawTinyStringColor( nameX, y, player, nameColor );
+			}
+
+			y += TINYCHAR_HEIGHT;
 		}
-
-		y += TINYCHAR_HEIGHT;
 
 	}
 

--- a/engine/code/cgame/cg_rally_hud2.c
+++ b/engine/code/cgame/cg_rally_hud2.c
@@ -326,13 +326,17 @@ void CG_DrawHUD_OpponentList(float x, float y){
 	int			startPos, endPos;
 	int			maxPositions;
 	vec4_t		color;
+	float		eliminatedBackground[4] = { 0.25f, 0.25f, 0.25f, 0.5f };
+	vec4_t		eliminatedTextColor = { 0.7f, 0.7f, 0.7f, 1.0f };
 	const float	labelX = x + 12.0f;
 	const float	smallCharWidth = SMALLCHAR_WIDTH + 2.0f;
 	int			digits;
 	float		nameX;
+	qboolean	isEliminationMode;
 
 	//ps = &cg.snap->ps;
 	cent = &cg_entities[cg.snap->ps.clientNum];
+	isEliminationMode = ( cgs.gametype == GT_ELIMINATION );
 
 	startPos = cent->currentPosition - 4 < 1 ? 1 : cent->currentPosition - 4;
 	endPos = startPos + 8 > cgs.numRacers ? cgs.numRacers : startPos + 8;
@@ -360,11 +364,34 @@ void CG_DrawHUD_OpponentList(float x, float y){
 	{
 		const char *label = "POS:";
 		char valueText[32];
+		vec4_t valueColor;
 		const float valueX = labelX + ( CG_DrawStrlen( label ) + 1 ) * smallCharWidth;
+		int positionValue;
+		qboolean isEliminated = qfalse;
 
 		CG_DrawSmallStringColor(labelX, y, label, colorWhite);
-		Com_sprintf(valueText, sizeof(valueText), "%i/%i", cent->currentPosition, cgs.numRacers);
-		CG_DrawSmallDigitalStringColor(valueX, y, valueText, colorWhite);
+
+		positionValue = cent->currentPosition;
+		Vector4Copy( colorWhite, valueColor );
+
+		if ( positionValue > 0 ) {
+			Com_sprintf(valueText, sizeof(valueText), "%i/%i", positionValue, cgs.numRacers);
+		} else {
+			Q_strncpyz(valueText, "--", sizeof(valueText));
+		}
+
+		if ( isEliminationMode && positionValue > 0 && cgs.eliminationRemainingPlayers > 0 &&
+			positionValue > cgs.eliminationRemainingPlayers ) {
+			isEliminated = qtrue;
+		}
+
+		if ( isEliminated ) {
+			valueColor[0] = 0.6f;
+			valueColor[1] = 0.6f;
+			valueColor[2] = 0.6f;
+		}
+
+		CG_DrawSmallDigitalStringColor(valueX, y, valueText, valueColor);
 	}
 
 	y += 20;
@@ -413,15 +440,43 @@ void CG_DrawHUD_OpponentList(float x, float y){
 			Vector4Copy(bgColor, color);
 		}
 
-		CG_FillRect(x, y, width, height, color);
-
-		Q_strncpyz(player, cgs.clientinfo[num].name, 16 );
 		{
+			int positionValue;
+			qboolean entryEliminated;
+			const float *numberColor;
+			const float *nameColor;
 			char prefix[16];
 
-			Com_sprintf(prefix, sizeof(prefix), "%*i:", digits, cgs.clientinfo[num].position);
-			CG_DrawSmallDigitalStringColor(labelX, y, prefix, colorWhite);
-			CG_DrawSmallStringColor(nameX, y, player, colorWhite);
+			positionValue = cgs.clientinfo[num].position;
+			entryEliminated = qfalse;
+			numberColor = colorWhite;
+			nameColor = colorWhite;
+
+			if ( isEliminationMode && positionValue > 0 && cgs.eliminationRemainingPlayers > 0 &&
+				positionValue > cgs.eliminationRemainingPlayers ) {
+				entryEliminated = qtrue;
+			}
+
+			if ( entryEliminated ) {
+				Vector4Copy( eliminatedBackground, color );
+				numberColor = eliminatedTextColor;
+				nameColor = eliminatedTextColor;
+			}
+
+			CG_FillRect(x, y, width, height, color);
+
+			Q_strncpyz(player, cgs.clientinfo[num].name, 16 );
+
+			if ( positionValue > 0 ) {
+				Com_sprintf(prefix, sizeof(prefix), "%*i:", digits, positionValue);
+			} else {
+				char placeholder[8];
+				Q_strncpyz( placeholder, "--", sizeof( placeholder ) );
+				Com_sprintf(prefix, sizeof(prefix), "%*s:", digits, placeholder);
+			}
+
+			CG_DrawSmallDigitalStringColor(labelX, y, prefix, numberColor);
+			CG_DrawSmallStringColor(nameX, y, player, nameColor);
 		}
 
 		y += 20;

--- a/engine/code/cgame/cg_scoreboard.c
+++ b/engine/code/cgame/cg_scoreboard.c
@@ -514,6 +514,7 @@ static void CG_DrawColumnData(sbColumn_t colType, int x, int y, int width,
     vec4_t botColor;
     vec4_t readyColor;
     qboolean isRacingMode;
+    qboolean isEliminationMode;
     
     if (score->client < 0 || score->client >= cgs.maxclients) {
         return;
@@ -531,17 +532,47 @@ static void CG_DrawColumnData(sbColumn_t colType, int x, int y, int width,
     rowHeight = isCompact ? MODERN_SB_COMPACT_HEIGHT : MODERN_SB_ROW_HEIGHT;
     avatarSize = rowHeight - 8;
     isRacingMode = CG_IsRacingGametype();
+    isEliminationMode = (cgs.gametype == GT_ELIMINATION);
     
     switch (colType) {
         case SBCOL_RANK:
             if (ci->team == TEAM_SPECTATOR) {
                 Com_sprintf(buffer, sizeof(buffer), "SPEC");
                 CG_DrawModernText(x, y, buffer, 1, width, textColor, qfalse);
+            } else if (isEliminationMode) {
+                if (score->position > 0) {
+                    qboolean isEliminated = qfalse;
+
+                    if (cgs.eliminationActive || cgs.eliminationRemainingPlayers > 0) {
+                        if (cgs.eliminationRemainingPlayers > 0 &&
+                            score->position > cgs.eliminationRemainingPlayers) {
+                            isEliminated = qtrue;
+                        }
+                    }
+
+                    Com_sprintf(buffer, sizeof(buffer), "%d", score->position);
+                    if (isEliminated) {
+                        vec4_t eliminatedColor;
+
+                        eliminatedColor[0] = 0.6f;
+                        eliminatedColor[1] = 0.6f;
+                        eliminatedColor[2] = 0.6f;
+                        eliminatedColor[3] = fade;
+                        CG_DrawModernText(x, y, buffer, 1, width, eliminatedColor, qfalse);
+                    } else {
+                        CG_GetRankColor(score->position, rankColor);
+                        rankColor[3] = fade;
+                        CG_DrawModernText(x, y, buffer, 1, width, rankColor,
+                                         (score->position <= 3) ? qtrue : qfalse);
+                    }
+                } else {
+                    CG_DrawModernText(x, y, "-", 1, width, textColor, qfalse);
+                }
             } else if (isRacingMode && score->position > 0) {
                 Com_sprintf(buffer, sizeof(buffer), "%d", score->position);
                 CG_GetRankColor(score->position, rankColor);
                 rankColor[3] = fade;
-                CG_DrawModernText(x, y, buffer, 1, width, rankColor, 
+                CG_DrawModernText(x, y, buffer, 1, width, rankColor,
                                  (score->position <= 3) ? qtrue : qfalse);
             } else if (!isRacingMode && rank > 0) {
                 Com_sprintf(buffer, sizeof(buffer), "%d", rank);

--- a/engine/code/game/g_cmds.c
+++ b/engine/code/game/g_cmds.c
@@ -83,26 +83,45 @@ void DeathmatchScoreboardMessage( gentity_t *ent ) {
 		}
 		perfect = ( cl->ps.persistant[PERS_RANK] == 0 && cl->ps.persistant[PERS_KILLED] == 0 ) ? 1 : 0;
 
-		Com_sprintf (entry, sizeof(entry),
+                {
+                        int positionValue;
+                        int totalDrivers;
 
-			" %i %i %i %i %i %i %i %i %i %i %i %i %i %i %i %i %i %i", level.sortedClients[i],
-			cl->ps.persistant[PERS_SCORE], ping, time,
-			scoreFlags, g_entities[level.sortedClients[i]].s.powerups, accuracy, 
-			cl->ps.persistant[PERS_IMPRESSIVE_COUNT],
-	    cl->ps.persistant[PERS_IMPRESSIVETELEFRAG_COUNT],
-			cl->ps.persistant[PERS_EXCELLENT_COUNT],
-			cl->ps.persistant[PERS_GAUNTLET_FRAG_COUNT], 
-			cl->ps.persistant[PERS_DEFEND_COUNT], 
-			cl->ps.persistant[PERS_ASSIST_COUNT], 
-			perfect,
-			cl->ps.persistant[PERS_CAPTURES],
-			cl->ps.stats[STAT_DAMAGE_DEALT],
-			cl->ps.stats[STAT_DAMAGE_TAKEN],
-			cl->ps.stats[STAT_POSITION]
-			);
+                        positionValue = cl->ps.stats[STAT_POSITION];
+                        if ( g_gametype.integer == GT_ELIMINATION ) {
+                                if ( positionValue <= 0 ) {
+                                        totalDrivers = level.eliminationRound + level.eliminationRemainingPlayers;
+                                        if ( totalDrivers <= 0 ) {
+                                                totalDrivers = level.numNonSpectatorClients;
+                                        }
+                                        if ( totalDrivers <= 0 ) {
+                                                totalDrivers = 1;
+                                        }
+                                        positionValue = totalDrivers;
+                                }
+                        }
+
+                        Com_sprintf (entry, sizeof(entry),
+
+                                " %i %i %i %i %i %i %i %i %i %i %i %i %i %i %i %i %i %i", level.sortedClients[i],
+                                cl->ps.persistant[PERS_SCORE], ping, time,
+                                scoreFlags, g_entities[level.sortedClients[i]].s.powerups, accuracy,
+                                cl->ps.persistant[PERS_IMPRESSIVE_COUNT],
+                cl->ps.persistant[PERS_IMPRESSIVETELEFRAG_COUNT],
+                                cl->ps.persistant[PERS_EXCELLENT_COUNT],
+                                cl->ps.persistant[PERS_GAUNTLET_FRAG_COUNT],
+                                cl->ps.persistant[PERS_DEFEND_COUNT],
+                                cl->ps.persistant[PERS_ASSIST_COUNT],
+                                perfect,
+                                cl->ps.persistant[PERS_CAPTURES],
+                                cl->ps.stats[STAT_DAMAGE_DEALT],
+                                cl->ps.stats[STAT_DAMAGE_TAKEN],
+                                positionValue
+                                );
+                }
 
 
-		j = strlen(entry);
+                j = strlen(entry);
 		if (stringlength + j >= sizeof(string))
 			break;
 		strcpy (string + stringlength, entry);

--- a/engine/code/game/g_main.c
+++ b/engine/code/game/g_main.c
@@ -2163,6 +2163,31 @@ void G_RegisterEliminationDeath( gentity_t *victim ) {
         level.eliminationRound++;
         G_UpdateEliminationPlayerCount();
 
+        {
+                int totalDrivers;
+                int knockoutRank;
+
+                if ( level.eliminationRemainingPlayers < 0 ) {
+                        level.eliminationRemainingPlayers = 0;
+                }
+
+                totalDrivers = level.eliminationRound + level.eliminationRemainingPlayers;
+                if ( totalDrivers < 1 ) {
+                        totalDrivers = ( level.eliminationRound > 0 ) ? level.eliminationRound : 1;
+                }
+
+                knockoutRank = totalDrivers - level.eliminationRound + 1;
+                if ( knockoutRank < 1 ) {
+                        knockoutRank = 1;
+                }
+
+                if ( victim->client->ps.stats[STAT_POSITION] != knockoutRank ) {
+                        victim->client->ps.stats[STAT_POSITION] = knockoutRank;
+                        Cmd_RacePositions_f();
+                        CalculateRanks();
+                }
+        }
+
         if ( level.eliminationRemainingPlayers > 1 ) {
                 G_SetEliminationSchedule( level.time, level.eliminationInterval );
         } else {

--- a/engine/code/game/g_rally_racetools.c
+++ b/engine/code/game/g_rally_racetools.c
@@ -381,6 +381,16 @@ void CalculatePlayerPositions( void )
 		if ( ent->client->sess.sessionTeam == TEAM_SPECTATOR ) continue;
 //		if ( isRaceObserver(ent->s.number) ) continue;
 
+		if ( g_gametype.integer == GT_ELIMINATION && level.startRaceTime ) {
+			if ( ent->client->finishRaceTime && ent->client->ps.stats[STAT_HEALTH] <= 0 ) {
+				continue;
+			}
+
+			if ( ent->client->ps.stats[STAT_HEALTH] <= 0 ) {
+				continue;
+			}
+		}
+
 		ent->carBehind = NULL;
 
 		if ( leader == NULL )


### PR DESCRIPTION
## Summary
- assign elimination knockout rankings to victims and broadcast the updated order
- prevent the race position calculator and scoreboard publisher from reverting elimination results
- render elimination positions on the HUD and scoreboard, graying out drivers that have been knocked out

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68cea7b96f508324a6d853af6e5bae1b