### PR TITLE
Document ladder service architecture and add CVars

### DIFF
--- a/engine/code/server/server.h
+++ b/engine/code/server/server.h
@@ -270,6 +270,9 @@ extern	cvar_t	*sv_zombietime;
 extern	cvar_t	*sv_rconPassword;
 extern	cvar_t	*sv_privatePassword;
 extern	cvar_t	*sv_allowDownload;
+extern	cvar_t	*sv_ladderEnabled;
+extern	cvar_t	*sv_ladderUrl;
+extern	cvar_t	*sv_ladderApiKey;
 extern	cvar_t	*sv_maxclients;
 
 extern	cvar_t	*sv_privateClients;

--- a/engine/code/server/sv_init.c
+++ b/engine/code/server/sv_init.c
@@ -679,6 +679,10 @@ void SV_Init (void)
 	Cvar_Get ("nextmap", "", CVAR_TEMP );
 
 	sv_allowDownload = Cvar_Get ("sv_allowDownload", "0", CVAR_SERVERINFO);
+	sv_ladderEnabled = Cvar_Get ("sv_ladderEnabled", "0", CVAR_ARCHIVE);
+	Cvar_CheckRange( sv_ladderEnabled, 0, 1, qtrue );
+	sv_ladderUrl = Cvar_Get ("sv_ladderUrl", "", CVAR_ARCHIVE);
+	sv_ladderApiKey = Cvar_Get ("sv_ladderApiKey", "", CVAR_TEMP | CVAR_PROTECTED);
 	Cvar_Get ("sv_dlURL", "", CVAR_SERVERINFO | CVAR_ARCHIVE);
 	
 	sv_master[0] = Cvar_Get("sv_master1", MASTER_SERVER_NAME, 0);

--- a/engine/code/server/sv_main.c
+++ b/engine/code/server/sv_main.c
@@ -37,6 +37,9 @@ cvar_t	*sv_zombietime;			// seconds to sink messages after disconnect
 cvar_t	*sv_rconPassword;		// password for remote server commands
 cvar_t	*sv_privatePassword;		// password for the privateClient slots
 cvar_t	*sv_allowDownload;
+cvar_t	*sv_ladderEnabled;
+cvar_t	*sv_ladderUrl;
+cvar_t	*sv_ladderApiKey;
 cvar_t	*sv_maxclients;
 
 cvar_t	*sv_privateClients;		// number of clients reserved for password


### PR DESCRIPTION
## Summary
- add an architecture overview for the planned ladder service payloads
- add ladder reporting CVars to the dedicated server so operators can configure the endpoint

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d0d1d673608324ba15a957884cd9e4