### PR TITLE
Freeze elimination race positions

### DIFF
--- a/engine/code/game/g_rally_racetools.c
+++ b/engine/code/game/g_rally_racetools.c
@@ -366,6 +366,7 @@ void CalculatePlayerPositions( void )
 	gentity_t	*ent, *leader, *cur, *last;
 	int			position;
 	qboolean	positionChanged;
+	qboolean	eliminationMode;
 
 //	if (level.startRaceTime + FRAMETIME > level.time || level.startRaceTime == 0){
 //		return;
@@ -375,6 +376,7 @@ void CalculatePlayerPositions( void )
 	}
 
 	positionChanged = qfalse;
+	eliminationMode = ( g_gametype.integer == GT_ELIMINATION || g_gametype.integer == GT_LCS );
 	leader = ent = last = NULL;
 	while ( (ent = G_Find (ent, FOFS(classname), "player")) != NULL )
 	{
@@ -382,6 +384,11 @@ void CalculatePlayerPositions( void )
 //		if ( isRaceObserver(ent->s.number) ) continue;
 
 		ent->carBehind = NULL;
+
+		if ( eliminationMode && ent->client->finishRaceTime ) {
+			// eliminated drivers already have their knockout slot locked in
+			continue;
+		}
 
 		if ( leader == NULL )
 		{


### PR DESCRIPTION
## Summary
- stop the live race position solver from reordering drivers that have already been eliminated
- gate the skip logic behind the elimination-style gametypes so other races continue to update normally

## Testing
- `make -j4` *(fails: missing SDL_version.h in build environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cef56afc7c8324b7d41f3bbb31d9cd