### PR TITLE
Use clientinfo positions for rally HUD

### DIFF
--- a/engine/code/cgame/cg_rally_hud.c
+++ b/engine/code/cgame/cg_rally_hud.c
@@ -706,7 +706,8 @@ CG_DrawCurrentPosition
 ======================
 */
 static float CG_DrawCurrentPosition( float y ) {
-	centity_t		*cent;
+	const int		clientNum = cg.snap->ps.clientNum;
+	const clientInfo_t	*clientInfo;
 	//playerState_t	*ps;
 	int			pos;
 	float		x, width, height;
@@ -717,9 +718,9 @@ static float CG_DrawCurrentPosition( float y ) {
 	const float	tinyCharWidth = TINYCHAR_WIDTH + 2.0f;
 
 	//ps = &cg.snap->ps;
-	cent = &cg_entities[cg.snap->ps.clientNum];
+	clientInfo = &cgs.clientinfo[clientNum];
 
-	pos = cent->currentPosition;
+	pos = clientInfo->infoValid ? clientInfo->position : 0;
 
 	x = 636 - 80;
 	width = 90;
@@ -782,7 +783,8 @@ CG_DrawCarAheadAndBehind
 ========================
 */
 static float CG_DrawCarAheadAndBehind( float y ) {
-	centity_t	*cent, *other;
+	const int	clientNum = cg.snap->ps.clientNum;
+	const clientInfo_t	*clientInfo;
 	char		player[64];
 	int			i, j, num;
 	float		x, width, height;
@@ -801,10 +803,11 @@ static float CG_DrawCarAheadAndBehind( float y ) {
 	qboolean	isEliminationMode;
 
 	//ps = &cg.snap->ps;
-	cent = &cg_entities[cg.snap->ps.clientNum];
+	clientInfo = &cgs.clientinfo[clientNum];
 	isEliminationMode = ( cgs.gametype == GT_ELIMINATION );
 
-	startPos = cent->currentPosition - 4 < 1 ? 1 : cent->currentPosition - 4;
+	startPos = clientInfo->infoValid ? clientInfo->position - 4 : 1;
+	startPos = startPos < 1 ? 1 : startPos;
 	endPos = startPos + 8 > cgs.numRacers ? cgs.numRacers : startPos + 8;
 	startPos = endPos - 8 < 1 ? 1 : endPos - 8;
 
@@ -819,11 +822,15 @@ static float CG_DrawCarAheadAndBehind( float y ) {
 	for (i = startPos; i <= endPos; i++){
 		num = -1;
 		for (j = 0; j < cgs.maxclients; j++){
-			other = &cg_entities[j];
-			if (!other) continue;
+			const clientInfo_t *otherInfo = &cgs.clientinfo[j];
 
-			if (other->currentPosition == i){
-				num = other->currentState.clientNum;
+			if ( !otherInfo->infoValid ) {
+				continue;
+			}
+
+			if ( otherInfo->position == i ){
+				num = j;
+				break;
 			}
 		}
 
@@ -835,7 +842,7 @@ static float CG_DrawCarAheadAndBehind( float y ) {
 			vec4_t numberColor;
 			vec4_t nameColor;
 
-			otherPos = cg_entities[num].currentPosition;
+			otherPos = cgs.clientinfo[num].position;
 			entryEliminated = qfalse;
 			Vector4Copy( colorWhite, numberColor );
 			Vector4Copy( colorWhite, nameColor );
@@ -845,7 +852,7 @@ static float CG_DrawCarAheadAndBehind( float y ) {
 				entryEliminated = qtrue;
 			}
 
-			if ( num == cent->currentState.clientNum ) {
+			if ( num == clientNum ) {
 				CG_FillRect( x, y, width, height, selected );
 			} else if ( entryEliminated ) {
 				CG_FillRect( x, y, width, height, eliminatedBackground );

--- a/engine/code/cgame/cg_rally_hud2.c
+++ b/engine/code/cgame/cg_rally_hud2.c
@@ -179,7 +179,7 @@ void CG_DrawHUD_Positions(float x, float y){
 
 	// draw your position
 	CG_DrawSmallDigitalStringColor(x + 12, y, "YOU:", colorWhite);
-	CG_DrawSmallDigitalStringColor(x + 102, y, va("%i/%i", cg_entities[cg.snap->ps.clientNum].currentPosition, cgs.numRacers), colorWhite);
+	CG_DrawSmallDigitalStringColor(x + 102, y, va("%i/%i", cgs.clientinfo[cg.snap->ps.clientNum].position, cgs.numRacers), colorWhite);
 
 	y += 20;
 
@@ -319,7 +319,8 @@ CG_DrawHUD_OpponentList
 =======================
 */
 void CG_DrawHUD_OpponentList(float x, float y){
-	centity_t		*cent, *other;
+	const int	clientNum = cg.snap->ps.clientNum;
+	const clientInfo_t	*clientInfo;
 	char		player[64];
 	int				i, j, num;
 	float		width, height;
@@ -335,10 +336,11 @@ void CG_DrawHUD_OpponentList(float x, float y){
 	qboolean	isEliminationMode;
 
 	//ps = &cg.snap->ps;
-	cent = &cg_entities[cg.snap->ps.clientNum];
+	clientInfo = &cgs.clientinfo[clientNum];
 	isEliminationMode = ( cgs.gametype == GT_ELIMINATION );
 
-	startPos = cent->currentPosition - 4 < 1 ? 1 : cent->currentPosition - 4;
+	startPos = clientInfo->infoValid ? clientInfo->position - 4 : 1;
+	startPos = startPos < 1 ? 1 : startPos;
 	endPos = startPos + 8 > cgs.numRacers ? cgs.numRacers : startPos + 8;
 	startPos = endPos - 8 < 1 ? 1 : endPos - 8;
 
@@ -371,7 +373,7 @@ void CG_DrawHUD_OpponentList(float x, float y){
 
 		CG_DrawSmallStringColor(labelX, y, label, colorWhite);
 
-		positionValue = cent->currentPosition;
+		positionValue = clientInfo->infoValid ? clientInfo->position : 0;
 		Vector4Copy( colorWhite, valueColor );
 
 		if ( positionValue > 0 ) {
@@ -399,13 +401,14 @@ void CG_DrawHUD_OpponentList(float x, float y){
 	for (i = startPos; i <= endPos; i++){
 		num = -1;
 		for (j = 0; j < cgs.maxclients; j++){
-			other = &cg_entities[j];
-			if ( !other ) continue;
-//			if ( isRaceObserver(other->currentState.clientNum) ) continue;
-			if ( cgs.clientinfo[other->currentState.clientNum].team == TEAM_SPECTATOR ) continue;
+			const clientInfo_t *otherInfo = &cgs.clientinfo[j];
 
-			if ( cgs.clientinfo[other->currentState.clientNum].position == i ) {
-				num = other->currentState.clientNum;
+			if ( !otherInfo->infoValid ) continue;
+//			if ( isRaceObserver(j) ) continue;
+			if ( otherInfo->team == TEAM_SPECTATOR ) continue;
+
+			if ( otherInfo->position == i ) {
+				num = j;
 				break;
 			}
 		}


### PR DESCRIPTION
## Summary
- read the local position for the rally HUD widgets from `cgs.clientinfo[].position` instead of `cg_entities` and preserve the elimination coloring
- use `cgs.clientinfo` for the small HUD position display and neighbor list so the KO order matches the scoreboard

## Testing
- make *(fails: missing SDL_version.h)*

------
https://chatgpt.com/codex/tasks/task_e_68ceddccb31c8324a8206043d8797031