### PR TITLE
Document jukebox music rotation

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -74,6 +74,7 @@ Added:
 - finished the flag status hud for domination
 - finished 4 Teams Domination
 - main menu music rotation
+- Jukebox background music rotation toggled with `/jukebox`, including random playlist support
 - New Gamemode: Elimination
   - Countdown-driven rounds decide when racers get knocked out
   - Fresh HUD cues highlight elimination status and timer warnings


### PR DESCRIPTION
## Summary
- add a changelog note for the jukebox background music rotation toggle and random playlist support

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d0471269108324a1c8aa38420f1b7f