### PR TITLE
Add jukebox playlist state machine to background music

### DIFF
--- a/engine/code/client/snd_dma.c
+++ b/engine/code/client/snd_dma.c
@@ -41,6 +41,150 @@ snd_stream_t	*s_backgroundStream = NULL;
 static char		s_backgroundLoop[MAX_QPATH];
 //static char		s_backgroundMusic[MAX_QPATH]; //TTimo: unused
 
+#define JUKEBOX_BASE_PATH			"music/jukebox"
+#define JUKEBOX_EXTENSION			".ogg"
+#define JUKEBOX_FILELIST_BUFSIZE	(MAX_OSPATH * 64)
+#define JUKEBOX_MAX_TRACKS			128
+
+typedef struct {
+	qboolean	active;
+	int			startSample;
+	int			trackSamples;
+	int			trackRate;
+	int			currentTrack;
+	int			trackCount;
+	char		currentTrackPath[MAX_QPATH];
+	char		tracks[JUKEBOX_MAX_TRACKS][MAX_QPATH];
+} jukeboxState_t;
+
+static jukeboxState_t s_jukeboxState;
+
+static void Jukebox_Reset( void )
+{
+	Com_Memset( &s_jukeboxState, 0, sizeof( s_jukeboxState ) );
+}
+
+static qboolean Jukebox_PathIsUnderBase( const char *path )
+{
+	size_t	baseLen;
+
+	if( !path || !path[0] ) {
+		return qfalse;
+	}
+
+	baseLen = strlen( JUKEBOX_BASE_PATH );
+
+	if( Q_stricmpn( path, JUKEBOX_BASE_PATH, baseLen ) ) {
+		return qfalse;
+	}
+
+	if( path[baseLen] && path[baseLen] != '/' && path[baseLen] != '\' ) {
+		return qfalse;
+	}
+
+	return qtrue;
+}
+
+static qboolean Jukebox_IsPlaylistTrack( const char *intro, const char *loop )
+{
+	if( Jukebox_PathIsUnderBase( loop ) ) {
+		return qtrue;
+	}
+
+	if( Jukebox_PathIsUnderBase( intro ) ) {
+		return qtrue;
+	}
+
+	return qfalse;
+}
+
+static qboolean Jukebox_LoadPlaylist( const char *currentTrack )
+{
+	char	fileList[JUKEBOX_FILELIST_BUFSIZE];
+	char	*fileName;
+	int		numTracks;
+	int		i;
+
+	s_jukeboxState.trackCount = 0;
+	s_jukeboxState.currentTrack = -1;
+	s_jukeboxState.currentTrackPath[0] = '\0';
+
+	numTracks = FS_GetFileList( JUKEBOX_BASE_PATH, JUKEBOX_EXTENSION, fileList, sizeof( fileList ) );
+	if( numTracks <= 0 ) {
+		return qfalse;
+	}
+
+	fileName = fileList;
+
+	for( i = 0; i < numTracks && s_jukeboxState.trackCount < JUKEBOX_MAX_TRACKS &&
+		fileName < fileList + sizeof( fileList ); i++ ) {
+		int len = strlen( fileName );
+
+		if( len > 0 ) {
+			Com_sprintf( s_jukeboxState.tracks[s_jukeboxState.trackCount],
+				sizeof( s_jukeboxState.tracks[s_jukeboxState.trackCount] ),
+				"%s/%s", JUKEBOX_BASE_PATH, fileName );
+
+			if( currentTrack && currentTrack[0] &&
+				!Q_stricmp( s_jukeboxState.tracks[s_jukeboxState.trackCount], currentTrack ) ) {
+				s_jukeboxState.currentTrack = s_jukeboxState.trackCount;
+			}
+
+			s_jukeboxState.trackCount++;
+		}
+
+		fileName += len + 1;
+	}
+
+	if( s_jukeboxState.trackCount <= 0 ) {
+		return qfalse;
+	}
+
+	if( s_jukeboxState.currentTrack < 0 ) {
+		s_jukeboxState.currentTrack = 0;
+	}
+
+	Q_strncpyz( s_jukeboxState.currentTrackPath,
+		s_jukeboxState.tracks[s_jukeboxState.currentTrack],
+		sizeof( s_jukeboxState.currentTrackPath ) );
+
+	return qtrue;
+}
+
+static qboolean Jukebox_Begin( const char *currentTrack )
+{
+	if( !currentTrack || !currentTrack[0] ) {
+		return qfalse;
+	}
+
+	Jukebox_Reset();
+
+	if( !Jukebox_LoadPlaylist( currentTrack ) ) {
+		return qfalse;
+	}
+
+	s_jukeboxState.active = qtrue;
+
+	return qtrue;
+}
+
+static void Jukebox_UpdateTrackInfo( void )
+{
+	if( !s_jukeboxState.active ) {
+		return;
+	}
+
+	s_jukeboxState.startSample = s_soundtime;
+
+	if( s_backgroundStream ) {
+		s_jukeboxState.trackSamples = s_backgroundStream->info.samples;
+		s_jukeboxState.trackRate = s_backgroundStream->info.rate;
+	} else {
+		s_jukeboxState.trackSamples = 0;
+		s_jukeboxState.trackRate = 0;
+	}
+}
+
 
 // =======================================================================
 // Internal sound data & structures
@@ -1374,6 +1518,8 @@ S_StopBackgroundTrack
 ======================
 */
 void S_Base_StopBackgroundTrack( void ) {
+	Jukebox_Reset();
+
 	if(!s_backgroundStream)
 		return;
 	S_CodecCloseStream(s_backgroundStream);
@@ -1407,12 +1553,55 @@ static void S_OpenBackgroundStream( const char *filename ) {
 	}
 }
 
+static qboolean Jukebox_AdvanceTrack( void )
+{
+	int	attempt;
+
+	if( !s_jukeboxState.active ) {
+		return qfalse;
+	}
+
+	if( s_jukeboxState.trackCount <= 0 ) {
+		Jukebox_Reset();
+		return qfalse;
+	}
+
+	if( s_jukeboxState.currentTrack < 0 || s_jukeboxState.currentTrack >= s_jukeboxState.trackCount ) {
+		s_jukeboxState.currentTrack = 0;
+	}
+
+	for( attempt = 0; attempt < s_jukeboxState.trackCount; attempt++ ) {
+		int nextIndex = ( s_jukeboxState.currentTrack + 1 + attempt ) % s_jukeboxState.trackCount;
+		const char *nextPath = s_jukeboxState.tracks[nextIndex];
+
+		if( !nextPath[0] ) {
+			continue;
+		}
+
+		S_OpenBackgroundStream( nextPath );
+
+		if( s_backgroundStream ) {
+			s_jukeboxState.currentTrack = nextIndex;
+			Q_strncpyz( s_jukeboxState.currentTrackPath, nextPath, sizeof( s_jukeboxState.currentTrackPath ) );
+			s_backgroundLoop[0] = '\0';
+			Jukebox_UpdateTrackInfo();
+			return qtrue;
+		}
+	}
+
+	Jukebox_Reset();
+
+	return qfalse;
+}
+
 /*
 ======================
 S_StartBackgroundTrack
 ======================
 */
 void S_Base_StartBackgroundTrack( const char *intro, const char *loop ){
+	qboolean	playlistActive = qfalse;
+
 	if ( !intro ) {
 		intro = "";
 	}
@@ -1427,9 +1616,30 @@ void S_Base_StartBackgroundTrack( const char *intro, const char *loop ){
 		return;
 	}
 
-	Q_strncpyz( s_backgroundLoop, loop, sizeof( s_backgroundLoop ) );
+	if( Jukebox_IsPlaylistTrack( intro, loop ) ) {
+		if( Jukebox_Begin( loop ) ) {
+			playlistActive = qtrue;
+		}
+	}
+
+	if( playlistActive ) {
+		s_backgroundLoop[0] = '\0';
+	} else {
+		Jukebox_Reset();
+		Q_strncpyz( s_backgroundLoop, loop, sizeof( s_backgroundLoop ) );
+	}
 
 	S_OpenBackgroundStream( intro );
+	if(!s_backgroundStream) {
+		if( playlistActive ) {
+			Jukebox_Reset();
+		}
+		return;
+	}
+
+	if( playlistActive ) {
+		Jukebox_UpdateTrackInfo();
+	}
 }
 
 /*
@@ -1489,12 +1699,16 @@ void S_UpdateBackgroundTrack( void ) {
 		}
 		else
 		{
-			// loop
+			// loop or advance playlist
 			if(s_backgroundLoop[0])
 			{
 				S_OpenBackgroundStream( s_backgroundLoop );
 				if(!s_backgroundStream)
 					return;
+			}
+			else if( Jukebox_AdvanceTrack() )
+			{
+				continue;
 			}
 			else
 			{


### PR DESCRIPTION
## Summary
- introduce a jukebox playback state in `snd_dma` that tracks playlists, start samples, and track metadata
- hook the jukebox state into start/stop/update so custom playlists advance to the next entry instead of looping a single song
- reset the jukebox state when background playback stops to restore default map music behaviour

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cf22689fb083248ee64fbc8a07a26c