### PR TITLE
Include qcommon header for g_main

### DIFF
--- a/engine/code/game/g_main.c
+++ b/engine/code/game/g_main.c
@@ -23,6 +23,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 //
 
 #include "g_local.h"
+#include "../qcommon/qcommon.h"
 
 level_locals_t	level;
 


### PR DESCRIPTION
## Summary
- include the shared qcommon header in g_main so Com_BlockChecksum is declared when building the game module

## Testing
- make -C engine PLATFORM=mingw32 *(fails: Cannot find a suitable cross compiler for mingw32)*

------
https://chatgpt.com/codex/tasks/task_e_68d22703dd888324875e4abdc2fa3198