### PR TITLE
Implement server ladder uploader

### DIFF
--- a/engine/Makefile
+++ b/engine/Makefile
@@ -134,6 +134,10 @@ ifndef SERVERBIN
 SERVERBIN=q3rally-server
 endif
 
+ifndef SERVER_LIBS
+SERVER_LIBS=
+endif
+
 ifndef BASEGAME
 BASEGAME=baseq3r
 endif
@@ -427,6 +431,7 @@ ifneq (,$(findstring "$(PLATFORM)", "linux" "gnu_kfreebsd" "kfreebsd-gnu" "gnu")
 
   CLIENT_LIBS=$(SDL_LIBS)
   RENDERER_LIBS = $(SDL_LIBS)
+  SERVER_LIBS =
 
   ifeq ($(USE_PORTABLE_RPATH),1)
     # $ is escaped using two, so this is literally $ORIGIN
@@ -444,6 +449,7 @@ ifneq (,$(findstring "$(PLATFORM)", "linux" "gnu_kfreebsd" "kfreebsd-gnu" "gnu")
     CLIENT_CFLAGS += $(CURL_CFLAGS)
     ifneq ($(USE_CURL_DLOPEN),1)
       CLIENT_LIBS += $(CURL_LIBS)
+      SERVER_LIBS += $(CURL_LIBS)
     endif
   endif
 
@@ -1990,7 +1996,8 @@ Q3OBJ = \
   $(B)/client/sv_net_chan.o \
   $(B)/client/sv_snapshot.o \
   $(B)/client/sv_world.o \
-  \
+  $(B)/client/sv_ladder.o \
+\
   $(B)/client/q_math.o \
   $(B)/client/q_shared.o \
   \
@@ -2552,6 +2559,7 @@ Q3DOBJ = \
   $(B)/ded/sv_net_chan.o \
   $(B)/ded/sv_snapshot.o \
   $(B)/ded/sv_world.o \
+  $(B)/ded/sv_ladder.o \
   \
   $(B)/ded/cm_load.o \
   $(B)/ded/cm_patch.o \
@@ -2669,7 +2677,7 @@ endif
 
 $(B)/$(SERVERBIN)$(FULLBINEXT): $(Q3DOBJ)
 	$(echo_cmd) "LD $@"
-	$(Q)$(CC) $(CFLAGS) $(LDFLAGS) $(NOTSHLIBLDFLAGS) -o $@ $(Q3DOBJ) $(LIBS)
+	$(Q)$(CC) $(CFLAGS) $(LDFLAGS) $(NOTSHLIBLDFLAGS) -o $@ $(Q3DOBJ) $(LIBS) $(SERVER_LIBS)
 
 
 

--- a/engine/code/game/bg_public.h
+++ b/engine/code/game/bg_public.h
@@ -22,6 +22,8 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 */
 //
 // bg_public.h -- definitions shared by both the server game and client game modules
+#ifndef BG_PUBLIC_H
+#define BG_PUBLIC_H
 
 // STONELANCE
 #include "bg_physics.h"
@@ -950,3 +952,4 @@ qboolean        BG_PlayerTouchesItem( playerState_t *ps, entityState_t *item, in
 #define KAMI_BOOMSPHERE_MAXRADIUS               720
 #define KAMI_SHOCKWAVE2_MAXRADIUS               704
 
+#endif /* BG_PUBLIC_H */

--- a/engine/code/game/g_local.h
+++ b/engine/code/game/g_local.h
@@ -44,7 +44,6 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #define	INTERMISSION_DELAY_TIME	1000
 #define	SP_INTERMISSION_DELAY_TIME	5000
 
-#define RACE_MAX_RECORDED_LAPS  64
 
 // gentity->flags
 #define	FL_GODMODE				0x00000010
@@ -440,21 +439,7 @@ struct gclient_s {
 #define	MAX_SPAWN_VARS			64
 #define	MAX_SPAWN_VARS_CHARS	4096
 
-typedef struct {
-	int			clientNum;
-	int			kills;
-	int			deaths;
-	float			kdRatio;
-	int			survivalMs;
-	int			eliminationRound;
-	int			eliminationPlayersRemaining;
-	float			eliminationMetric;
-} ladderPlayerPayload_t;
 
-typedef struct {
-	int			count;
-	ladderPlayerPayload_t players[MAX_CLIENTS];
-} ladderMatchPayload_t;
 
 typedef struct {
 	struct gclient_s	*clients;		// [maxclients]
@@ -475,6 +460,9 @@ typedef struct {
 	int			previousTime;			// so movers can back up when blocked
 
 	int			startTime;				// level.time the map was started
+	qtime_t		matchStartTime;
+	int			matchStartEpoch;
+
 
 	int			teamScores[TEAM_NUM_TEAMS];
 // STONELANCE
@@ -1126,6 +1114,7 @@ void	trap_Cvar_Set( const char *var_name, const char *value );
 int		trap_Cvar_VariableIntegerValue( const char *var_name );
 float	trap_Cvar_VariableValue( const char *var_name );
 void	trap_Cvar_VariableStringBuffer( const char *var_name, char *buffer, int bufsize );
+void	trap_LadderSubmit( const ladderMatchPayload_t *payload );
 void	trap_LocateGameData( gentity_t *gEnts, int numGEntities, int sizeofGEntity_t, playerState_t *gameClients, int sizeofGameClient );
 void	trap_DropClient( int clientNum, const char *reason );
 void	trap_SendServerCommand( int clientNum, const char *text );

--- a/engine/code/game/g_main.c
+++ b/engine/code/game/g_main.c
@@ -653,6 +653,8 @@ void G_InitGame( int levelTime, int randomSeed, int restart ) {
 	memset( &level, 0, sizeof( level ) );
 	level.time = levelTime;
 	level.startTime = levelTime;
+	Com_Memset( &level.matchStartTime, 0, sizeof( level.matchStartTime ) );
+	level.matchStartEpoch = trap_RealTime( &level.matchStartTime );
 
 	trap_Cvar_Update( &g_eliminationStartDelay );
 	trap_Cvar_Update( &g_eliminationInterval );
@@ -1513,6 +1515,123 @@ void QDECL G_DebugLogPrintf( const char *fmt, ... ) {
 // END
 
 
+static void G_LadderStripColors( const char *in, char *out, int outSize ) {
+	int len = 0;
+
+	if ( !in || !out || outSize <= 0 ) {
+		return;
+	}
+
+	while ( *in && len < outSize - 1 ) {
+		if ( *in == '^' && in[1] ) {
+			in += 2;
+			continue;
+		}
+
+		if ( (unsigned char)*in < 32 ) {
+			in++;
+			continue;
+		}
+
+		out[len++] = *in++;
+	}
+
+	out[len] = '\0';
+}
+
+static const char *G_LadderGametypeString( int gametype ) {
+	switch ( gametype ) {
+	case GT_RACING: return "GT_RACING";
+	case GT_RACING_DM: return "GT_RACING_DM";
+	case GT_SINGLE_PLAYER: return "GT_SINGLE_PLAYER";
+	case GT_DERBY: return "GT_DERBY";
+	case GT_LCS: return "GT_LCS";
+	case GT_ELIMINATION: return "GT_ELIMINATION";
+	case GT_DEATHMATCH: return "GT_DEATHMATCH";
+	case GT_TEAM: return "GT_TEAM";
+	case GT_TEAM_RACING: return "GT_TEAM_RACING";
+	case GT_TEAM_RACING_DM: return "GT_TEAM_RACING_DM";
+	case GT_CTF: return "GT_CTF";
+	case GT_CTF4: return "GT_CTF4";
+	case GT_DOMINATION: return "GT_DOMINATION";
+	default: return "GT_UNKNOWN";
+	}
+}
+
+static void G_LadderFormatIso8601( const qtime_t *qt, char *out, size_t outSize ) {
+	if ( !out || outSize < 2 ) {
+		return;
+	}
+
+	if ( !qt ) {
+		out[0] = '\0';
+		return;
+	}
+
+	Com_sprintf( out, outSize, "%04i-%02i-%02iT%02i:%02i:%02iZ",
+		qt->tm_year + 1900, qt->tm_mon + 1, qt->tm_mday,
+		qt->tm_hour, qt->tm_min, qt->tm_sec );
+}
+
+static void G_LadderFormatDurationIso( int seconds, char *out, size_t outSize ) {
+	if ( !out || outSize < 2 ) {
+		return;
+	}
+
+	if ( seconds < 0 ) {
+		seconds = 0;
+	}
+
+	int hours = seconds / 3600;
+	seconds %= 3600;
+	int minutes = seconds / 60;
+	seconds %= 60;
+
+	if ( hours > 0 ) {
+		Com_sprintf( out, outSize, "PT%iH%02iM%02iS", hours, minutes, seconds );
+	} else if ( minutes > 0 ) {
+		Com_sprintf( out, outSize, "PT%iM%02iS", minutes, seconds );
+	} else {
+		Com_sprintf( out, outSize, "PT%iS", seconds );
+	}
+}
+
+static void G_LadderBuildMatchId( char *out, size_t outSize, int serverId, const qtime_t *startTime, int startTimeMs ) {
+	if ( !out || outSize < 2 ) {
+		return;
+	}
+
+	if ( !startTime ) {
+		Q_strncpyz( out, "srv-unknown", outSize );
+		return;
+	}
+
+	Com_sprintf( out, outSize, "srv-%i-%04i%02i%02i-%02i%02i%02i-%03i",
+		serverId,
+		startTime->tm_year + 1900, startTime->tm_mon + 1, startTime->tm_mday,
+		startTime->tm_hour, startTime->tm_min, startTime->tm_sec,
+		startTimeMs % 1000 );
+}
+
+static void G_LadderComputePlayerId( const char *guid, const char *cleanName, char *out, size_t outSize ) {
+	char combined[128];
+
+	combined[0] = '\0';
+	if ( guid && guid[0] ) {
+		Q_strncpyz( combined, guid, sizeof( combined ) );
+	}
+	Q_strcat( combined, sizeof( combined ), "|" );
+	if ( cleanName && cleanName[0] ) {
+		Q_strcat( combined, sizeof( combined ), cleanName );
+	}
+	if ( !combined[0] ) {
+		Q_strncpyz( combined, "anonymous", sizeof( combined ) );
+	}
+
+	unsigned int hash = Com_BlockChecksum( combined, strlen( combined ) );
+	Com_sprintf( out, outSize, "cksum:%08x", hash );
+}
+
 /*
 ================
 LogExit
@@ -1527,15 +1646,17 @@ void LogExit( const char *string ) {
 	qboolean won = qtrue;
 	team_t team = TEAM_RED;
 #endif
+	qboolean ladderEnabled = trap_Cvar_VariableIntegerValue( "sv_ladderEnabled" ) != 0;
+	ladderMatchPayload_t *ladder = &level.ladderPayload;
+	qtime_t endTime;
+	int endEpoch = 0;
+
 	G_LogPrintf( "Exit: %s\n", string );
 
 	level.intermissionQueued = level.time;
 
-	// this will keep the clients from playing any voice sounds
-	// that will get cut off when the queued intermission starts
 	trap_SetConfigstring( CS_INTERMISSION, "1" );
 
-	// don't send more than 32 scores (FIXME?)
 	numSorted = level.numConnectedClients;
 	if ( numSorted > 32 ) {
 		numSorted = 32;
@@ -1543,18 +1664,85 @@ void LogExit( const char *string ) {
 
 	if ( g_gametype.integer >= GT_TEAM ) {
 // STONELANCE
-//		G_LogPrintf( "red:%i  blue:%i\n",
-//			level.teamScores[TEAM_RED], level.teamScores[TEAM_BLUE] );
 		G_LogPrintf( "red:%i  blue:%i  green:%i  yellow:%i\n",
 			level.teamScores[TEAM_RED], level.teamScores[TEAM_BLUE],
-			level.teamScores[TEAM_GREEN], level.teamScores[TEAM_YELLOW]);
+			level.teamScores[TEAM_GREEN], level.teamScores[TEAM_YELLOW] );
 // END
 	}
 
-	level.ladderPayload.count = 0;
+	if ( ladderEnabled ) {
+		char serverinfo[MAX_INFO_STRING];
+		char ipBuffer[MAX_CVAR_VALUE_STRING];
+		char portBuffer[MAX_CVAR_VALUE_STRING];
+		const char *value;
 
-	for (i=0 ; i < numSorted ; i++) {
-		int		ping;
+		Com_Memset( ladder, 0, sizeof( *ladder ) );
+		ladder->valid = qtrue;
+		ladder->gametype = g_gametype.integer;
+		Q_strncpyz( ladder->mode, G_LadderGametypeString( ladder->gametype ), sizeof( ladder->mode ) );
+
+		trap_GetServerinfo( serverinfo, sizeof( serverinfo ) );
+		value = Info_ValueForKey( serverinfo, "mapname" );
+		if ( value ) {
+			Q_strncpyz( ladder->mapName, value, sizeof( ladder->mapName ) );
+		}
+
+		value = Info_ValueForKey( serverinfo, "sv_hostname" );
+		if ( value ) {
+			G_LadderStripColors( value, ladder->serverName, sizeof( ladder->serverName ) );
+			if ( !ladder->serverName[0] ) {
+				Q_strncpyz( ladder->serverName, value, sizeof( ladder->serverName ) );
+			}
+		}
+
+		trap_Cvar_VariableStringBuffer( "net_ip", ipBuffer, sizeof( ipBuffer ) );
+		trap_Cvar_VariableStringBuffer( "net_port", portBuffer, sizeof( portBuffer ) );
+		if ( !portBuffer[0] ) {
+			Q_strncpyz( portBuffer, "27960", sizeof( portBuffer ) );
+		}
+
+		if ( ipBuffer[0] && Q_stricmp( ipBuffer, "0.0.0.0" ) ) {
+			Com_sprintf( ladder->serverHost, sizeof( ladder->serverHost ), "%s:%s", ipBuffer, portBuffer );
+		} else if ( ladder->serverName[0] ) {
+			Q_strncpyz( ladder->serverHost, ladder->serverName, sizeof( ladder->serverHost ) );
+		} else {
+			Q_strncpyz( ladder->serverHost, "localhost", sizeof( ladder->serverHost ) );
+		}
+
+		Q_strncpyz( ladder->serverBuild, Q3_VERSION, sizeof( ladder->serverBuild ) );
+		ladder->numberOfLaps = level.numberOfLaps;
+		ladder->trackReversed = trap_Cvar_VariableIntegerValue( "g_trackReversed" ) ? qtrue : qfalse;
+		ladder->eliminationStartDelay = level.eliminationStartDelay;
+		ladder->eliminationInterval = level.eliminationInterval;
+		ladder->eliminationWarning = level.eliminationWarning;
+		ladder->levelStartTime = level.startTime;
+		ladder->levelEndTime = level.time;
+		ladder->raceStartTime = level.startRaceTime;
+		ladder->raceEndTime = level.finishRaceTime ? level.finishRaceTime : level.time;
+		ladder->finishRaceTime = level.finishRaceTime;
+		ladder->winnerClientNum = level.winnerNumber;
+		Com_Memcpy( ladder->teamScores, level.teamScores, sizeof( ladder->teamScores ) );
+		Com_Memcpy( ladder->teamTimes, level.teamTimes, sizeof( ladder->teamTimes ) );
+
+		G_LadderFormatIso8601( &level.matchStartTime, ladder->startTimeIso, sizeof( ladder->startTimeIso ) );
+		ladder->startEpoch = level.matchStartEpoch;
+		endEpoch = trap_RealTime( &endTime );
+		ladder->endEpoch = endEpoch;
+		G_LadderFormatIso8601( &endTime, ladder->endTimeIso, sizeof( ladder->endTimeIso ) );
+		ladder->durationSeconds = endEpoch - level.matchStartEpoch;
+		if ( ladder->durationSeconds < 0 ) {
+			ladder->durationSeconds = 0;
+		}
+		G_LadderFormatDurationIso( ladder->durationSeconds, ladder->durationIso, sizeof( ladder->durationIso ) );
+		G_LadderBuildMatchId( ladder->matchId, sizeof( ladder->matchId ),
+			trap_Cvar_VariableIntegerValue( "sv_serverid" ), &level.matchStartTime, level.startTime );
+	} else {
+		Com_Memset( ladder, 0, sizeof( *ladder ) );
+	}
+
+	for ( i = 0 ; i < numSorted ; i++ ) {
+		int ping;
+		int timePlayed;
 
 		cl = &level.clients[level.sortedClients[i]];
 
@@ -1565,21 +1753,83 @@ void LogExit( const char *string ) {
 			continue;
 		}
 
-		if ( level.ladderPayload.count < MAX_CLIENTS ) {
-			ladderPlayerPayload_t *payloadEntry = &level.ladderPayload.players[level.ladderPayload.count++];
-			payloadEntry->clientNum = level.sortedClients[i];
-			payloadEntry->kills = cl->ladderKills;
-			payloadEntry->deaths = cl->ladderDeaths;
-			payloadEntry->kdRatio = (float)cl->ladderKills / (float)((cl->ladderDeaths > 0) ? cl->ladderDeaths : 1);
-			payloadEntry->survivalMs = cl->ladderSurvivalMs;
-			payloadEntry->eliminationRound = cl->ladderEliminationRound;
-			payloadEntry->eliminationPlayersRemaining = cl->ladderEliminationPlayersRemaining;
-			payloadEntry->eliminationMetric = cl->ladderEliminationMetric;
+		ping = cl->ps.ping < 999 ? cl->ps.ping : 999;
+		timePlayed = level.time - cl->pers.enterTime;
+		if ( timePlayed < 0 ) {
+			timePlayed = 0;
 		}
 
-		ping = cl->ps.ping < 999 ? cl->ps.ping : 999;
+		if ( ladderEnabled && ladder->playerCount < MAX_CLIENTS ) {
+			ladderPlayerPayload_t *entry = &ladder->players[ladder->playerCount++];
+			char userinfo[MAX_INFO_STRING];
+			char cleanName[LADDER_MAX_PLAYER_NAME];
+			const char *guid;
+			const char *name;
+			const char *model;
 
-		G_LogPrintf( "score: %i  ping: %i  client: %i %s\n", cl->ps.persistant[PERS_SCORE], ping, level.sortedClients[i],	cl->pers.netname );
+			Com_Memset( entry, 0, sizeof( *entry ) );
+			entry->clientNum = level.sortedClients[i];
+			entry->team = cl->sess.sessionTeam;
+			entry->score = cl->ps.persistant[PERS_SCORE];
+			entry->ping = ping;
+			entry->time = timePlayed;
+			entry->powerUps = g_entities[level.sortedClients[i]].s.powerups;
+			entry->accuracy = cl->accuracy_shots ? ( cl->accuracy_hits * 100 / cl->accuracy_shots ) : 0;
+			entry->impressiveCount = cl->ps.persistant[PERS_IMPRESSIVE_COUNT];
+			entry->impressiveTelefragCount = cl->ps.persistant[PERS_IMPRESSIVETELEFRAG_COUNT];
+			entry->excellentCount = cl->ps.persistant[PERS_EXCELLENT_COUNT];
+			entry->gauntletCount = cl->ps.persistant[PERS_GAUNTLET_FRAG_COUNT];
+			entry->defendCount = cl->ps.persistant[PERS_DEFEND_COUNT];
+			entry->assistCount = cl->ps.persistant[PERS_ASSIST_COUNT];
+			entry->perfect = ( cl->ps.persistant[PERS_RANK] == 0 && cl->ps.persistant[PERS_KILLED] == 0 );
+			entry->captures = cl->ps.persistant[PERS_CAPTURES];
+			entry->damageDealt = cl->ps.stats[STAT_DAMAGE_DEALT];
+			entry->damageTaken = cl->ps.stats[STAT_DAMAGE_TAKEN];
+			entry->position = cl->ps.stats[STAT_POSITION];
+			entry->kills = cl->ladderKills;
+			entry->deaths = cl->ladderDeaths;
+			entry->kdRatio = ( cl->ladderDeaths > 0 ) ? (float)cl->ladderKills / (float)cl->ladderDeaths : (float)cl->ladderKills;
+			entry->survivalMs = cl->ladderSurvivalMs;
+			entry->zoneHoldMs = cl->ladderZoneHoldMs;
+			entry->zoneActiveSigil = cl->ladderZoneActiveSigil;
+			entry->eliminationRound = cl->ladderEliminationRound;
+			entry->eliminationPlayersRemaining = cl->ladderEliminationPlayersRemaining;
+			entry->eliminationMetric = cl->ladderEliminationMetric;
+			entry->bestLapMs = cl->ladderBestLapMs;
+			entry->totalRaceMs = cl->ladderTotalRaceMs;
+			entry->lapCount = cl->ladderLapCount;
+			entry->finishRaceTime = cl->finishRaceTime;
+			if ( entry->lapCount < 0 ) {
+				entry->lapCount = 0;
+			} else if ( entry->lapCount > RACE_MAX_RECORDED_LAPS ) {
+				entry->lapCount = RACE_MAX_RECORDED_LAPS;
+			}
+			Com_Memcpy( entry->lapTimes, cl->ladderLapTimes, sizeof( entry->lapTimes ) );
+
+			trap_GetUserinfo( level.sortedClients[i], userinfo, sizeof( userinfo ) );
+			guid = Info_ValueForKey( userinfo, "cl_guid" );
+			name = Info_ValueForKey( userinfo, "name" );
+			model = Info_ValueForKey( userinfo, "model" );
+
+			if ( name ) {
+				Q_strncpyz( entry->name, name, sizeof( entry->name ) );
+				G_LadderStripColors( name, cleanName, sizeof( cleanName ) );
+				Q_strncpyz( entry->cleanName, cleanName, sizeof( entry->cleanName ) );
+			} else {
+				entry->name[0] = '\0';
+				entry->cleanName[0] = '\0';
+			}
+
+			if ( guid ) {
+				Q_strncpyz( entry->guid, guid, sizeof( entry->guid ) );
+			}
+			if ( model ) {
+				Q_strncpyz( entry->model, model, sizeof( entry->model ) );
+			}
+			G_LadderComputePlayerId( entry->guid, entry->cleanName, entry->playerId, sizeof( entry->playerId ) );
+		}
+
+		G_LogPrintf( "score: %i  ping: %i  client: %i %s\n", cl->ps.persistant[PERS_SCORE], ping, level.sortedClients[i], cl->pers.netname );
 #ifdef MISSIONPACK
 		if (g_singlePlayer.integer && !(g_entities[cl - level.clients].r.svFlags & SVF_BOT)) {
 			team = cl->sess.sessionTeam;
@@ -1590,7 +1840,10 @@ void LogExit( const char *string ) {
 			}
 		}
 #endif
+	}
 
+	if ( ladderEnabled ) {
+		trap_LadderSubmit( ladder );
 	}
 
 #ifdef MISSIONPACK
@@ -1606,8 +1859,8 @@ void LogExit( const char *string ) {
 	}
 #endif
 
-
 }
+
 
 
 /*

--- a/engine/code/game/g_public.h
+++ b/engine/code/game/g_public.h
@@ -25,6 +25,21 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 // g_public.h -- game module information visible to server
 
 #define	GAME_API_VERSION	8
+#include "bg_public.h"
+
+#define	LADDER_MAX_MATCH_ID		64
+#define	LADDER_MAX_MODE_NAME		32
+#define	LADDER_MAX_SERVER_NAME		128
+#define	LADDER_MAX_SERVER_HOST		96
+#define	LADDER_MAX_SERVER_BUILD	32
+#define	LADDER_MAX_PLAYER_ID		72
+#define	LADDER_MAX_GUID			64
+#define	LADDER_MAX_PLAYER_NAME	64
+#define	LADDER_MAX_MODEL_NAME	64
+
+#ifndef RACE_MAX_RECORDED_LAPS
+#define RACE_MAX_RECORDED_LAPS	64
+#endif
 
 // entity->svFlags
 // the server does not know how to interpret most of the values
@@ -97,6 +112,80 @@ typedef struct {
 	entityState_t	s;				// communicated by server to clients
 	entityShared_t	r;				// shared by both the server system and game
 } sharedEntity_t;
+
+
+typedef struct {
+	int				clientNum;
+	char	playerId[LADDER_MAX_PLAYER_ID];
+	char	guid[LADDER_MAX_GUID];
+	char	name[LADDER_MAX_PLAYER_NAME];
+	char	cleanName[LADDER_MAX_PLAYER_NAME];
+	char	model[LADDER_MAX_MODEL_NAME];
+	int				team;
+	int				score;
+	int				ping;
+	int				time;
+	int				scoreFlags;
+	int				powerUps;
+	int				accuracy;
+	int				impressiveCount;
+	int				impressiveTelefragCount;
+	int				excellentCount;
+	int				gauntletCount;
+	int				defendCount;
+	int				assistCount;
+	int				perfect;
+	int				captures;
+	int				damageDealt;
+	int				damageTaken;
+	int				position;
+	int				bestLapMs;
+	int				totalRaceMs;
+	int				lapCount;
+	int				lapTimes[RACE_MAX_RECORDED_LAPS];
+	int				kills;
+	int				deaths;
+	int				zoneHoldMs;
+	int				zoneActiveSigil;
+	int				survivalMs;
+	int				eliminationRound;
+	int				eliminationPlayersRemaining;
+	float				eliminationMetric;
+	int				finishRaceTime;
+	float				kdRatio;
+} ladderPlayerPayload_t;
+
+typedef struct {
+	qboolean	valid;
+	int				gametype;
+	char	matchId[LADDER_MAX_MATCH_ID];
+	char	mode[LADDER_MAX_MODE_NAME];
+	char	mapName[MAX_QPATH];
+	char	serverName[LADDER_MAX_SERVER_NAME];
+	char	serverHost[LADDER_MAX_SERVER_HOST];
+	char	serverBuild[LADDER_MAX_SERVER_BUILD];
+	char	startTimeIso[32];
+	char	endTimeIso[32];
+	char	durationIso[32];
+	int				startEpoch;
+	int				endEpoch;
+	int				durationSeconds;
+	int				levelStartTime;
+	int				levelEndTime;
+	int				raceStartTime;
+	int				raceEndTime;
+	int				finishRaceTime;
+	int				winnerClientNum;
+	int				numberOfLaps;
+	qboolean	trackReversed;
+	int				eliminationStartDelay;
+	int				eliminationInterval;
+	int				eliminationWarning;
+	int				teamScores[TEAM_NUM_TEAMS];
+	int				teamTimes[TEAM_NUM_TEAMS];
+	int				playerCount;
+	ladderPlayerPayload_t	players[MAX_CLIENTS];
+} ladderMatchPayload_t;
 
 
 
@@ -230,6 +319,7 @@ typedef enum {
 	
 	// 1.32
 	G_FS_SEEK,
+	G_LADDER_SUBMIT,
 
 	BOTLIB_SETUP = 200,				// ( void );
 	BOTLIB_SHUTDOWN,				// ( void );

--- a/engine/code/game/g_syscalls.asm
+++ b/engine/code/game/g_syscalls.asm
@@ -46,6 +46,7 @@ equ trap_SnapVector			-43
 equ trap_TraceCapsule		-44
 equ trap_EntityContactCapsule	-45
 equ trap_FS_Seek -46
+equ	trap_LadderSubmit	-47
 
 equ	memset					-101
 equ	memcpy					-102

--- a/engine/code/game/g_syscalls.c
+++ b/engine/code/game/g_syscalls.c
@@ -112,9 +112,13 @@ void trap_Cvar_VariableStringBuffer( const char *var_name, char *buffer, int buf
 	syscall( G_CVAR_VARIABLE_STRING_BUFFER, var_name, buffer, bufsize );
 }
 
+void trap_LadderSubmit( const ladderMatchPayload_t *payload ) {
+	syscall( G_LADDER_SUBMIT, payload );
+}
+
 
 void trap_LocateGameData( gentity_t *gEnts, int numGEntities, int sizeofGEntity_t,
-						 playerState_t *clients, int sizeofGClient ) {
+                                                 playerState_t *clients, int sizeofGClient ) {
 	syscall( G_LOCATE_GAME_DATA, gEnts, numGEntities, sizeofGEntity_t, clients, sizeofGClient );
 }
 

--- a/engine/code/server/server.h
+++ b/engine/code/server/server.h
@@ -416,6 +416,10 @@ void		SV_InitGameProgs ( void );
 void		SV_ShutdownGameProgs ( void );
 void		SV_RestartGameProgs( void );
 qboolean	SV_inPVS (const vec3_t p1, const vec3_t p2);
+void	SV_LadderInit( void );
+void	SV_LadderShutdown( void );
+void	SV_LadderSubmit( const ladderMatchPayload_t *payload );
+void	SV_LadderFrame( void );
 
 //
 // sv_bot.c

--- a/engine/code/server/sv_game.c
+++ b/engine/code/server/sv_game.c
@@ -337,6 +337,9 @@ intptr_t SV_GameSystemCalls( intptr_t *args ) {
 		return FS_GetFileList( VMA(1), VMA(2), VMA(3), args[4] );
 	case G_FS_SEEK:
 		return FS_Seek( args[1], args[2], args[3] );
+        case G_LADDER_SUBMIT:
+                SV_LadderSubmit( (const ladderMatchPayload_t *) VMA(1) );
+                return 0;
 
 	case G_LOCATE_GAME_DATA:
 		SV_LocateGameData( VMA(1), args[2], args[3], VMA(4), args[5] );

--- a/engine/code/server/sv_init.c
+++ b/engine/code/server/sv_init.c
@@ -704,11 +704,13 @@ void SV_Init (void)
 	// initialize bot cvars so they are listed and can be set before loading the botlib
 	SV_BotInitCvars();
 
-	// init the botlib here because we need the pre-compiler in the UI
-	SV_BotInitBotLib();
-	
-	// Load saved bans
-	Cbuf_AddText("rehashbans\n");
+        // init the botlib here because we need the pre-compiler in the UI
+        SV_BotInitBotLib();
+
+        // Load saved bans
+        Cbuf_AddText("rehashbans\n");
+
+        SV_LadderInit();
 }
 
 
@@ -765,12 +767,13 @@ void SV_Shutdown( char *finalmsg ) {
 		SV_FinalMessage( finalmsg );
 	}
 
-	SV_RemoveOperatorCommands();
-	SV_MasterShutdown();
-	SV_ShutdownGameProgs();
+        SV_RemoveOperatorCommands();
+        SV_MasterShutdown();
+        SV_ShutdownGameProgs();
+        SV_LadderShutdown();
 
-	// free current level
-	SV_ClearServer();
+        // free current level
+        SV_ClearServer();
 
 	// free server static data
 	if(svs.clients)

--- a/engine/code/server/sv_ladder.c
+++ b/engine/code/server/sv_ladder.c
@@ -1,0 +1,1654 @@
+/*
+==========================================================================
+Copyright (C) 1999-2005 Id Software, Inc.
+Copyright (C) 2002-2021 Q3Rally Team (Per Thormann - q3rally@gmail.com)
+
+This file is part of q3rally source code.
+
+q3rally source code is free software; you can redistribute it
+and/or modify it under the terms of the GNU General Public License as
+published by the Free Software Foundation; either version 2 of the License,
+or (at your option) any later version.
+
+q3rally source code is distributed in the hope that it will be
+useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with q3rally; if not, write to the Free Software
+Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+==========================================================================
+*/
+// sv_ladder.c -- ladder upload interface
+
+#include "server.h"
+
+#include <ctype.h>
+#include <errno.h>
+#include <math.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#ifdef _MSC_VER
+#include <float.h>
+#endif
+
+#define LADDER_SPOOL_LIMIT                      8
+#define LADDER_JSON_INITIAL_CAPACITY    (16 * 1024)
+#define LADDER_BACKOFF_BASE_MS          5000
+#define LADDER_BACKOFF_MAX_MS           300000
+#define LADDER_RESPONSE_LIMIT           512
+#define LADDER_SPOOL_MAX_SIZE           (512 * 1024)
+#define LADDER_MATCH_ID_FALLBACK        "pending"
+
+#ifdef USE_CURL
+#include <curl/curl.h>
+#ifdef USE_CURL_DLOPEN
+#include "../sys/sys_loadlib.h"
+#endif
+#endif
+
+typedef struct ladderJsonBuilder_s {
+        char            *data;
+        size_t  length;
+        size_t  capacity;
+} ladderJsonBuilder_t;
+
+typedef struct ladderRequest_s {
+        struct ladderRequest_s *next;
+        ladderMatchPayload_t    payload;
+        char            *json;
+        size_t  jsonLength;
+        char            matchId[LADDER_MAX_MATCH_ID];
+        char            spoolPath[MAX_OSPATH];
+        char            spoolName[64];
+        int             attempt;
+        int             nextAttemptTime;
+#ifdef USE_CURL
+        CURL            *easy;
+        struct curl_slist *headers;
+        char            errorBuffer[CURL_ERROR_SIZE];
+        char            response[LADDER_RESPONSE_LIMIT];
+        size_t  responseLength;
+#endif
+} ladderRequest_t;
+
+typedef struct {
+        qboolean        initialized;
+        qboolean        spoolReady;
+        qboolean        warnedNoCurl;
+        qboolean        warnedNoUrl;
+        int             maxQueue;
+        int             queueSize;
+        int             nextFileId;
+        char            spoolDirectory[MAX_OSPATH];
+        ladderRequest_t *head;
+        ladderRequest_t *tail;
+        ladderRequest_t *active;
+#ifdef USE_CURL
+        qboolean        curlLoaded;
+        CURLM           *multi;
+#endif
+} svLadderState_t;
+
+static svLadderState_t sv_ladder;
+
+#ifdef USE_CURL
+#ifdef USE_CURL_DLOPEN
+static void *sv_curlLib;
+static CURL* (*sv_curl_easy_init)(void);
+static CURLcode (*sv_curl_easy_setopt)(CURL *curl, CURLoption option, ...);
+static CURLcode (*sv_curl_easy_getinfo)(CURL *curl, CURLINFO info, ...);
+static void (*sv_curl_easy_cleanup)(CURL *curl);
+static const char *(*sv_curl_easy_strerror)(CURLcode errornum);
+static CURLM* (*sv_curl_multi_init)(void);
+static CURLMcode (*sv_curl_multi_add_handle)(CURLM *multi_handle, CURL *curl_handle);
+static CURLMcode (*sv_curl_multi_remove_handle)(CURLM *multi_handle, CURL *curl_handle);
+static CURLMcode (*sv_curl_multi_perform)(CURLM *multi_handle, int *running_handles);
+static CURLMcode (*sv_curl_multi_cleanup)(CURLM *multi_handle);
+static CURLMsg *(*sv_curl_multi_info_read)(CURLM *multi_handle, int *msgs_in_queue);
+static const char *(*sv_curl_multi_strerror)(CURLMcode errornum);
+static struct curl_slist *(*sv_curl_slist_append)(struct curl_slist *list, const char *string);
+static void (*sv_curl_slist_free_all)(struct curl_slist *list);
+#else
+#define sv_curl_easy_init curl_easy_init
+#define sv_curl_easy_setopt curl_easy_setopt
+#define sv_curl_easy_getinfo curl_easy_getinfo
+#define sv_curl_easy_cleanup curl_easy_cleanup
+#define sv_curl_easy_strerror curl_easy_strerror
+#define sv_curl_multi_init curl_multi_init
+#define sv_curl_multi_add_handle curl_multi_add_handle
+#define sv_curl_multi_remove_handle curl_multi_remove_handle
+#define sv_curl_multi_perform curl_multi_perform
+#define sv_curl_multi_cleanup curl_multi_cleanup
+#define sv_curl_multi_info_read curl_multi_info_read
+#define sv_curl_multi_strerror curl_multi_strerror
+#define sv_curl_slist_append curl_slist_append
+#define sv_curl_slist_free_all curl_slist_free_all
+#endif
+#endif
+
+static qboolean SV_LadderJsonInit( ladderJsonBuilder_t *builder, size_t capacity ) {
+        builder->length = 0;
+        builder->capacity = capacity;
+        builder->data = Z_Malloc( builder->capacity );
+        if ( !builder->data ) {
+                builder->capacity = 0;
+                return qfalse;
+        }
+        builder->data[0] = '\0';
+        return qtrue;
+}
+
+static qboolean SV_LadderJsonEnsure( ladderJsonBuilder_t *builder, size_t extra ) {
+        size_t required;
+        char *newData;
+
+        if ( !builder->data ) {
+                return qfalse;
+        }
+
+        required = builder->length + extra + 1;
+        if ( required <= builder->capacity ) {
+                return qtrue;
+        }
+
+        while ( builder->capacity < required ) {
+                builder->capacity *= 2;
+        }
+
+        newData = Z_Malloc( builder->capacity );
+        if ( !newData ) {
+                return qfalse;
+        }
+
+        Com_Memcpy( newData, builder->data, builder->length + 1 );
+        Z_Free( builder->data );
+        builder->data = newData;
+        return qtrue;
+}
+
+static qboolean SV_LadderJsonAppendRaw( ladderJsonBuilder_t *builder, const char *text, size_t length ) {
+        if ( !SV_LadderJsonEnsure( builder, length ) ) {
+                return qfalse;
+        }
+
+        Com_Memcpy( builder->data + builder->length, text, length );
+        builder->length += length;
+        builder->data[builder->length] = '\0';
+        return qtrue;
+}
+
+static qboolean SV_LadderJsonAppendChar( ladderJsonBuilder_t *builder, char ch ) {
+        if ( !SV_LadderJsonEnsure( builder, 1 ) ) {
+                return qfalse;
+        }
+
+        builder->data[builder->length++] = ch;
+        builder->data[builder->length] = '\0';
+        return qtrue;
+}
+
+static qboolean SV_LadderJsonAppendString( ladderJsonBuilder_t *builder, const char *text ) {
+        const unsigned char *cursor;
+
+        if ( !SV_LadderJsonAppendChar( builder, '\"' ) ) {
+                return qfalse;
+        }
+
+        if ( !text ) {
+                text = "";
+        }
+
+        cursor = (const unsigned char *)text;
+        while ( *cursor ) {
+                unsigned char c = *cursor++;
+
+                switch ( c ) {
+                case '\\':
+                        if ( !SV_LadderJsonAppendRaw( builder, "\\\\", 2 ) ) {
+                                return qfalse;
+                        }
+                        break;
+                case '\"':
+                        if ( !SV_LadderJsonAppendRaw( builder, "\\\"", 2 ) ) {
+                                return qfalse;
+                        }
+                        break;
+                case '\b':
+                        if ( !SV_LadderJsonAppendRaw( builder, "\\b", 2 ) ) {
+                                return qfalse;
+                        }
+                        break;
+                case '\f':
+                        if ( !SV_LadderJsonAppendRaw( builder, "\\f", 2 ) ) {
+                                return qfalse;
+                        }
+                        break;
+                case '\n':
+                        if ( !SV_LadderJsonAppendRaw( builder, "\\n", 2 ) ) {
+                                return qfalse;
+                        }
+                        break;
+                case '\r':
+                        if ( !SV_LadderJsonAppendRaw( builder, "\\r", 2 ) ) {
+                                return qfalse;
+                        }
+                        break;
+                case '\t':
+                        if ( !SV_LadderJsonAppendRaw( builder, "\\t", 2 ) ) {
+                                return qfalse;
+                        }
+                        break;
+                default:
+                        if ( c < 0x20 ) {
+                                char buffer[7];
+                                Com_sprintf( buffer, sizeof( buffer ), "\\u%04x", c );
+                                if ( !SV_LadderJsonAppendRaw( builder, buffer, strlen( buffer ) ) ) {
+                                        return qfalse;
+                                }
+                        } else {
+                                if ( !SV_LadderJsonEnsure( builder, 1 ) ) {
+                                        return qfalse;
+                                }
+                                builder->data[builder->length++] = (char)c;
+                        }
+                        break;
+                }
+        }
+
+        if ( !SV_LadderJsonAppendChar( builder, '\"' ) ) {
+                return qfalse;
+        }
+
+        return qtrue;
+}
+
+static qboolean SV_LadderJsonAppendInt( ladderJsonBuilder_t *builder, int value ) {
+        char buffer[32];
+
+        Com_sprintf( buffer, sizeof( buffer ), "%d", value );
+        return SV_LadderJsonAppendRaw( builder, buffer, strlen( buffer ) );
+}
+
+static qboolean SV_LadderIsFinite( float value ) {
+#if defined(_MSC_VER)
+        return _finite( value ) != 0;
+#else
+        return isfinite( value );
+#endif
+}
+
+static qboolean SV_LadderJsonAppendFloat( ladderJsonBuilder_t *builder, float value ) {
+        char buffer[48];
+
+        if ( Q_isnan( value ) || !SV_LadderIsFinite( value ) ) {
+                value = 0.0f;
+        }
+
+        Com_sprintf( buffer, sizeof( buffer ), "%.3f", value );
+        return SV_LadderJsonAppendRaw( builder, buffer, strlen( buffer ) );
+}
+
+static qboolean SV_LadderJsonAppendBoolean( ladderJsonBuilder_t *builder, qboolean value ) {
+        if ( value ) {
+                return SV_LadderJsonAppendRaw( builder, "true", 4 );
+        }
+        return SV_LadderJsonAppendRaw( builder, "false", 5 );
+}
+
+static qboolean SV_LadderJsonAppendKey( ladderJsonBuilder_t *builder, const char *key, qboolean *first ) {
+        if ( !SV_LadderJsonEnsure( builder, 1 ) ) {
+                return qfalse;
+        }
+
+        if ( !*first ) {
+                if ( !SV_LadderJsonAppendChar( builder, ',' ) ) {
+                        return qfalse;
+                }
+        } else {
+                *first = qfalse;
+        }
+
+        if ( !SV_LadderJsonAppendString( builder, key ) ) {
+                return qfalse;
+        }
+        if ( !SV_LadderJsonAppendChar( builder, ':' ) ) {
+                return qfalse;
+        }
+        return qtrue;
+}
+
+static qboolean SV_LadderJsonAppendTeamArray( ladderJsonBuilder_t *builder, const int *values, int count ) {
+        int i;
+
+        if ( !SV_LadderJsonAppendChar( builder, '[' ) ) {
+                return qfalse;
+        }
+        for ( i = 0; i < count; ++i ) {
+                if ( i > 0 ) {
+                        if ( !SV_LadderJsonAppendChar( builder, ',' ) ) {
+                                return qfalse;
+                        }
+                }
+                if ( !SV_LadderJsonAppendInt( builder, values[i] ) ) {
+                        return qfalse;
+                }
+        }
+        if ( !SV_LadderJsonAppendChar( builder, ']' ) ) {
+                return qfalse;
+        }
+        return qtrue;
+}
+
+static qboolean SV_LadderJsonAppendLapArray( ladderJsonBuilder_t *builder, const ladderPlayerPayload_t *player ) {
+        int count = player->lapCount;
+        int i;
+
+        if ( count < 0 ) {
+                count = 0;
+        }
+        if ( count > RACE_MAX_RECORDED_LAPS ) {
+                count = RACE_MAX_RECORDED_LAPS;
+        }
+
+        if ( !SV_LadderJsonAppendChar( builder, '[' ) ) {
+                return qfalse;
+        }
+        for ( i = 0; i < count; ++i ) {
+                if ( i > 0 ) {
+                        if ( !SV_LadderJsonAppendChar( builder, ',' ) ) {
+                                return qfalse;
+                        }
+                }
+                if ( !SV_LadderJsonAppendInt( builder, player->lapTimes[i] ) ) {
+                        return qfalse;
+                }
+        }
+        if ( !SV_LadderJsonAppendChar( builder, ']' ) ) {
+                return qfalse;
+        }
+        return qtrue;
+}
+
+static qboolean SV_LadderJsonAppendPlayer( ladderJsonBuilder_t *builder, const ladderPlayerPayload_t *player ) {
+        qboolean first = qtrue;
+
+        if ( !SV_LadderJsonAppendChar( builder, '{' ) ) {
+                return qfalse;
+        }
+
+        if ( !SV_LadderJsonAppendKey( builder, "clientNum", &first ) ||
+             !SV_LadderJsonAppendInt( builder, player->clientNum ) ) {
+                return qfalse;
+        }
+        if ( !SV_LadderJsonAppendKey( builder, "playerId", &first ) ||
+             !SV_LadderJsonAppendString( builder, player->playerId ) ) {
+                return qfalse;
+        }
+        if ( !SV_LadderJsonAppendKey( builder, "guid", &first ) ||
+             !SV_LadderJsonAppendString( builder, player->guid ) ) {
+                return qfalse;
+        }
+        if ( !SV_LadderJsonAppendKey( builder, "name", &first ) ||
+             !SV_LadderJsonAppendString( builder, player->name ) ) {
+                return qfalse;
+        }
+        if ( !SV_LadderJsonAppendKey( builder, "cleanName", &first ) ||
+             !SV_LadderJsonAppendString( builder, player->cleanName ) ) {
+                return qfalse;
+        }
+        if ( !SV_LadderJsonAppendKey( builder, "model", &first ) ||
+             !SV_LadderJsonAppendString( builder, player->model ) ) {
+                return qfalse;
+        }
+        if ( !SV_LadderJsonAppendKey( builder, "team", &first ) ||
+             !SV_LadderJsonAppendInt( builder, player->team ) ) {
+                return qfalse;
+        }
+        if ( !SV_LadderJsonAppendKey( builder, "score", &first ) ||
+             !SV_LadderJsonAppendInt( builder, player->score ) ) {
+                return qfalse;
+        }
+        if ( !SV_LadderJsonAppendKey( builder, "ping", &first ) ||
+             !SV_LadderJsonAppendInt( builder, player->ping ) ) {
+                return qfalse;
+        }
+        if ( !SV_LadderJsonAppendKey( builder, "time", &first ) ||
+             !SV_LadderJsonAppendInt( builder, player->time ) ) {
+                return qfalse;
+        }
+        if ( !SV_LadderJsonAppendKey( builder, "scoreFlags", &first ) ||
+             !SV_LadderJsonAppendInt( builder, player->scoreFlags ) ) {
+                return qfalse;
+        }
+        if ( !SV_LadderJsonAppendKey( builder, "powerUps", &first ) ||
+             !SV_LadderJsonAppendInt( builder, player->powerUps ) ) {
+                return qfalse;
+        }
+        if ( !SV_LadderJsonAppendKey( builder, "accuracy", &first ) ||
+             !SV_LadderJsonAppendInt( builder, player->accuracy ) ) {
+                return qfalse;
+        }
+        if ( !SV_LadderJsonAppendKey( builder, "impressiveCount", &first ) ||
+             !SV_LadderJsonAppendInt( builder, player->impressiveCount ) ) {
+                return qfalse;
+        }
+        if ( !SV_LadderJsonAppendKey( builder, "impressiveTelefragCount", &first ) ||
+             !SV_LadderJsonAppendInt( builder, player->impressiveTelefragCount ) ) {
+                return qfalse;
+        }
+        if ( !SV_LadderJsonAppendKey( builder, "excellentCount", &first ) ||
+             !SV_LadderJsonAppendInt( builder, player->excellentCount ) ) {
+                return qfalse;
+        }
+        if ( !SV_LadderJsonAppendKey( builder, "gauntletCount", &first ) ||
+             !SV_LadderJsonAppendInt( builder, player->gauntletCount ) ) {
+                return qfalse;
+        }
+        if ( !SV_LadderJsonAppendKey( builder, "defendCount", &first ) ||
+             !SV_LadderJsonAppendInt( builder, player->defendCount ) ) {
+                return qfalse;
+        }
+        if ( !SV_LadderJsonAppendKey( builder, "assistCount", &first ) ||
+             !SV_LadderJsonAppendInt( builder, player->assistCount ) ) {
+                return qfalse;
+        }
+        if ( !SV_LadderJsonAppendKey( builder, "perfect", &first ) ||
+             !SV_LadderJsonAppendBoolean( builder, player->perfect ) ) {
+                return qfalse;
+        }
+        if ( !SV_LadderJsonAppendKey( builder, "captures", &first ) ||
+             !SV_LadderJsonAppendInt( builder, player->captures ) ) {
+                return qfalse;
+        }
+        if ( !SV_LadderJsonAppendKey( builder, "damageDealt", &first ) ||
+             !SV_LadderJsonAppendInt( builder, player->damageDealt ) ) {
+                return qfalse;
+        }
+        if ( !SV_LadderJsonAppendKey( builder, "damageTaken", &first ) ||
+             !SV_LadderJsonAppendInt( builder, player->damageTaken ) ) {
+                return qfalse;
+        }
+        if ( !SV_LadderJsonAppendKey( builder, "position", &first ) ||
+             !SV_LadderJsonAppendInt( builder, player->position ) ) {
+                return qfalse;
+        }
+        if ( !SV_LadderJsonAppendKey( builder, "bestLapMs", &first ) ||
+             !SV_LadderJsonAppendInt( builder, player->bestLapMs ) ) {
+                return qfalse;
+        }
+        if ( !SV_LadderJsonAppendKey( builder, "totalRaceMs", &first ) ||
+             !SV_LadderJsonAppendInt( builder, player->totalRaceMs ) ) {
+                return qfalse;
+        }
+        if ( !SV_LadderJsonAppendKey( builder, "lapCount", &first ) ||
+             !SV_LadderJsonAppendInt( builder, player->lapCount ) ) {
+                return qfalse;
+        }
+        if ( !SV_LadderJsonAppendKey( builder, "lapTimes", &first ) ||
+             !SV_LadderJsonAppendLapArray( builder, player ) ) {
+                return qfalse;
+        }
+        if ( !SV_LadderJsonAppendKey( builder, "kills", &first ) ||
+             !SV_LadderJsonAppendInt( builder, player->kills ) ) {
+                return qfalse;
+        }
+        if ( !SV_LadderJsonAppendKey( builder, "deaths", &first ) ||
+             !SV_LadderJsonAppendInt( builder, player->deaths ) ) {
+                return qfalse;
+        }
+        if ( !SV_LadderJsonAppendKey( builder, "zoneHoldMs", &first ) ||
+             !SV_LadderJsonAppendInt( builder, player->zoneHoldMs ) ) {
+                return qfalse;
+        }
+        if ( !SV_LadderJsonAppendKey( builder, "zoneActiveSigil", &first ) ||
+             !SV_LadderJsonAppendInt( builder, player->zoneActiveSigil ) ) {
+                return qfalse;
+        }
+        if ( !SV_LadderJsonAppendKey( builder, "survivalMs", &first ) ||
+             !SV_LadderJsonAppendInt( builder, player->survivalMs ) ) {
+                return qfalse;
+        }
+        if ( !SV_LadderJsonAppendKey( builder, "eliminationRound", &first ) ||
+             !SV_LadderJsonAppendInt( builder, player->eliminationRound ) ) {
+                return qfalse;
+        }
+        if ( !SV_LadderJsonAppendKey( builder, "eliminationPlayersRemaining", &first ) ||
+             !SV_LadderJsonAppendInt( builder, player->eliminationPlayersRemaining ) ) {
+                return qfalse;
+        }
+        if ( !SV_LadderJsonAppendKey( builder, "eliminationMetric", &first ) ||
+             !SV_LadderJsonAppendFloat( builder, player->eliminationMetric ) ) {
+                return qfalse;
+        }
+        if ( !SV_LadderJsonAppendKey( builder, "finishRaceTime", &first ) ||
+             !SV_LadderJsonAppendInt( builder, player->finishRaceTime ) ) {
+                return qfalse;
+        }
+        if ( !SV_LadderJsonAppendKey( builder, "kdRatio", &first ) ||
+             !SV_LadderJsonAppendFloat( builder, player->kdRatio ) ) {
+                return qfalse;
+        }
+
+        if ( !SV_LadderJsonAppendChar( builder, '}' ) ) {
+                return qfalse;
+        }
+
+        return qtrue;
+}
+
+static char *SV_LadderSerializeMatch( const ladderMatchPayload_t *payload, size_t *lengthOut ) {
+        ladderJsonBuilder_t builder;
+        qboolean first = qtrue;
+        int i;
+
+        if ( !payload || !payload->valid ) {
+                return NULL;
+        }
+
+        if ( !SV_LadderJsonInit( &builder, LADDER_JSON_INITIAL_CAPACITY ) ) {
+                return NULL;
+        }
+
+        if ( !SV_LadderJsonAppendChar( &builder, '{' ) ) {
+                Z_Free( builder.data );
+                return NULL;
+        }
+
+        if ( !SV_LadderJsonAppendKey( &builder, "matchId", &first ) ||
+             !SV_LadderJsonAppendString( &builder, payload->matchId ) ) {
+                Z_Free( builder.data );
+                return NULL;
+        }
+
+        if ( !SV_LadderJsonAppendKey( &builder, "mode", &first ) ||
+             !SV_LadderJsonAppendString( &builder, payload->mode ) ) {
+                Z_Free( builder.data );
+                return NULL;
+        }
+
+        if ( !SV_LadderJsonAppendKey( &builder, "gametype", &first ) ||
+             !SV_LadderJsonAppendInt( &builder, payload->gametype ) ) {
+                Z_Free( builder.data );
+                return NULL;
+        }
+
+        if ( !SV_LadderJsonAppendKey( &builder, "map", &first ) ||
+             !SV_LadderJsonAppendString( &builder, payload->mapName ) ) {
+                Z_Free( builder.data );
+                return NULL;
+        }
+
+        if ( !SV_LadderJsonAppendKey( &builder, "startTime", &first ) ||
+             !SV_LadderJsonAppendString( &builder, payload->startTimeIso ) ) {
+                Z_Free( builder.data );
+                return NULL;
+        }
+        if ( !SV_LadderJsonAppendKey( &builder, "endTime", &first ) ||
+             !SV_LadderJsonAppendString( &builder, payload->endTimeIso ) ) {
+                Z_Free( builder.data );
+                return NULL;
+        }
+        if ( !SV_LadderJsonAppendKey( &builder, "duration", &first ) ||
+             !SV_LadderJsonAppendString( &builder, payload->durationIso ) ) {
+                Z_Free( builder.data );
+                return NULL;
+        }
+        if ( !SV_LadderJsonAppendKey( &builder, "startEpoch", &first ) ||
+             !SV_LadderJsonAppendInt( &builder, payload->startEpoch ) ) {
+                Z_Free( builder.data );
+                return NULL;
+        }
+        if ( !SV_LadderJsonAppendKey( &builder, "endEpoch", &first ) ||
+             !SV_LadderJsonAppendInt( &builder, payload->endEpoch ) ) {
+                Z_Free( builder.data );
+                return NULL;
+        }
+        if ( !SV_LadderJsonAppendKey( &builder, "durationSeconds", &first ) ||
+             !SV_LadderJsonAppendInt( &builder, payload->durationSeconds ) ) {
+                Z_Free( builder.data );
+                return NULL;
+        }
+
+        if ( !SV_LadderJsonAppendKey( &builder, "server", &first ) ) {
+                Z_Free( builder.data );
+                return NULL;
+        }
+        if ( !SV_LadderJsonAppendChar( &builder, '{' ) ) {
+                Z_Free( builder.data );
+                return NULL;
+        }
+        {
+                qboolean serverFirst = qtrue;
+                if ( !SV_LadderJsonAppendKey( &builder, "name", &serverFirst ) ||
+                     !SV_LadderJsonAppendString( &builder, payload->serverName ) ) {
+                        Z_Free( builder.data );
+                        return NULL;
+                }
+                if ( !SV_LadderJsonAppendKey( &builder, "host", &serverFirst ) ||
+                     !SV_LadderJsonAppendString( &builder, payload->serverHost ) ) {
+                        Z_Free( builder.data );
+                        return NULL;
+                }
+                if ( !SV_LadderJsonAppendKey( &builder, "build", &serverFirst ) ||
+                     !SV_LadderJsonAppendString( &builder, payload->serverBuild ) ) {
+                        Z_Free( builder.data );
+                        return NULL;
+                }
+        }
+        if ( !SV_LadderJsonAppendChar( &builder, '}' ) ) {
+                Z_Free( builder.data );
+                return NULL;
+        }
+
+        if ( !SV_LadderJsonAppendKey( &builder, "settings", &first ) ) {
+                Z_Free( builder.data );
+                return NULL;
+        }
+        if ( !SV_LadderJsonAppendChar( &builder, '{' ) ) {
+                Z_Free( builder.data );
+                return NULL;
+        }
+        {
+                qboolean settingsFirst = qtrue;
+                if ( !SV_LadderJsonAppendKey( &builder, "levelStartTime", &settingsFirst ) ||
+                     !SV_LadderJsonAppendInt( &builder, payload->levelStartTime ) ) {
+                        Z_Free( builder.data );
+                        return NULL;
+                }
+                if ( !SV_LadderJsonAppendKey( &builder, "levelEndTime", &settingsFirst ) ||
+                     !SV_LadderJsonAppendInt( &builder, payload->levelEndTime ) ) {
+                        Z_Free( builder.data );
+                        return NULL;
+                }
+                if ( !SV_LadderJsonAppendKey( &builder, "raceStartTime", &settingsFirst ) ||
+                     !SV_LadderJsonAppendInt( &builder, payload->raceStartTime ) ) {
+                        Z_Free( builder.data );
+                        return NULL;
+                }
+                if ( !SV_LadderJsonAppendKey( &builder, "raceEndTime", &settingsFirst ) ||
+                     !SV_LadderJsonAppendInt( &builder, payload->raceEndTime ) ) {
+                        Z_Free( builder.data );
+                        return NULL;
+                }
+                if ( !SV_LadderJsonAppendKey( &builder, "finishRaceTime", &settingsFirst ) ||
+                     !SV_LadderJsonAppendInt( &builder, payload->finishRaceTime ) ) {
+                        Z_Free( builder.data );
+                        return NULL;
+                }
+                if ( !SV_LadderJsonAppendKey( &builder, "winnerClientNum", &settingsFirst ) ||
+                     !SV_LadderJsonAppendInt( &builder, payload->winnerClientNum ) ) {
+                        Z_Free( builder.data );
+                        return NULL;
+                }
+                if ( !SV_LadderJsonAppendKey( &builder, "numberOfLaps", &settingsFirst ) ||
+                     !SV_LadderJsonAppendInt( &builder, payload->numberOfLaps ) ) {
+                        Z_Free( builder.data );
+                        return NULL;
+                }
+                if ( !SV_LadderJsonAppendKey( &builder, "trackReversed", &settingsFirst ) ||
+                     !SV_LadderJsonAppendBoolean( &builder, payload->trackReversed ) ) {
+                        Z_Free( builder.data );
+                        return NULL;
+                }
+                if ( !SV_LadderJsonAppendKey( &builder, "eliminationStartDelay", &settingsFirst ) ||
+                     !SV_LadderJsonAppendInt( &builder, payload->eliminationStartDelay ) ) {
+                        Z_Free( builder.data );
+                        return NULL;
+                }
+                if ( !SV_LadderJsonAppendKey( &builder, "eliminationInterval", &settingsFirst ) ||
+                     !SV_LadderJsonAppendInt( &builder, payload->eliminationInterval ) ) {
+                        Z_Free( builder.data );
+                        return NULL;
+                }
+                if ( !SV_LadderJsonAppendKey( &builder, "eliminationWarning", &settingsFirst ) ||
+                     !SV_LadderJsonAppendInt( &builder, payload->eliminationWarning ) ) {
+                        Z_Free( builder.data );
+                        return NULL;
+                }
+        }
+        if ( !SV_LadderJsonAppendChar( &builder, '}' ) ) {
+                Z_Free( builder.data );
+                return NULL;
+        }
+
+        if ( !SV_LadderJsonAppendKey( &builder, "teamScores", &first ) ||
+             !SV_LadderJsonAppendTeamArray( &builder, payload->teamScores, TEAM_NUM_TEAMS ) ) {
+                Z_Free( builder.data );
+                return NULL;
+        }
+        if ( !SV_LadderJsonAppendKey( &builder, "teamTimes", &first ) ||
+             !SV_LadderJsonAppendTeamArray( &builder, payload->teamTimes, TEAM_NUM_TEAMS ) ) {
+                Z_Free( builder.data );
+                return NULL;
+        }
+
+        {
+                int playerCount = payload->playerCount;
+                if ( playerCount < 0 ) {
+                        playerCount = 0;
+                } else if ( playerCount > MAX_CLIENTS ) {
+                        Com_Printf( "Ladder: clamping playerCount from %d to %d\n",
+                                payload->playerCount, MAX_CLIENTS );
+                        playerCount = MAX_CLIENTS;
+                }
+                if ( !SV_LadderJsonAppendKey( &builder, "playerCount", &first ) ||
+                     !SV_LadderJsonAppendInt( &builder, playerCount ) ) {
+                        Z_Free( builder.data );
+                        return NULL;
+                }
+
+                if ( !SV_LadderJsonAppendKey( &builder, "players", &first ) ) {
+                        Z_Free( builder.data );
+                        return NULL;
+                }
+                if ( !SV_LadderJsonAppendChar( &builder, '[' ) ) {
+                        Z_Free( builder.data );
+                        return NULL;
+                }
+                for ( i = 0; i < playerCount; ++i ) {
+                        if ( i > 0 ) {
+                                if ( !SV_LadderJsonAppendChar( &builder, ',' ) ) {
+                                        Z_Free( builder.data );
+                                        return NULL;
+                                }
+                        }
+                        if ( !SV_LadderJsonAppendPlayer( &builder, &payload->players[i] ) ) {
+                                Z_Free( builder.data );
+                                return NULL;
+                        }
+                }
+                if ( !SV_LadderJsonAppendChar( &builder, ']' ) ) {
+                        Z_Free( builder.data );
+                        return NULL;
+                }
+        }
+
+        if ( !SV_LadderJsonAppendChar( &builder, '}' ) ) {
+                Z_Free( builder.data );
+                return NULL;
+        }
+
+        if ( lengthOut ) {
+                *lengthOut = builder.length;
+        }
+        return builder.data;
+}
+
+static void SV_LadderSanitizeComponent( const char *input, char *output, size_t outputSize ) {
+        size_t written = 0;
+
+        if ( outputSize == 0 ) {
+                return;
+        }
+
+        if ( !input ) {
+                input = LADDER_MATCH_ID_FALLBACK;
+        }
+
+        while ( *input && written + 1 < outputSize ) {
+                char c = *input++;
+                if ( ( c >= 'a' && c <= 'z' ) || ( c >= 'A' && c <= 'Z' ) ||
+                     ( c >= '0' && c <= '9' ) || c == '-' || c == '_' ) {
+                        output[written++] = c;
+                }
+        }
+
+        if ( written == 0 ) {
+                Q_strncpyz( output, LADDER_MATCH_ID_FALLBACK, outputSize );
+        } else {
+                output[written] = '\0';
+        }
+}
+
+static void SV_LadderBuildSpoolName( ladderRequest_t *request ) {
+        char safeId[32];
+        int id;
+
+        SV_LadderSanitizeComponent( request->matchId, safeId, sizeof( safeId ) );
+        id = sv_ladder.nextFileId++;
+        Com_sprintf( request->spoolName, sizeof( request->spoolName ),
+                "match-%08x-%02d-%s.json", Sys_Milliseconds(), id & 0xff, safeId );
+}
+
+static qboolean SV_LadderEnsureSpoolDirectory( void ) {
+        char home[MAX_OSPATH];
+        char path[MAX_OSPATH];
+        const char *homePath;
+
+        sv_ladder.spoolReady = qfalse;
+        sv_ladder.spoolDirectory[0] = '\0';
+
+        homePath = Cvar_VariableString( "fs_homepath" );
+        if ( !homePath || !homePath[0] ) {
+                        return qfalse;
+        }
+
+        Q_strncpyz( home, homePath, sizeof( home ) );
+
+        Com_sprintf( path, sizeof( path ), "%s%ctelemetry", home, PATH_SEP );
+        if ( !Sys_Mkdir( path ) ) {
+                Com_Printf( "Ladder: failed to create directory '%s' (%s)\n", path, strerror( errno ) );
+                return qfalse;
+        }
+
+        Com_sprintf( path, sizeof( path ), "%s%ctelemetry%coutbox", home, PATH_SEP, PATH_SEP );
+        if ( !Sys_Mkdir( path ) ) {
+                Com_Printf( "Ladder: failed to create directory '%s' (%s)\n", path, strerror( errno ) );
+                return qfalse;
+        }
+
+        Q_strncpyz( sv_ladder.spoolDirectory, path, sizeof( sv_ladder.spoolDirectory ) );
+        sv_ladder.spoolReady = qtrue;
+        return qtrue;
+}
+
+static void SV_LadderExtractMatchIdFromJson( ladderRequest_t *request ) {
+        const char *needle = "\"matchId\":\"";
+        char *found;
+
+        if ( !request->json ) {
+                return;
+        }
+
+        found = strstr( request->json, needle );
+        if ( found ) {
+                char *cursor = found + strlen( needle );
+                size_t length = 0;
+                while ( *cursor && *cursor != '\"' && length + 1 < sizeof( request->matchId ) ) {
+                        request->matchId[length++] = *cursor++;
+                }
+                request->matchId[length] = '\0';
+        }
+}
+
+static qboolean SV_LadderWriteSpool( ladderRequest_t *request ) {
+        char pathCopy[MAX_OSPATH];
+        FILE *file;
+        size_t written;
+
+        if ( !sv_ladder.spoolReady || !request->json || !request->jsonLength ) {
+                return qfalse;
+        }
+
+        if ( !request->spoolName[0] ) {
+                SV_LadderBuildSpoolName( request );
+        }
+
+        Com_sprintf( request->spoolPath, sizeof( request->spoolPath ),
+                "%s%c%s", sv_ladder.spoolDirectory, PATH_SEP, request->spoolName );
+
+        Q_strncpyz( pathCopy, request->spoolPath, sizeof( pathCopy ) );
+        if ( FS_CreatePath( pathCopy ) ) {
+                Com_Printf( "Ladder: failed to prepare spool path '%s'\n", request->spoolPath );
+                return qfalse;
+        }
+
+        file = Sys_FOpen( request->spoolPath, "wb" );
+        if ( !file ) {
+                Com_Printf( "Ladder: failed to open spool file '%s' (%s)\n", request->spoolPath, strerror( errno ) );
+                return qfalse;
+        }
+
+        written = fwrite( request->json, 1, request->jsonLength, file );
+        fclose( file );
+
+        if ( written != request->jsonLength ) {
+                Com_Printf( "Ladder: failed to write spool file '%s' (%s)\n", request->spoolPath, strerror( errno ) );
+                return qfalse;
+        }
+
+        return qtrue;
+}
+
+static void SV_LadderQueuePush( ladderRequest_t *request ) {
+        request->next = NULL;
+
+        if ( !sv_ladder.tail ) {
+                sv_ladder.head = request;
+                sv_ladder.tail = request;
+        } else {
+                sv_ladder.tail->next = request;
+                sv_ladder.tail = request;
+        }
+        sv_ladder.queueSize++;
+}
+
+static ladderRequest_t *SV_LadderQueuePop( void ) {
+        ladderRequest_t *request = sv_ladder.head;
+
+        if ( !request ) {
+                return NULL;
+        }
+
+        sv_ladder.head = request->next;
+        if ( !sv_ladder.head ) {
+                sv_ladder.tail = NULL;
+        }
+        request->next = NULL;
+        if ( sv_ladder.queueSize > 0 ) {
+                sv_ladder.queueSize--;
+        }
+        return request;
+}
+
+static void SV_LadderFreeRequest( ladderRequest_t *request, qboolean keepSpool ) {
+        if ( !request ) {
+                return;
+        }
+#ifdef USE_CURL
+        if ( request->headers ) {
+                sv_curl_slist_free_all( request->headers );
+                request->headers = NULL;
+        }
+        if ( request->easy ) {
+                if ( sv_ladder.multi ) {
+                        sv_curl_multi_remove_handle( sv_ladder.multi, request->easy );
+                }
+                sv_curl_easy_cleanup( request->easy );
+                request->easy = NULL;
+        }
+#endif
+        if ( request->json ) {
+                Z_Free( request->json );
+                request->json = NULL;
+        }
+
+        if ( request->spoolPath[0] && !keepSpool ) {
+                if ( remove( request->spoolPath ) != 0 && errno != ENOENT ) {
+                        Com_DPrintf( "Ladder: failed to remove spool file '%s' (%s)\n",
+                                request->spoolPath, strerror( errno ) );
+                }
+        }
+
+        Z_Free( request );
+}
+
+static ladderRequest_t *SV_LadderAllocRequest( void ) {
+        ladderRequest_t *request = Z_Malloc( sizeof( ladderRequest_t ) );
+        if ( request ) {
+                Com_Memset( request, 0, sizeof( *request ) );
+        }
+        return request;
+}
+
+static void SV_LadderLoadSpool( void ) {
+        char **files;
+        int count;
+        int loaded = 0;
+
+        if ( !sv_ladder.spoolReady ) {
+                return;
+        }
+
+        files = Sys_ListFiles( sv_ladder.spoolDirectory, ".json", NULL, &count, qfalse );
+        if ( !files || count <= 0 ) {
+                if ( files ) {
+                        Sys_FreeFileList( files );
+                }
+                return;
+        }
+
+        qsort( files, count, sizeof( char * ), (int (*)( const void *, const void * ))strcmp );
+
+        for ( int i = 0; i < count; ++i ) {
+                char path[MAX_OSPATH];
+                FILE *file;
+                long size;
+                ladderRequest_t *request;
+
+                if ( !files[i] || !files[i][0] ) {
+                        continue;
+                }
+
+                if ( sv_ladder.queueSize + ( sv_ladder.active ? 1 : 0 ) >= sv_ladder.maxQueue ) {
+                        break;
+                }
+
+                if ( files[i][0] == '.' ) {
+                        continue;
+                }
+
+                request = SV_LadderAllocRequest();
+                if ( !request ) {
+                        break;
+                }
+
+                Q_strncpyz( request->spoolName, files[i], sizeof( request->spoolName ) );
+                Com_sprintf( path, sizeof( path ), "%s%c%s", sv_ladder.spoolDirectory, PATH_SEP, files[i] );
+                Q_strncpyz( request->spoolPath, path, sizeof( request->spoolPath ) );
+
+                file = Sys_FOpen( path, "rb" );
+                if ( !file ) {
+                        Com_Printf( "Ladder: unable to open spool file '%s' (%s)\n", path, strerror( errno ) );
+                        SV_LadderFreeRequest( request, qfalse );
+                        continue;
+                }
+
+                if ( fseek( file, 0, SEEK_END ) != 0 ) {
+                        fclose( file );
+                        SV_LadderFreeRequest( request, qfalse );
+                        continue;
+                }
+
+                size = ftell( file );
+                if ( size <= 0 || size > LADDER_SPOOL_MAX_SIZE ) {
+                        fclose( file );
+                        Com_Printf( "Ladder: skipping spool file '%s' (invalid size)\n", path );
+                        SV_LadderFreeRequest( request, qfalse );
+                        continue;
+                }
+
+                if ( fseek( file, 0, SEEK_SET ) != 0 ) {
+                        fclose( file );
+                        SV_LadderFreeRequest( request, qfalse );
+                        continue;
+                }
+
+                request->json = Z_Malloc( size + 1 );
+                if ( !request->json ) {
+                        fclose( file );
+                        SV_LadderFreeRequest( request, qfalse );
+                        break;
+                }
+
+                request->jsonLength = fread( request->json, 1, size, file );
+                fclose( file );
+
+                if ( request->jsonLength != (size_t)size ) {
+                        SV_LadderFreeRequest( request, qfalse );
+                        continue;
+                }
+                request->json[request->jsonLength] = '\0';
+
+                SV_LadderExtractMatchIdFromJson( request );
+
+                SV_LadderQueuePush( request );
+                loaded++;
+        }
+
+        Sys_FreeFileList( files );
+
+        sv_ladder.nextFileId += loaded;
+
+        if ( loaded > 0 ) {
+                Com_Printf( "Ladder: queued %d stored match%s from spool\n",
+                        loaded, loaded == 1 ? "" : "es" );
+        }
+}
+
+#ifdef USE_CURL
+static int SV_LadderComputeBackoff( int attempt ) {
+        int delay = LADDER_BACKOFF_BASE_MS;
+        int i;
+
+        if ( attempt <= 1 ) {
+                return delay;
+        }
+
+        for ( i = 1; i < attempt; ++i ) {
+                if ( delay >= LADDER_BACKOFF_MAX_MS / 2 ) {
+                        delay = LADDER_BACKOFF_MAX_MS;
+                        break;
+                }
+                delay *= 2;
+        }
+
+        if ( delay > LADDER_BACKOFF_MAX_MS ) {
+                delay = LADDER_BACKOFF_MAX_MS;
+        }
+        return delay;
+}
+
+#endif
+
+#ifdef USE_CURL
+#ifdef USE_CURL_DLOPEN
+#ifdef WIN32
+#define LADDER_DEFAULT_CURL_LIB "libcurl-4.dll"
+#define LADDER_ALTERNATE_CURL_LIB "libcurl-3.dll"
+#elif defined(__APPLE__)
+#define LADDER_DEFAULT_CURL_LIB "libcurl.dylib"
+#else
+#define LADDER_DEFAULT_CURL_LIB "libcurl.so.4"
+#define LADDER_ALTERNATE_CURL_LIB "libcurl.so.3"
+#endif
+
+static void *SV_LadderGPA( const char *symbol ) {
+        void *func = Sys_LoadFunction( sv_curlLib, symbol );
+        if ( !func ) {
+                Com_Printf( "Ladder: missing curl symbol %s\n", symbol );
+                return NULL;
+        }
+        return func;
+}
+
+static qboolean SV_LadderLoadCurlLibrary( void ) {
+        if ( sv_ladder.curlLoaded ) {
+                return qtrue;
+        }
+
+        if ( !sv_curlLib ) {
+                sv_curlLib = Sys_LoadDll( LADDER_DEFAULT_CURL_LIB, qtrue );
+#ifdef LADDER_ALTERNATE_CURL_LIB
+                if ( !sv_curlLib ) {
+                        sv_curlLib = Sys_LoadDll( LADDER_ALTERNATE_CURL_LIB, qtrue );
+                }
+#endif
+                if ( !sv_curlLib ) {
+                        if ( !sv_ladder.warnedNoCurl ) {
+                                Com_Printf( "Ladder: unable to load %s\n", LADDER_DEFAULT_CURL_LIB );
+                                sv_ladder.warnedNoCurl = qtrue;
+                        }
+                        return qfalse;
+                }
+        }
+
+        sv_curl_easy_init = SV_LadderGPA( "curl_easy_init" );
+        sv_curl_easy_setopt = SV_LadderGPA( "curl_easy_setopt" );
+        sv_curl_easy_getinfo = SV_LadderGPA( "curl_easy_getinfo" );
+        sv_curl_easy_cleanup = SV_LadderGPA( "curl_easy_cleanup" );
+        sv_curl_easy_strerror = SV_LadderGPA( "curl_easy_strerror" );
+        sv_curl_multi_init = SV_LadderGPA( "curl_multi_init" );
+        sv_curl_multi_add_handle = SV_LadderGPA( "curl_multi_add_handle" );
+        sv_curl_multi_remove_handle = SV_LadderGPA( "curl_multi_remove_handle" );
+        sv_curl_multi_perform = SV_LadderGPA( "curl_multi_perform" );
+        sv_curl_multi_cleanup = SV_LadderGPA( "curl_multi_cleanup" );
+        sv_curl_multi_info_read = SV_LadderGPA( "curl_multi_info_read" );
+        sv_curl_multi_strerror = SV_LadderGPA( "curl_multi_strerror" );
+        sv_curl_slist_append = SV_LadderGPA( "curl_slist_append" );
+        sv_curl_slist_free_all = SV_LadderGPA( "curl_slist_free_all" );
+
+        if ( !sv_curl_easy_init || !sv_curl_easy_setopt || !sv_curl_easy_getinfo ||
+             !sv_curl_easy_cleanup || !sv_curl_easy_strerror || !sv_curl_multi_init ||
+             !sv_curl_multi_add_handle || !sv_curl_multi_remove_handle ||
+             !sv_curl_multi_perform || !sv_curl_multi_cleanup || !sv_curl_multi_info_read ||
+             !sv_curl_multi_strerror || !sv_curl_slist_append || !sv_curl_slist_free_all ) {
+                Com_Printf( "Ladder: failed to resolve required curl symbols\n" );
+                sv_ladder.warnedNoCurl = qtrue;
+                return qfalse;
+        }
+
+        sv_ladder.curlLoaded = qtrue;
+        sv_ladder.warnedNoCurl = qfalse;
+        return qtrue;
+}
+#else
+static qboolean SV_LadderLoadCurlLibrary( void ) {
+        sv_ladder.curlLoaded = qtrue;
+        return qtrue;
+}
+#endif
+
+static qboolean SV_LadderEnsureCurl( void ) {
+        if ( !SV_LadderLoadCurlLibrary() ) {
+                return qfalse;
+        }
+
+        if ( !sv_ladder.multi ) {
+                sv_ladder.multi = sv_curl_multi_init();
+                if ( !sv_ladder.multi ) {
+                        Com_Printf( "Ladder: failed to initialize curl multi interface\n" );
+                        return qfalse;
+                }
+        }
+
+        return qtrue;
+}
+
+static void SV_LadderShutdownCurl( void ) {
+        if ( sv_ladder.multi ) {
+                sv_curl_multi_cleanup( sv_ladder.multi );
+                sv_ladder.multi = NULL;
+        }
+
+#ifdef USE_CURL_DLOPEN
+        if ( sv_curlLib ) {
+                Sys_UnloadLibrary( sv_curlLib );
+                sv_curlLib = NULL;
+        }
+        sv_curl_easy_init = NULL;
+        sv_curl_easy_setopt = NULL;
+        sv_curl_easy_getinfo = NULL;
+        sv_curl_easy_cleanup = NULL;
+        sv_curl_easy_strerror = NULL;
+        sv_curl_multi_init = NULL;
+        sv_curl_multi_add_handle = NULL;
+        sv_curl_multi_remove_handle = NULL;
+        sv_curl_multi_perform = NULL;
+        sv_curl_multi_cleanup = NULL;
+        sv_curl_multi_info_read = NULL;
+        sv_curl_multi_strerror = NULL;
+        sv_curl_slist_append = NULL;
+        sv_curl_slist_free_all = NULL;
+#endif
+
+        sv_ladder.curlLoaded = qfalse;
+}
+
+static size_t SV_LadderCurlWriteCallback( void *buffer, size_t size, size_t nmemb, void *userdata ) {
+        ladderRequest_t *request = (ladderRequest_t *)userdata;
+        size_t bytes = size * nmemb;
+        size_t remaining;
+        size_t toCopy;
+
+        if ( !request ) {
+                return bytes;
+        }
+
+        if ( request->responseLength >= sizeof( request->response ) - 1 ) {
+                return bytes;
+        }
+
+        remaining = sizeof( request->response ) - 1 - request->responseLength;
+        toCopy = bytes;
+        if ( toCopy > remaining ) {
+                toCopy = remaining;
+        }
+
+        if ( toCopy > 0 ) {
+                Com_Memcpy( request->response + request->responseLength, buffer, toCopy );
+                request->responseLength += toCopy;
+                request->response[request->responseLength] = '\0';
+        }
+
+        return bytes;
+}
+
+static qboolean SV_LadderStartRequest( ladderRequest_t *request ) {
+        CURL *easy;
+        CURLcode code;
+        struct curl_slist *headers = NULL;
+        char authHeader[256];
+        const char *url = sv_ladderUrl ? sv_ladderUrl->string : "";
+        const char *apiKey = sv_ladderApiKey ? sv_ladderApiKey->string : "";
+
+        if ( !url || !url[0] ) {
+                return qfalse;
+        }
+
+        if ( !SV_LadderEnsureCurl() ) {
+                return qfalse;
+        }
+
+        easy = sv_curl_easy_init();
+        if ( !easy ) {
+                return qfalse;
+        }
+
+        request->easy = easy;
+        request->errorBuffer[0] = '\0';
+        request->response[0] = '\0';
+        request->responseLength = 0;
+
+        code = sv_curl_easy_setopt( easy, CURLOPT_URL, url );
+        if ( code != CURLE_OK ) {
+                return qfalse;
+        }
+
+        code = sv_curl_easy_setopt( easy, CURLOPT_POST, 1L );
+        if ( code != CURLE_OK ) {
+                return qfalse;
+        }
+
+        code = sv_curl_easy_setopt( easy, CURLOPT_POSTFIELDS, request->json );
+        if ( code != CURLE_OK ) {
+                return qfalse;
+        }
+
+        code = sv_curl_easy_setopt( easy, CURLOPT_POSTFIELDSIZE, (long)request->jsonLength );
+        if ( code != CURLE_OK ) {
+                return qfalse;
+        }
+
+        code = sv_curl_easy_setopt( easy, CURLOPT_ERRORBUFFER, request->errorBuffer );
+        if ( code != CURLE_OK ) {
+                return qfalse;
+        }
+
+        code = sv_curl_easy_setopt( easy, CURLOPT_WRITEFUNCTION, SV_LadderCurlWriteCallback );
+        if ( code != CURLE_OK ) {
+                return qfalse;
+        }
+
+        code = sv_curl_easy_setopt( easy, CURLOPT_WRITEDATA, request );
+        if ( code != CURLE_OK ) {
+                return qfalse;
+        }
+
+        code = sv_curl_easy_setopt( easy, CURLOPT_FOLLOWLOCATION, 1L );
+        if ( code != CURLE_OK ) {
+                return qfalse;
+        }
+
+        code = sv_curl_easy_setopt( easy, CURLOPT_MAXREDIRS, 5L );
+        if ( code != CURLE_OK ) {
+                return qfalse;
+        }
+
+        code = sv_curl_easy_setopt( easy, CURLOPT_CONNECTTIMEOUT, 10L );
+        if ( code != CURLE_OK ) {
+                        return qfalse;
+        }
+
+        code = sv_curl_easy_setopt( easy, CURLOPT_TIMEOUT, 30L );
+        if ( code != CURLE_OK ) {
+                return qfalse;
+        }
+
+        code = sv_curl_easy_setopt( easy, CURLOPT_NOSIGNAL, 1L );
+        if ( code != CURLE_OK ) {
+                return qfalse;
+        }
+
+        code = sv_curl_easy_setopt( easy, CURLOPT_USERAGENT, Q3_VERSION );
+        if ( code != CURLE_OK ) {
+                return qfalse;
+        }
+
+        headers = sv_curl_slist_append( headers, "Content-Type: application/json" );
+        headers = sv_curl_slist_append( headers, "Accept: application/json" );
+
+        if ( apiKey && apiKey[0] ) {
+                Com_sprintf( authHeader, sizeof( authHeader ), "Authorization: Bearer %s", apiKey );
+                headers = sv_curl_slist_append( headers, authHeader );
+        }
+
+        if ( headers ) {
+                code = sv_curl_easy_setopt( easy, CURLOPT_HTTPHEADER, headers );
+                if ( code != CURLE_OK ) {
+                        sv_curl_slist_free_all( headers );
+                        return qfalse;
+                }
+        }
+
+        request->headers = headers;
+
+        code = sv_curl_easy_setopt( easy, CURLOPT_PRIVATE, request );
+        if ( code != CURLE_OK ) {
+                return qfalse;
+        }
+
+        if ( sv_curl_multi_add_handle( sv_ladder.multi, easy ) != CURLM_OK ) {
+                return qfalse;
+        }
+
+        return qtrue;
+}
+
+static void SV_LadderHandleFailure( ladderRequest_t *request, const char *reason, long responseCode, qboolean retry ) {
+        if ( retry ) {
+                int delay = SV_LadderComputeBackoff( ++request->attempt );
+                request->nextAttemptTime = Sys_Milliseconds() + delay;
+                Com_Printf( "Ladder: upload failed for match %s (%s, HTTP %ld), retrying in %.1f s\n",
+                        request->matchId[0] ? request->matchId : "<unknown>",
+                        reason ? reason : "error", responseCode, delay / 1000.0f );
+                SV_LadderQueuePush( request );
+        } else {
+                Com_Printf( "Ladder: upload dropped for match %s (%s, HTTP %ld)\n",
+                        request->matchId[0] ? request->matchId : "<unknown>",
+                        reason ? reason : "error", responseCode );
+                SV_LadderFreeRequest( request, qfalse );
+        }
+}
+
+static void SV_LadderCompleteRequest( ladderRequest_t *request, CURLcode result, long responseCode ) {
+        const char *errorMsg = NULL;
+        qboolean retry = qfalse;
+
+        if ( result == CURLE_OK && responseCode >= 200 && responseCode < 300 ) {
+                Com_Printf( "Ladder: uploaded match %s (HTTP %ld)\n",
+                        request->matchId[0] ? request->matchId : "<unknown>", responseCode );
+                SV_LadderFreeRequest( request, qfalse );
+                return;
+        }
+
+        if ( result != CURLE_OK ) {
+                errorMsg = request->errorBuffer[0] ? request->errorBuffer : sv_curl_easy_strerror( result );
+                retry = qtrue;
+        } else if ( responseCode >= 500 || responseCode == 0 ) {
+                errorMsg = request->response[0] ? request->response : "server error";
+                retry = qtrue;
+        } else {
+                errorMsg = request->response[0] ? request->response : "client error";
+                retry = qfalse;
+        }
+
+        SV_LadderHandleFailure( request, errorMsg, responseCode, retry );
+}
+
+#endif
+
+#ifdef USE_CURL
+static void SV_LadderActivateNext( void ) {
+        int pending;
+
+        if ( sv_ladder.active ) {
+                return;
+        }
+
+        if ( !sv_ladder.multi ) {
+                if ( !SV_LadderEnsureCurl() ) {
+                        return;
+                }
+        }
+
+        pending = sv_ladder.queueSize;
+        while ( pending-- > 0 ) {
+                ladderRequest_t *request = SV_LadderQueuePop();
+                if ( !request ) {
+                        break;
+                }
+
+                if ( request->nextAttemptTime > Sys_Milliseconds() ) {
+                        SV_LadderQueuePush( request );
+                        continue;
+                }
+
+                if ( SV_LadderStartRequest( request ) ) {
+                        sv_ladder.active = request;
+                        return;
+                }
+
+                request->nextAttemptTime = Sys_Milliseconds() + SV_LadderComputeBackoff( ++request->attempt );
+                SV_LadderQueuePush( request );
+        }
+}
+
+static void SV_LadderPollActive( void ) {
+        CURLMsg *msg;
+        int messages;
+
+        if ( !sv_ladder.multi ) {
+                return;
+        }
+
+        if ( sv_ladder.active ) {
+                int running = 0;
+                CURLMcode mcode = sv_curl_multi_perform( sv_ladder.multi, &running );
+                if ( mcode != CURLM_OK && !sv_ladder.warnedNoCurl ) {
+                        Com_Printf( "Ladder: curl_multi_perform failed: %s\n", sv_curl_multi_strerror( mcode ) );
+                        sv_ladder.warnedNoCurl = qtrue;
+                }
+        }
+
+        while ( ( msg = sv_curl_multi_info_read( sv_ladder.multi, &messages ) ) != NULL ) {
+                if ( msg->msg == CURLMSG_DONE ) {
+                        ladderRequest_t *request = NULL;
+                        long responseCode = 0;
+                        CURL *easy = msg->easy_handle;
+
+                        sv_curl_easy_getinfo( easy, CURLINFO_PRIVATE, (char **)&request );
+                        sv_curl_easy_getinfo( easy, CURLINFO_RESPONSE_CODE, &responseCode );
+
+                        sv_curl_multi_remove_handle( sv_ladder.multi, easy );
+                        sv_curl_easy_cleanup( easy );
+
+                        if ( request ) {
+                                if ( sv_ladder.active == request ) {
+                                        sv_ladder.active = NULL;
+                                }
+                                request->easy = NULL;
+                                if ( request->headers ) {
+                                        sv_curl_slist_free_all( request->headers );
+                                        request->headers = NULL;
+                                }
+                                SV_LadderCompleteRequest( request, msg->data.result, responseCode );
+                        }
+                }
+        }
+}
+#endif
+
+static void SV_LadderClearQueue( qboolean keepSpool ) {
+        ladderRequest_t *request;
+
+        while ( ( request = SV_LadderQueuePop() ) != NULL ) {
+                SV_LadderFreeRequest( request, keepSpool );
+        }
+}
+
+static void SV_LadderResetState( void ) {
+        sv_ladder.queueSize = 0;
+        sv_ladder.head = NULL;
+        sv_ladder.tail = NULL;
+        sv_ladder.active = NULL;
+        sv_ladder.warnedNoCurl = qfalse;
+        sv_ladder.warnedNoUrl = qfalse;
+        sv_ladder.nextFileId = 1;
+}
+
+void SV_LadderInit( void ) {
+        if ( sv_ladder.initialized ) {
+                SV_LadderShutdown();
+        }
+
+        Com_Memset( &sv_ladder, 0, sizeof( sv_ladder ) );
+        sv_ladder.maxQueue = LADDER_SPOOL_LIMIT;
+        sv_ladder.initialized = qtrue;
+
+        if ( SV_LadderEnsureSpoolDirectory() ) {
+                SV_LadderLoadSpool();
+        }
+}
+
+void SV_LadderShutdown( void ) {
+        if ( !sv_ladder.initialized ) {
+                return;
+        }
+
+#ifdef USE_CURL
+        if ( sv_ladder.active ) {
+                SV_LadderFreeRequest( sv_ladder.active, qtrue );
+                sv_ladder.active = NULL;
+        }
+#endif
+        SV_LadderClearQueue( qtrue );
+#ifdef USE_CURL
+        SV_LadderShutdownCurl();
+#endif
+        sv_ladder.initialized = qfalse;
+        SV_LadderResetState();
+}
+
+void SV_LadderSubmit( const ladderMatchPayload_t *payload ) {
+        ladderRequest_t *request;
+        char *json;
+        size_t length = 0;
+        int total;
+
+        if ( !sv_ladder.initialized ) {
+                SV_LadderInit();
+        }
+
+        if ( !sv_ladder.initialized ) {
+                return;
+        }
+
+        if ( !sv_ladderEnabled || !sv_ladderEnabled->integer ) {
+                return;
+        }
+
+        if ( !payload || !payload->valid ) {
+                return;
+        }
+
+        if ( sv_ladderUrl && sv_ladderUrl->string[0] ) {
+                sv_ladder.warnedNoUrl = qfalse;
+        } else {
+                if ( !sv_ladder.warnedNoUrl ) {
+                        Com_Printf( "Ladder: sv_ladderUrl is not set, dropping payload\n" );
+                        sv_ladder.warnedNoUrl = qtrue;
+                }
+                return;
+        }
+
+        total = sv_ladder.queueSize + ( sv_ladder.active ? 1 : 0 );
+        if ( total >= sv_ladder.maxQueue ) {
+                Com_Printf( "Ladder: queue full, dropping match %s\n",
+                        payload->matchId[0] ? payload->matchId : "<unknown>" );
+                return;
+        }
+
+        json = SV_LadderSerializeMatch( payload, &length );
+        if ( !json || !length ) {
+                        Com_Printf( "Ladder: failed to serialize match payload\n" );
+                if ( json ) {
+                        Z_Free( json );
+                }
+                return;
+        }
+
+        request = SV_LadderAllocRequest();
+        if ( !request ) {
+                Z_Free( json );
+                return;
+        }
+
+        Com_Memcpy( &request->payload, payload, sizeof( *payload ) );
+        request->json = json;
+        request->jsonLength = length;
+        Q_strncpyz( request->matchId, payload->matchId, sizeof( request->matchId ) );
+        request->nextAttemptTime = 0;
+        request->attempt = 0;
+
+        if ( sv_ladder.spoolReady ) {
+                if ( !SV_LadderWriteSpool( request ) ) {
+                        request->spoolName[0] = '\0';
+                        request->spoolPath[0] = '\0';
+                }
+        }
+
+#ifndef USE_CURL
+        if ( !sv_ladder.warnedNoCurl ) {
+                Com_Printf( "Ladder: built without libcurl support, dropping match %s\n",
+                        payload->matchId[0] ? payload->matchId : "<unknown>" );
+                sv_ladder.warnedNoCurl = qtrue;
+        }
+        SV_LadderFreeRequest( request, qfalse );
+        return;
+#else
+        SV_LadderQueuePush( request );
+        SV_LadderActivateNext();
+#endif
+}
+
+void SV_LadderFrame( void ) {
+        if ( !sv_ladder.initialized ) {
+                return;
+        }
+
+        if ( !sv_ladderEnabled || !sv_ladderEnabled->integer ) {
+                return;
+        }
+
+#ifdef USE_CURL
+        SV_LadderActivateNext();
+        SV_LadderPollActive();
+        if ( !sv_ladder.active ) {
+                SV_LadderActivateNext();
+        }
+#endif
+}

--- a/engine/code/server/sv_main.c
+++ b/engine/code/server/sv_main.c
@@ -1159,11 +1159,13 @@ void SV_Frame( int msec ) {
 	// check timeouts
 	SV_CheckTimeouts();
 
-	// send messages back to the clients
-	SV_SendClientMessages();
+        // send messages back to the clients
+        SV_SendClientMessages();
 
-	// send a heartbeat to the master if needed
-	SV_MasterHeartbeat(HEARTBEAT_FOR_MASTER);
+        SV_LadderFrame();
+
+        // send a heartbeat to the master if needed
+        SV_MasterHeartbeat(HEARTBEAT_FOR_MASTER);
 }
 
 /*


### PR DESCRIPTION
## Summary
- implement the dedicated server ladder uploader with JSON serialization, disk spooling, retry/backoff and libcurl transport
- register ladder cvars and wire the uploader into the VM syscall path, init/shutdown, and per-frame processing
- guard bg_public.h for reuse and update build scripts so the new module and curl linkage are compiled

## Testing
- `make -C engine` *(fails: missing SDL_version.h on this builder)*

------
https://chatgpt.com/codex/tasks/task_e_68d1b17c54008324812e83ec6c4e6015