### PR TITLE
Update elimination ranking after knockouts

### DIFF
--- a/engine/code/game/g_main.c
+++ b/engine/code/game/g_main.c
@@ -2163,6 +2163,10 @@ void G_RegisterEliminationDeath( gentity_t *victim ) {
         level.eliminationRound++;
         G_UpdateEliminationPlayerCount();
 
+        victim->client->ps.stats[STAT_POSITION] = level.eliminationRemainingPlayers + 1;
+        Cmd_RacePositions_f();
+        CalculateRanks();
+
         if ( level.eliminationRemainingPlayers > 1 ) {
                 G_SetEliminationSchedule( level.time, level.eliminationInterval );
         } else {


### PR DESCRIPTION
## Summary
- update elimination death handling to assign the knocked-out player's finishing slot and refresh race rankings

## Testing
- make -C engine *(fails: missing SDL_version.h in the container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ceee20a86c8324a271ea00f3285923