### PR TITLE
Add music metadata tracking and HUD banner

### DIFF
--- a/engine/code/cgame/cg_draw.c
+++ b/engine/code/cgame/cg_draw.c
@@ -3173,6 +3173,122 @@ void CG_DrawTimedMenus( void ) {
 CG_Draw2D
 =========
 */
+#define CG_MUSIC_BANNER_TIME 5000
+
+static void CG_DrawMusicBanner( void )
+{
+	cgameMusicState_t state;
+	int titleMaxChars;
+	int elapsedSamples;
+	int totalSamples;
+	int sampleRate;
+	int elapsedMs;
+	int totalMs;
+	float progress;
+	char timeBuffer[64];
+	const char *title;
+	int elapsedSec;
+	int totalSec;
+	int percent;
+	float x = 8.0f;
+	float y = 8.0f;
+	float width = 360.0f;
+	float height = SMALLCHAR_HEIGHT * 2 + 14.0f;
+	float barX;
+	float barY;
+	float barWidth;
+	const float bgColor[4] = { 0.0f, 0.0f, 0.0f, 0.6f };
+	const float borderColor[4] = { 1.0f, 1.0f, 1.0f, 0.25f };
+	const float barBg[4] = { 1.0f, 1.0f, 1.0f, 0.2f };
+	const float barFill[4] = { 0.2f, 0.6f, 1.0f, 0.8f };
+
+	Com_Memset( &state, 0, sizeof( state ) );
+	trap_S_GetMusicState( &state );
+
+	if( !state.valid ) {
+		cg.musicBannerExpire = 0;
+		return;
+	}
+
+	if( !cg.musicTitle[0] || state.startSample != cg.musicStartSample ||
+		state.totalSamples != cg.musicTotalSamples || state.sampleRate != cg.musicSampleRate ) {
+		title = state.title[0] ? state.title : state.trackPath;
+		Q_strncpyz( cg.musicTitle, title, sizeof( cg.musicTitle ) );
+		cg.musicStartSample = state.startSample;
+		cg.musicSampleRate = state.sampleRate;
+		cg.musicTotalSamples = state.totalSamples;
+		cg.musicDurationMs = ( state.sampleRate > 0 && state.totalSamples > 0 ) ?
+			(int)((int64_t)state.totalSamples * 1000 / state.sampleRate) : 0;
+		cg.musicBannerExpire = cg.time + CG_MUSIC_BANNER_TIME;
+	}
+
+	if( cg.time >= cg.musicBannerExpire ) {
+		return;
+	}
+
+	title = cg.musicTitle[0] ? cg.musicTitle : ( state.title[0] ? state.title : state.trackPath );
+	sampleRate = cg.musicSampleRate > 0 ? cg.musicSampleRate : state.sampleRate;
+	totalSamples = cg.musicTotalSamples > 0 ? cg.musicTotalSamples : state.totalSamples;
+	elapsedSamples = state.currentSample - cg.musicStartSample;
+	if( elapsedSamples < 0 ) {
+		elapsedSamples = 0;
+	}
+	if( totalSamples > 0 && elapsedSamples > totalSamples ) {
+		elapsedSamples = totalSamples;
+	}
+
+	progress = 0.0f;
+	if( totalSamples > 0 ) {
+		progress = (float)elapsedSamples / (float)totalSamples;
+		if( progress > 1.0f ) {
+			progress = 1.0f;
+		}
+	}
+
+	elapsedMs = 0;
+	if( sampleRate > 0 ) {
+		elapsedMs = (int)((int64_t)elapsedSamples * 1000 / sampleRate);
+	}
+	totalMs = cg.musicDurationMs;
+	if( totalMs <= 0 && totalSamples > 0 && sampleRate > 0 ) {
+		totalMs = (int)((int64_t)totalSamples * 1000 / sampleRate);
+	}
+	if( totalMs > 0 && elapsedMs > totalMs ) {
+		elapsedMs = totalMs;
+	}
+	if( totalMs < 0 ) {
+		totalMs = 0;
+	}
+
+	elapsedSec = elapsedMs / 1000;
+	totalSec = totalMs / 1000;
+	percent = (int)(progress * 100.0f + 0.5f);
+	if( percent < 0 ) {
+		percent = 0;
+	} else if( percent > 100 ) {
+		percent = 100;
+	}
+
+	Com_sprintf( timeBuffer, sizeof( timeBuffer ), "%02d:%02d / %02d:%02d (%d%%)",
+		elapsedSec / 60, elapsedSec % 60, totalSec / 60, totalSec % 60, percent );
+
+	CG_FillRect( x, y, width, height, bgColor );
+	CG_DrawRect( x, y, width, height, 1.0f, borderColor );
+
+	titleMaxChars = (int)((width - 16.0f) / (SMALLCHAR_WIDTH + 2));
+	if( titleMaxChars < 0 ) {
+		titleMaxChars = 0;
+	}
+	CG_DrawStringExt( (int)(x + 8.0f), (int)(y + 4.0f), title, colorWhite, qfalse, qtrue, SMALLCHAR_WIDTH, SMALLCHAR_HEIGHT, titleMaxChars );
+	CG_DrawStringExt( (int)(x + 8.0f), (int)(y + SMALLCHAR_HEIGHT + 6.0f), timeBuffer, colorWhite, qfalse, qtrue, SMALLCHAR_WIDTH, SMALLCHAR_HEIGHT, 0 );
+
+	barX = x + 8.0f;
+	barWidth = width - 16.0f;
+	barY = y + height - 8.0f;
+	CG_FillRect( barX, barY, barWidth, 4.0f, barBg );
+	CG_FillRect( barX, barY, barWidth * progress, 4.0f, barFill );
+}
+
 static void CG_Draw2D(stereoFrame_t stereoFrame)
 {
 #ifdef MISSIONPACK
@@ -3193,6 +3309,8 @@ static void CG_Draw2D(stereoFrame_t stereoFrame)
 		CG_DrawIntermission();
 		return;
 	}
+
+	CG_DrawMusicBanner();
 
 	if ( cg.snap->ps.persistant[PERS_TEAM] == TEAM_SPECTATOR 
 		|| isRaceObserver( cg.snap->ps.clientNum ) ) {

--- a/engine/code/cgame/cg_local.h
+++ b/engine/code/cgame/cg_local.h
@@ -748,6 +748,14 @@ typedef struct {
 	int			soundTime;
 	qhandle_t	soundBuffer[MAX_SOUNDBUFFER];
 
+	// background music banner state
+	char		musicTitle[MAX_QPATH];
+	int			musicDurationMs;
+	int			musicBannerExpire;
+	int			musicStartSample;
+	int			musicSampleRate;
+	int			musicTotalSamples;
+
 	// warmup countdown
 	int			warmup;
 	int			warmupCount;
@@ -2088,6 +2096,7 @@ sfxHandle_t     trap_S_RegisterSoundDebug( const char *sample, qboolean compress
 
 void		trap_S_StartBackgroundTrack( const char *intro, const char *loop );	// empty name stops music
 void	    trap_S_StopBackgroundTrack( void );
+void	    trap_S_GetMusicState( cgameMusicState_t *state );
 
 
 void		trap_R_LoadWorldMap( const char *mapname );

--- a/engine/code/cgame/cg_main.c
+++ b/engine/code/cgame/cg_main.c
@@ -1525,6 +1525,13 @@ void CG_StartMusic( void ) {
 	Q_strncpyz( parm1, COM_Parse( &s ), sizeof( parm1 ) );
 	Q_strncpyz( parm2, COM_Parse( &s ), sizeof( parm2 ) );
 
+	cg.musicTitle[0] = '\0';
+	cg.musicDurationMs = 0;
+	cg.musicBannerExpire = 0;
+	cg.musicStartSample = -1;
+	cg.musicSampleRate = 0;
+	cg.musicTotalSamples = 0;
+
 	trap_S_StartBackgroundTrack( parm1, parm2 );
 }
 #ifdef MISSIONPACK

--- a/engine/code/cgame/cg_public.h
+++ b/engine/code/cgame/cg_public.h
@@ -54,6 +54,16 @@ typedef struct {
 	int				serverCommandSequence;	// snapshot becomes current
 } snapshot_t;
 
+typedef struct cgameMusicState_s {
+	qboolean		valid;
+	char			trackPath[MAX_QPATH];
+	char			title[MAX_QPATH];
+	int			totalSamples;
+	int			sampleRate;
+	int			startSample;
+	int			currentSample;
+} cgameMusicState_t;
+
 enum {
   CGAME_EVENT_NONE,
   CGAME_EVENT_TEAMMENU,
@@ -166,6 +176,7 @@ typedef enum {
 	CG_R_INPVS,
 	// 1.32
 	CG_FS_SEEK,
+	CG_S_GETMUSICSTATE,
 
 /*
 	CG_LOADCAMERA,

--- a/engine/code/cgame/cg_syscalls.asm
+++ b/engine/code/cgame/cg_syscalls.asm
@@ -91,6 +91,7 @@ equ trap_GetEntityToken					-88
 equ	trap_R_AddPolysToScene				-89
 equ trap_R_inPVS						-90
 equ trap_FS_Seek			-91
+equ trap_S_GetMusicState			-92
 
 equ	memset						-101
 equ	memcpy						-102

--- a/engine/code/cgame/cg_syscalls.c
+++ b/engine/code/cgame/cg_syscalls.c
@@ -416,6 +416,10 @@ void	trap_S_StopBackgroundTrack( void ) {
 	syscall( CG_S_STOPBACKGROUNDTRACK );
 }
 
+void	trap_S_GetMusicState( cgameMusicState_t *state ) {
+	syscall( CG_S_GETMUSICSTATE, state );
+}
+
 int trap_RealTime(qtime_t *qtime) {
 	return syscall( CG_REAL_TIME, qtime );
 }

--- a/engine/code/client/cl_cgame.c
+++ b/engine/code/client/cl_cgame.c
@@ -653,6 +653,10 @@ intptr_t CL_CgameSystemCalls( intptr_t *args ) {
 		S_StopBackgroundTrack();
 		return 0;
 
+	case CG_S_GETMUSICSTATE:
+		S_GetMusicState( VMA(1) );
+		return 0;
+
 	case CG_REAL_TIME:
 		return Com_RealTime( VMA(1) );
 	case CG_SNAPVECTOR:

--- a/engine/code/client/snd_codec.c
+++ b/engine/code/client/snd_codec.c
@@ -217,6 +217,8 @@ snd_stream_t *S_CodecUtilOpen(const char *filename, snd_codec_t *codec)
 		return NULL;
 	}
 
+	Com_Memset( stream, 0, sizeof( *stream ) );
+
 	// Copy over, return
 	stream->codec = codec;
 	stream->file = hnd;

--- a/engine/code/client/snd_codec.h
+++ b/engine/code/client/snd_codec.h
@@ -47,6 +47,7 @@ typedef struct snd_stream_s
 	int length;
 	int pos;
 	void *ptr;
+	char commentTitle[MAX_QPATH];
 } snd_stream_t;
 
 // Codec functions

--- a/engine/code/client/snd_codec_ogg.c
+++ b/engine/code/client/snd_codec_ogg.c
@@ -322,6 +322,16 @@ snd_stream_t *S_OGG_CodecOpenStream(const char *filename)
 	// We use the generic pointer in stream for the OGG codec control structure
 	stream->ptr = vf;
 
+	{
+		vorbis_comment *comment = ov_comment( vf, -1 );
+		if( comment ) {
+			char *title = vorbis_comment_query( comment, "TITLE", 0 );
+			if( title && title[0] ) {
+				Q_strncpyz( stream->commentTitle, title, sizeof( stream->commentTitle ) );
+			}
+		}
+	}
+
 	return stream;
 }
 

--- a/engine/code/client/snd_dma.c
+++ b/engine/code/client/snd_dma.c
@@ -58,10 +58,85 @@ typedef struct {
 } jukeboxState_t;
 
 static jukeboxState_t s_jukeboxState;
+static cgameMusicState_t s_musicState;
+
+static void S_MusicInfoReset( void );
+static void S_UpdateMusicStateForStream( const char *filename );
+static void S_BuildMusicTitleFromPath( const char *filePath, char *out, size_t outSize );
 
 static void Jukebox_Reset( void )
 {
 	Com_Memset( &s_jukeboxState, 0, sizeof( s_jukeboxState ) );
+	S_MusicInfoReset();
+}
+
+static void S_MusicInfoReset( void )
+{
+	Com_Memset( &s_musicState, 0, sizeof( s_musicState ) );
+}
+
+static void S_BuildMusicTitleFromPath( const char *filePath, char *out, size_t outSize )
+{
+	char temp[MAX_QPATH];
+	const char *base = filePath;
+	const char *slash;
+	const char *backslash;
+	char *p;
+
+	if( !out || !outSize ) {
+		return;
+	}
+
+	out[0] = '\0';
+
+	if( !filePath || !filePath[0] ) {
+		return;
+	}
+
+	slash = strrchr( filePath, '/' );
+	backslash = strrchr( filePath, '\' );
+	if( backslash && ( !slash || backslash > slash ) ) {
+		slash = backslash;
+	}
+	if( slash && slash[1] ) {
+		base = slash + 1;
+	}
+
+	Q_strncpyz( temp, base, sizeof( temp ) );
+	COM_StripExtension( temp, temp, sizeof( temp ) );
+	for( p = temp; *p; ++p ) {
+		if( *p == '_' || *p == '-' ) {
+			*p = ' ';
+		}
+	}
+
+	Q_strncpyz( out, temp, outSize );
+	if( !out[0] ) {
+		Q_strncpyz( out, base, outSize );
+	}
+}
+
+static void S_UpdateMusicStateForStream( const char *filename )
+{
+	char sanitized[MAX_QPATH];
+
+	if( !filename || !filename[0] || !s_backgroundStream ) {
+		return;
+	}
+
+	s_musicState.valid = qtrue;
+	Q_strncpyz( s_musicState.trackPath, filename, sizeof( s_musicState.trackPath ) );
+
+	if( s_backgroundStream->commentTitle[0] ) {
+		Q_strncpyz( s_musicState.title, s_backgroundStream->commentTitle, sizeof( s_musicState.title ) );
+	} else {
+		S_BuildMusicTitleFromPath( filename, sanitized, sizeof( sanitized ) );
+		Q_strncpyz( s_musicState.title, sanitized, sizeof( s_musicState.title ) );
+	}
+
+	s_musicState.totalSamples = s_backgroundStream->info.samples;
+	s_musicState.sampleRate = s_backgroundStream->info.rate;
+	s_musicState.startSample = s_soundtime;
 }
 
 static qboolean Jukebox_PathIsUnderBase( const char *path )
@@ -78,7 +153,7 @@ static qboolean Jukebox_PathIsUnderBase( const char *path )
 		return qfalse;
 	}
 
-		if( path[baseLen] && path[baseLen] != '/' && path[baseLen] != '\\' ) {
+	if( path[baseLen] && path[baseLen] != '/' && path[baseLen] != '\' ) {
 		return qfalse;
 	}
 
@@ -177,13 +252,18 @@ static void Jukebox_UpdateTrackInfo( void )
 	}
 
 	s_jukeboxState.startSample = s_soundtime;
+	s_musicState.startSample = s_jukeboxState.startSample;
 
 	if( s_backgroundStream ) {
 		s_jukeboxState.trackSamples = s_backgroundStream->info.samples;
 		s_jukeboxState.trackRate = s_backgroundStream->info.rate;
+		s_musicState.totalSamples = s_jukeboxState.trackSamples;
+		s_musicState.sampleRate = s_jukeboxState.trackRate;
 	} else {
 		s_jukeboxState.trackSamples = 0;
 		s_jukeboxState.trackRate = 0;
+		s_musicState.totalSamples = 0;
+		s_musicState.sampleRate = 0;
 	}
 }
 
@@ -1519,6 +1599,16 @@ background music functions
 S_StopBackgroundTrack
 ======================
 */
+void S_Base_GetMusicState( cgameMusicState_t *state )
+{
+	if( !state ) {
+		return;
+	}
+
+	Com_Memcpy( state, &s_musicState, sizeof( *state ) );
+	state->currentSample = s_soundtime;
+}
+
 void S_Base_StopBackgroundTrack( void ) {
 	Jukebox_Reset();
 
@@ -1543,12 +1633,16 @@ static void S_OpenBackgroundStream( const char *filename ) {
 		s_backgroundStream = NULL;
 	}
 
+	S_MusicInfoReset();
+
 	// Open stream
 	s_backgroundStream = S_CodecOpenStream(filename);
 	if(!s_backgroundStream) {
 		Com_Printf( S_COLOR_YELLOW "WARNING: couldn't open music file %s\n", filename );
 		return;
 	}
+
+	S_UpdateMusicStateForStream( filename );
 
 	if(s_backgroundStream->info.channels != 2 || s_backgroundStream->info.rate != 22050) {
 		Com_Printf(S_COLOR_YELLOW "WARNING: music file %s is not 22k stereo\n", filename );
@@ -1816,6 +1910,7 @@ qboolean S_Base_Init( soundInterface_t *si ) {
 	si->StartLocalSound = S_Base_StartLocalSound;
 	si->StartBackgroundTrack = S_Base_StartBackgroundTrack;
 	si->StopBackgroundTrack = S_Base_StopBackgroundTrack;
+	si->GetMusicState = S_Base_GetMusicState;
 	si->RawSamples = S_Base_RawSamples;
 	si->StopAllSounds = S_Base_StopAllSounds;
 	si->ClearLoopingSounds = S_Base_ClearLoopingSounds;

--- a/engine/code/client/snd_local.h
+++ b/engine/code/client/snd_local.h
@@ -131,6 +131,7 @@ typedef struct
 	void (*StartLocalSound)( sfxHandle_t sfx, int channelNum );
 	void (*StartBackgroundTrack)( const char *intro, const char *loop );
 	void (*StopBackgroundTrack)( void );
+	void (*GetMusicState)( struct cgameMusicState_s *state );
 	void (*RawSamples)(int stream, int samples, int rate, int width, int channels, const byte *data, float volume, int entityNum);
 	void (*StopAllSounds)( void );
 	void (*ClearLoopingSounds)( qboolean killall );

--- a/engine/code/client/snd_main.c
+++ b/engine/code/client/snd_main.c
@@ -134,6 +134,19 @@ void S_StopBackgroundTrack( void )
 	}
 }
 
+void S_GetMusicState( cgameMusicState_t *state )
+{
+	if( !state ) {
+		return;
+	}
+
+	if( si.GetMusicState ) {
+		si.GetMusicState( state );
+	} else {
+		Com_Memset( state, 0, sizeof( *state ) );
+	}
+}
+
 /*
 =================
 S_RawSamples

--- a/engine/code/client/snd_openal.c
+++ b/engine/code/client/snd_openal.c
@@ -2004,6 +2004,16 @@ static void S_AL_CloseMusicFiles(void)
 	}
 }
 
+static
+void S_AL_GetMusicState( cgameMusicState_t *state )
+{
+	if( !state ) {
+		return;
+	}
+
+	Com_Memset( state, 0, sizeof( *state ) );
+}
+
 /*
 =================
 S_AL_StopBackgroundTrack
@@ -2721,6 +2731,7 @@ qboolean S_AL_Init( soundInterface_t *si )
 	si->StartLocalSound = S_AL_StartLocalSound;
 	si->StartBackgroundTrack = S_AL_StartBackgroundTrack;
 	si->StopBackgroundTrack = S_AL_StopBackgroundTrack;
+	si->GetMusicState = S_AL_GetMusicState;
 	si->RawSamples = S_AL_RawSamples;
 	si->StopAllSounds = S_AL_StopAllSounds;
 	si->ClearLoopingSounds = S_AL_ClearLoopingSounds;

--- a/engine/code/client/snd_public.h
+++ b/engine/code/client/snd_public.h
@@ -21,6 +21,8 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 */
 
 
+struct cgameMusicState_s;
+
 void S_Init( void );
 void S_Shutdown( void );
 
@@ -30,6 +32,7 @@ void S_StartLocalSound( sfxHandle_t sfx, int channelNum );
 
 void S_StartBackgroundTrack( const char *intro, const char *loop );
 void S_StopBackgroundTrack( void );
+void S_GetMusicState( struct cgameMusicState_s *state );
 
 // cinematics and voice-over-network will send raw samples
 // 1.0 volume will be direct output of source samples


### PR DESCRIPTION
## Summary
- add a shared `cgameMusicState_t` structure and expose it through the new `CG_S_GETMUSICSTATE` trap
- capture background music metadata (Vorbis TITLE comment fallback, timing, playlist handling) and expose it to the sound interface
- render a HUD banner that displays the current track title and playback progress while the music starts

## Testing
- make *(fails: missing SDL_version.h)*

------
https://chatgpt.com/codex/tasks/task_e_68cf2dc3fa348324bdbff41dda97f6e2