### PR TITLE
Declare s_soundtime before jukebox update

### DIFF
--- a/engine/code/client/snd_dma.c
+++ b/engine/code/client/snd_dma.c
@@ -168,6 +168,8 @@ static qboolean Jukebox_Begin( const char *currentTrack )
 	return qtrue;
 }
 
+extern int s_soundtime;
+
 static void Jukebox_UpdateTrackInfo( void )
 {
 	if( !s_jukeboxState.active ) {


### PR DESCRIPTION
## Summary
- add a forward declaration of `s_soundtime` before `Jukebox_UpdateTrackInfo`

## Testing
- make release (fails: SDL_version.h missing in build environment)


------
https://chatgpt.com/codex/tasks/task_e_68cf2c9699c88324a8d096adf5af31f8