### PR TITLE
Move s_soundtime declaration before S_UpdateMusicStateForStream

### DIFF
--- a/engine/code/client/snd_dma.c
+++ b/engine/code/client/snd_dma.c
@@ -60,6 +60,8 @@ typedef struct {
 static jukeboxState_t s_jukeboxState;
 static cgameMusicState_t s_musicState;
 
+extern int s_soundtime;
+
 static void S_MusicInfoReset( void );
 static void S_UpdateMusicStateForStream( const char *filename );
 static void S_BuildMusicTitleFromPath( const char *filePath, char *out, size_t outSize );
@@ -242,8 +244,6 @@ static qboolean Jukebox_Begin( const char *currentTrack )
 
 	return qtrue;
 }
-
-extern int s_soundtime;
 
 static void Jukebox_UpdateTrackInfo( void )
 {


### PR DESCRIPTION
## Summary
- declare s_soundtime before S_UpdateMusicStateForStream so the compiler sees it during parsing

## Testing
- make *(fails: missing SDL_version.h header in build environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cf3e98e46c8324a50fb5275b074633