### PR TITLE
Fix elimination HUD color pointers

### DIFF
--- a/engine/code/cgame/cg_rally_hud.c
+++ b/engine/code/cgame/cg_rally_hud.c
@@ -832,13 +832,13 @@ static float CG_DrawCarAheadAndBehind( float y ) {
 		{
 			int otherPos;
 			qboolean entryEliminated;
-			const float *numberColor;
-			const float *nameColor;
+			vec4_t numberColor;
+			vec4_t nameColor;
 
 			otherPos = cg_entities[num].currentPosition;
 			entryEliminated = qfalse;
-			numberColor = colorWhite;
-			nameColor = colorWhite;
+			Vector4Copy( colorWhite, numberColor );
+			Vector4Copy( colorWhite, nameColor );
 
 			if ( isEliminationMode && otherPos > 0 && cgs.eliminationRemainingPlayers > 0 &&
 				otherPos > cgs.eliminationRemainingPlayers ) {
@@ -854,8 +854,8 @@ static float CG_DrawCarAheadAndBehind( float y ) {
 			}
 
 			if ( entryEliminated ) {
-				numberColor = eliminatedTextColor;
-				nameColor = eliminatedTextColor;
+				Vector4Copy( eliminatedTextColor, numberColor );
+				Vector4Copy( eliminatedTextColor, nameColor );
 			}
 
 			Q_strncpyz(player, cgs.clientinfo[num].name, 16 );

--- a/engine/code/cgame/cg_rally_hud2.c
+++ b/engine/code/cgame/cg_rally_hud2.c
@@ -443,14 +443,14 @@ void CG_DrawHUD_OpponentList(float x, float y){
 		{
 			int positionValue;
 			qboolean entryEliminated;
-			const float *numberColor;
-			const float *nameColor;
+			vec4_t numberColor;
+			vec4_t nameColor;
 			char prefix[16];
 
 			positionValue = cgs.clientinfo[num].position;
 			entryEliminated = qfalse;
-			numberColor = colorWhite;
-			nameColor = colorWhite;
+			Vector4Copy( colorWhite, numberColor );
+			Vector4Copy( colorWhite, nameColor );
 
 			if ( isEliminationMode && positionValue > 0 && cgs.eliminationRemainingPlayers > 0 &&
 				positionValue > cgs.eliminationRemainingPlayers ) {
@@ -459,8 +459,8 @@ void CG_DrawHUD_OpponentList(float x, float y){
 
 			if ( entryEliminated ) {
 				Vector4Copy( eliminatedBackground, color );
-				numberColor = eliminatedTextColor;
-				nameColor = eliminatedTextColor;
+				Vector4Copy( eliminatedTextColor, numberColor );
+				Vector4Copy( eliminatedTextColor, nameColor );
 			}
 
 			CG_FillRect(x, y, width, height, color);


### PR DESCRIPTION
## Summary
- replace the color pointer usage in `CG_DrawCarAheadAndBehind` with local `vec4_t` buffers so elimination colors are copied before drawing
- adjust `CG_DrawHUD_OpponentList` to use mutable `vec4_t` colors when drawing opponent numbers and names

## Testing
- `make -j4` *(fails: missing SDL_version.h header in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cebefb70908324a9dac1f269b7a12b