### PR TITLE
Track elimination survival metrics

### DIFF
--- a/engine/code/game/g_client.c
+++ b/engine/code/game/g_client.c
@@ -1294,6 +1294,10 @@ void ClientBegin( int clientNum ) {
 	client->ladderZoneHoldMs = 0;
 	client->ladderZoneLastUpdateMs = 0;
 	client->ladderZoneActiveSigil = -1;
+	client->ladderSurvivalMs = 0;
+	client->ladderEliminationRound = 0;
+	client->ladderEliminationPlayersRemaining = 0;
+	client->ladderEliminationMetric = 0.0f;
 
 	// save eflags around this, because changing teams will
 	// cause this to happen with a valid entity, and we
@@ -1324,6 +1328,10 @@ void ClientBegin( int clientNum ) {
 		ent->client->ladderLapCount = 0;
 		ent->client->ladderKills = 0;
 		ent->client->ladderDeaths = 0;
+		ent->client->ladderSurvivalMs = 0;
+		ent->client->ladderEliminationRound = 0;
+		ent->client->ladderEliminationPlayersRemaining = 0;
+		ent->client->ladderEliminationMetric = 0.0f;
 		Com_Memset( ent->client->ladderLapTimes, 0, sizeof( ent->client->ladderLapTimes ) );
 	}
 
@@ -1383,6 +1391,10 @@ void ClientSpawn(gentity_t *ent) {
 	int		savedLadderKills;
 	int		savedLadderDeaths;
 	int		savedLadderZoneHold;
+	int		savedLadderSurvival;
+	int		savedLadderEliminationRound;
+	int		savedLadderEliminationPlayersRemaining;
+	float		savedLadderEliminationMetric;
 	gentity_t	*savedCarPoints[4];
 	vec3_t	origin, forward;
 // END
@@ -1484,6 +1496,10 @@ void ClientSpawn(gentity_t *ent) {
 	savedLadderKills = client->ladderKills;
 	savedLadderDeaths = client->ladderDeaths;
 	savedLadderZoneHold = client->ladderZoneHoldMs;
+	savedLadderSurvival = client->ladderSurvivalMs;
+	savedLadderEliminationRound = client->ladderEliminationRound;
+	savedLadderEliminationPlayersRemaining = client->ladderEliminationPlayersRemaining;
+	savedLadderEliminationMetric = client->ladderEliminationMetric;
 	Com_Memcpy( savedLadderLapTimes, client->ladderLapTimes, sizeof( savedLadderLapTimes ) );
 // END
 //	savedAreaBits = client->areabits;
@@ -1531,6 +1547,10 @@ void ClientSpawn(gentity_t *ent) {
 	client->ladderKills = savedLadderKills;
 	client->ladderDeaths = savedLadderDeaths;
 	client->ladderZoneHoldMs = savedLadderZoneHold;
+	client->ladderSurvivalMs = savedLadderSurvival;
+	client->ladderEliminationRound = savedLadderEliminationRound;
+	client->ladderEliminationPlayersRemaining = savedLadderEliminationPlayersRemaining;
+	client->ladderEliminationMetric = savedLadderEliminationMetric;
 	client->ladderZoneLastUpdateMs = 0;
 	client->ladderZoneActiveSigil = -1;
 	Com_Memcpy( client->ladderLapTimes, savedLadderLapTimes, sizeof( client->ladderLapTimes ) );
@@ -1551,6 +1571,10 @@ void ClientSpawn(gentity_t *ent) {
 		client->ladderZoneHoldMs = 0;
 		client->ladderZoneLastUpdateMs = 0;
 		client->ladderZoneActiveSigil = -1;
+		client->ladderSurvivalMs = 0;
+		client->ladderEliminationRound = 0;
+		client->ladderEliminationPlayersRemaining = 0;
+		client->ladderEliminationMetric = 0.0f;
 	}
         // increment the spawncount so the client will detect the respawn
 	client->ps.persistant[PERS_SPAWN_COUNT]++;

--- a/engine/code/game/g_combat.c
+++ b/engine/code/game/g_combat.c
@@ -531,15 +531,27 @@ void player_die( gentity_t *self, gentity_t *inflictor, gentity_t *attacker, int
 	self->client->ps.pm_type = PM_DEAD;
 
 // STONELANCE
-	if ((g_gametype.integer == GT_DERBY || g_gametype.integer == GT_LCS || g_gametype.integer == GT_ELIMINATION) && level.startRaceTime){
-		self->client->finishRaceTime = level.time;
-		trap_SendServerCommand( -1, va("raceFinishTime %i %i", self->s.number, self->client->finishRaceTime) );
-	}
+        if ((g_gametype.integer == GT_DERBY || g_gametype.integer == GT_LCS || g_gametype.integer == GT_ELIMINATION) && level.startRaceTime){
+                self->client->finishRaceTime = level.time;
+                trap_SendServerCommand( -1, va("raceFinishTime %i %i", self->s.number, self->client->finishRaceTime) );
+        }
 // END
 
-	if ( g_gametype.integer == GT_ELIMINATION && level.startRaceTime ) {
-		G_RegisterEliminationDeath( self );
-	}
+        if ( self->client && level.startRaceTime ) {
+                int survivalMs = level.time - level.startRaceTime;
+
+                if ( survivalMs < 0 ) {
+                        survivalMs = 0;
+                }
+
+                if ( self->client->ladderSurvivalMs <= 0 || !level.finishRaceTime ) {
+                        self->client->ladderSurvivalMs = survivalMs;
+                }
+        }
+
+        if ( g_gametype.integer == GT_ELIMINATION && level.startRaceTime ) {
+                G_RegisterEliminationDeath( self );
+        }
 
 	if ( attacker ) {
 		killer = attacker->s.number;

--- a/engine/code/game/g_local.h
+++ b/engine/code/game/g_local.h
@@ -420,6 +420,10 @@ struct gclient_s {
 	int			ladderZoneHoldMs;
 	int			ladderZoneLastUpdateMs;
 	int			ladderZoneActiveSigil;
+	int			ladderSurvivalMs;
+	int			ladderEliminationRound;
+	int			ladderEliminationPlayersRemaining;
+	float			ladderEliminationMetric;
 
 	int			horn_sound_time;
 
@@ -441,6 +445,10 @@ typedef struct {
 	int			kills;
 	int			deaths;
 	float			kdRatio;
+	int			survivalMs;
+	int			eliminationRound;
+	int			eliminationPlayersRemaining;
+	float			eliminationMetric;
 } ladderPlayerPayload_t;
 
 typedef struct {

--- a/engine/code/game/g_main.c
+++ b/engine/code/game/g_main.c
@@ -1571,6 +1571,10 @@ void LogExit( const char *string ) {
 			payloadEntry->kills = cl->ladderKills;
 			payloadEntry->deaths = cl->ladderDeaths;
 			payloadEntry->kdRatio = (float)cl->ladderKills / (float)((cl->ladderDeaths > 0) ? cl->ladderDeaths : 1);
+			payloadEntry->survivalMs = cl->ladderSurvivalMs;
+			payloadEntry->eliminationRound = cl->ladderEliminationRound;
+			payloadEntry->eliminationPlayersRemaining = cl->ladderEliminationPlayersRemaining;
+			payloadEntry->eliminationMetric = cl->ladderEliminationMetric;
 		}
 
 		ping = cl->ps.ping < 999 ? cl->ps.ping : 999;
@@ -2173,7 +2177,26 @@ void G_RegisterEliminationDeath( gentity_t *victim ) {
         level.eliminationRound++;
         G_UpdateEliminationPlayerCount();
 
-        victim->client->ps.stats[STAT_POSITION] = level.eliminationRemainingPlayers + 1;
+        {
+                int placement;
+
+                victim->client->ladderEliminationRound = level.eliminationRound;
+                victim->client->ladderEliminationPlayersRemaining = level.eliminationRemainingPlayers;
+
+                placement = level.eliminationRemainingPlayers + 1;
+                if ( placement < 1 ) {
+                        placement = 1;
+                }
+
+                victim->client->ps.stats[STAT_POSITION] = placement;
+
+                victim->client->ladderEliminationMetric = (float)placement;
+                if ( victim->client->ladderSurvivalMs > 0 ) {
+                        // use survival time as a fractional tie breaker so that identical
+                        // placements can still be ordered by longevity within the round
+                        victim->client->ladderEliminationMetric += (float)victim->client->ladderSurvivalMs / 1000000.0f;
+                }
+        }
         Cmd_RacePositions_f();
         CalculateRanks();
 

--- a/engine/code/game/g_rally_racetools.c
+++ b/engine/code/game/g_rally_racetools.c
@@ -33,11 +33,15 @@ static void G_ResetRaceTimingForClients( int raceStartTime ) {
 			continue;
 		}
 
-		cl->ladderBestLapMs = 0;
-		cl->ladderTotalRaceMs = 0;
-		cl->ladderLapCount = 0;
-		cl->ladderLastLapStartMs = raceStartTime;
-		Com_Memset( cl->ladderLapTimes, 0, sizeof( cl->ladderLapTimes ) );
+                cl->ladderBestLapMs = 0;
+                cl->ladderTotalRaceMs = 0;
+                cl->ladderLapCount = 0;
+                cl->ladderLastLapStartMs = raceStartTime;
+                Com_Memset( cl->ladderLapTimes, 0, sizeof( cl->ladderLapTimes ) );
+                cl->ladderSurvivalMs = 0;
+                cl->ladderEliminationRound = 0;
+                cl->ladderEliminationPlayersRemaining = 0;
+                cl->ladderEliminationMetric = 0.0f;
 	}
 }
 


### PR DESCRIPTION
## Summary
- add ladder survival and elimination bookkeeping to `gclient_t` and ladder payload structures and reset the data at race start or client spawn
- record a player's survival duration on death and capture elimination round/remaining players while deriving a placement-based metric with a survival tie breaker
- extend the elimination death registration and ladder payload so survival and placement data are preserved for back-end consumers

## Testing
- make *(fails: missing SDL_version.h development headers in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68d19e18ee90832482ffc424b7d6a547