### PR TITLE
Guard VM float helper for Q3 VM builds

### DIFF
--- a/engine/code/qcommon/qcommon.h
+++ b/engine/code/qcommon/qcommon.h
@@ -376,12 +376,16 @@ void	*VM_ArgPtr( intptr_t intValue );
 void	*VM_ExplicitArgPtr( vm_t *vm, intptr_t intValue );
 
 #define	VMA(x) VM_ArgPtr(args[x])
+#ifndef Q3_VM
 static ID_INLINE float _vmf(intptr_t x)
 {
 	floatint_t fi;
 	fi.i = (int) x;
 	return fi.f;
 }
+#else
+#define	_vmf(x)	(*(const float *)&(x))
+#endif
 #define	VMF(x)	_vmf(args[x])
 
 


### PR DESCRIPTION
## Summary
- wrap the native `_vmf` inline helper with `#ifndef Q3_VM`
- add a macro-based `_vmf` variant for Q3 VM builds to avoid duplicate symbols
- ensure `VMF(x)` resolves to the correct helper in both build configurations

## Testing
- make -C engine release BUILD_CLIENT=0

------
https://chatgpt.com/codex/tasks/task_e_68d30c253cb08324856175d6bc9d6be7