### PR TITLE
Fix backslash literals in sound path helpers

### DIFF
--- a/engine/code/client/snd_dma.c
+++ b/engine/code/client/snd_dma.c
@@ -94,7 +94,7 @@ static void S_BuildMusicTitleFromPath( const char *filePath, char *out, size_t o
 	}
 
 	slash = strrchr( filePath, '/' );
-	backslash = strrchr( filePath, '\' );
+	backslash = strrchr( filePath, '\\' );
 	if( backslash && ( !slash || backslash > slash ) ) {
 		slash = backslash;
 	}
@@ -153,7 +153,7 @@ static qboolean Jukebox_PathIsUnderBase( const char *path )
 		return qfalse;
 	}
 
-	if( path[baseLen] && path[baseLen] != '/' && path[baseLen] != '\' ) {
+	if( path[baseLen] && path[baseLen] != '/' && path[baseLen] != '\\' ) {
 		return qfalse;
 	}
 


### PR DESCRIPTION
## Summary
- ensure the music title builder searches for backslashes using an escaped literal
- treat backslashes correctly when validating jukebox paths against the base directory

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cf3c87bc40832499ba8018b9866cfb