### PR TITLE
Align elimination lap notice with label column

### DIFF
--- a/engine/code/q3_ui/ui_rally_startserver.c
+++ b/engine/code/q3_ui/ui_rally_startserver.c
@@ -1669,7 +1669,7 @@ static void ServerOptions_MenuInit( qboolean multiplayer ) {
 		if( s_serveroptions.gametype == GT_ELIMINATION && !s_serveroptions.pointToPoint ) {
 			s_serveroptions.laplimitNotice.generic.type		= MTYPE_TEXT;
 			s_serveroptions.laplimitNotice.generic.flags	 = QMF_INACTIVE|QMF_SMALLFONT;
-			s_serveroptions.laplimitNotice.generic.x		= OPTIONS_X;
+			s_serveroptions.laplimitNotice.generic.x		= OPTIONS_X - SMALLCHAR_WIDTH;
 			s_serveroptions.laplimitNotice.generic.y		= y;
 			s_serveroptions.laplimitNotice.string		= s_serveroptions.laplimitNoticeBuffer;
 			s_serveroptions.laplimitNotice.style		= UI_LEFT|UI_SMALLFONT;


### PR DESCRIPTION
## Summary
- anchor the elimination lap limit notice to the option label column so the text lines up with other labels

## Testing
- make -j4 *(fails: SDL_version.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68cefbf95acc8324813734305874cd84