### PR TITLE
Fix Jukebox base path backslash guard

### DIFF
--- a/engine/code/client/snd_dma.c
+++ b/engine/code/client/snd_dma.c
@@ -78,7 +78,7 @@ static qboolean Jukebox_PathIsUnderBase( const char *path )
 		return qfalse;
 	}
 
-	if( path[baseLen] && path[baseLen] != '/' && path[baseLen] != '\' ) {
+		if( path[baseLen] && path[baseLen] != '/' && path[baseLen] != '\\' ) {
 		return qfalse;
 	}
 


### PR DESCRIPTION
## Summary
- fix the backslash guard in `Jukebox_PathIsUnderBase` to use a valid backslash character literal

## Testing
- make -C engine release *(fails: SDL_version.h missing in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cf2b2b5c7c832482c86a8915b4a1c6