### PR TITLE
Mirror curl include handling in sv_ladder

### DIFF
--- a/engine/code/server/sv_ladder.c
+++ b/engine/code/server/sv_ladder.c
@@ -43,7 +43,11 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #define LADDER_MATCH_ID_FALLBACK        "pending"
 
 #ifdef USE_CURL
+#ifdef USE_LOCAL_HEADERS
+#include "../curl-7.54.0/include/curl/curl.h"
+#else
 #include <curl/curl.h>
+#endif
 #ifdef USE_CURL_DLOPEN
 #include "../sys/sys_loadlib.h"
 #endif


### PR DESCRIPTION
## Summary
- add USE_LOCAL_HEADERS handling to sv_ladder's curl include so bundled headers are used when requested

## Testing
- make -C engine PLATFORM=mingw32 *(fails: Cannot find a suitable cross compiler for mingw32)*

------
https://chatgpt.com/codex/tasks/task_e_68d223ab6dd083249275a5b0d6ad925a