### PR TITLE
Add ladder data storage and server command handling

### DIFF
--- a/engine/code/cgame/cg_ladder.c
+++ b/engine/code/cgame/cg_ladder.c
@@ -1,0 +1,171 @@
+#include "cg_local.h"
+
+cg_ladder_t cg_ladder;
+
+static void CG_LadderDropOldest(void) {
+	if (cg_ladder.numEntries <= 0) {
+		return;
+	}
+
+	if (cg_ladder.numEntries < MAX_LADDER_ENTRIES) {
+		return;
+	}
+
+	memmove(&cg_ladder.entries[0],
+			&cg_ladder.entries[1],
+			(MAX_LADDER_ENTRIES - 1) * sizeof(cg_ladder_entry_t));
+	cg_ladder.numEntries = MAX_LADDER_ENTRIES - 1;
+}
+
+static void CG_LadderUpdateTimestamp(void) {
+	cg_ladder.lastUpdateTime = cg.time;
+}
+
+void CG_LadderClear(void) {
+	Com_Memset(&cg_ladder, 0, sizeof(cg_ladder));
+	cg_ladder.status = LADDER_STATUS_EMPTY;
+}
+
+void CG_LadderInit(void) {
+	CG_LadderClear();
+}
+
+void CG_LadderBeginLoad(void) {
+	CG_LadderClear();
+	cg_ladder.status = LADDER_STATUS_LOADING;
+	cg_ladder.dirty = qtrue;
+	CG_LadderUpdateTimestamp();
+}
+
+void CG_LadderMarkReady(void) {
+	if (cg_ladder.status == LADDER_STATUS_ERROR) {
+		return;
+	}
+
+	if (cg_ladder.numEntries > 0) {
+		cg_ladder.status = LADDER_STATUS_READY;
+	} else {
+		cg_ladder.status = LADDER_STATUS_EMPTY;
+	}
+
+	CG_LadderUpdateTimestamp();
+}
+
+void CG_LadderSetError(const char *message) {
+	if (!message) {
+		message = "";
+	}
+
+	cg_ladder.status = LADDER_STATUS_ERROR;
+	Q_strncpyz(cg_ladder.errorMessage, message, sizeof(cg_ladder.errorMessage));
+	cg_ladder.dirty = qtrue;
+	CG_LadderUpdateTimestamp();
+}
+
+static void CG_LadderPushEntryInternal(cg_ladder_source_t source,
+									   int sequence,
+									   const char *identifier,
+									   const char *payload,
+									   int serverTime) {
+	cg_ladder_entry_t *entry;
+
+	if (cg_ladder.status == LADDER_STATUS_ERROR) {
+		return;
+	}
+
+	if (!identifier) {
+		identifier = "";
+	}
+
+	if (!payload) {
+		payload = "";
+	}
+
+	if (cg_ladder.numEntries >= MAX_LADDER_ENTRIES) {
+		CG_LadderDropOldest();
+	}
+
+	entry = &cg_ladder.entries[cg_ladder.numEntries++];
+	entry->source = source;
+	entry->sequence = sequence;
+	entry->serverTime = serverTime;
+	Q_strncpyz(entry->identifier, identifier, sizeof(entry->identifier));
+	Q_strncpyz(entry->payload, payload, sizeof(entry->payload));
+
+	if (cg_ladder.status == LADDER_STATUS_EMPTY) {
+		cg_ladder.status = LADDER_STATUS_READY;
+	}
+
+	cg_ladder.dirty = qtrue;
+	CG_LadderUpdateTimestamp();
+}
+
+void CG_LadderPushEntry(cg_ladder_source_t source,
+						int sequence,
+						const char *identifier,
+						const char *payload,
+						int serverTime) {
+	CG_LadderPushEntryInternal(source, sequence, identifier, payload, serverTime);
+}
+
+void CG_LadderHandleServerCommand(int sequence,
+								  const char *identifier,
+								  const char *payload,
+								  int serverTime) {
+	CG_LadderPushEntryInternal(LADDER_SOURCE_SERVER,
+							   sequence,
+							   identifier,
+							   payload,
+							   serverTime);
+}
+
+void CG_LadderHandleWebResponse(const char *identifier, const char *payload) {
+	const char *cursor;
+	char line[MAX_STRING_CHARS];
+	int lineSequence = 0;
+
+	if (!payload) {
+		payload = "";
+	}
+
+	CG_LadderBeginLoad();
+
+	cursor = payload;
+	while (*cursor) {
+		int len = 0;
+
+		while (*cursor && *cursor != '\n' && len < MAX_STRING_CHARS - 1) {
+			line[len++] = *cursor++;
+		}
+		line[len] = '\0';
+
+		if (*cursor == '\n') {
+			cursor++;
+		}
+
+		if (len > 0 || lineSequence == 0) {
+			CG_LadderPushEntryInternal(LADDER_SOURCE_WEBSERVICE,
+									   lineSequence,
+									   identifier,
+									   line,
+									   cg.time);
+			lineSequence++;
+		}
+	}
+
+	if (cg_ladder.status != LADDER_STATUS_ERROR) {
+		CG_LadderMarkReady();
+	}
+}
+
+const cg_ladder_t *CG_LadderState(void) {
+	return &cg_ladder;
+}
+
+qboolean CG_LadderIsLoading(void) {
+	return (cg_ladder.status == LADDER_STATUS_LOADING);
+}
+
+qboolean CG_LadderHasError(void) {
+	return (cg_ladder.status == LADDER_STATUS_ERROR);
+}

--- a/engine/code/cgame/cg_local.h
+++ b/engine/code/cgame/cg_local.h
@@ -1332,12 +1332,48 @@ typedef struct {
 
 //==============================================================================
 
+#define MAX_LADDER_ENTRIES			 64
+#define MAX_LADDER_IDENTIFIER		 64
+
+typedef enum {
+	LADDER_STATUS_EMPTY = 0,
+	LADDER_STATUS_LOADING,
+	LADDER_STATUS_READY,
+	LADDER_STATUS_ERROR
+} cg_ladder_status_t;
+
+typedef enum {
+	LADDER_SOURCE_SERVER = 0,
+	LADDER_SOURCE_WEBSERVICE
+} cg_ladder_source_t;
+
+typedef struct {
+	cg_ladder_source_t		source;
+	int					sequence;
+	int					serverTime;
+	char			identifier[MAX_LADDER_IDENTIFIER];
+	char			payload[MAX_STRING_CHARS];
+} cg_ladder_entry_t;
+
+typedef struct {
+	cg_ladder_status_t		status;
+	qboolean			dirty;
+	int					lastUpdateTime;
+	char			errorMessage[MAX_STRING_CHARS];
+	int				numEntries;
+	cg_ladder_entry_t	entries[MAX_LADDER_ENTRIES];
+} cg_ladder_t;
+
+//==============================================================================
+
 extern	cgs_t			cgs;
 extern	cg_t			cg;
 extern	centity_t		cg_entities[MAX_GENTITIES];
 extern	weaponInfo_t	cg_weapons[MAX_WEAPONS];
 extern	itemInfo_t		cg_items[MAX_ITEMS];
 extern	markPoly_t		cg_markPolys[MAX_MARK_POLYS];
+
+extern	cg_ladder_t		cg_ladder;
 
 extern	vmCvar_t		cg_centertime;
 extern	vmCvar_t		cg_runpitch;
@@ -1855,6 +1891,21 @@ qboolean CG_DrawOldScoreboard( void );
 // Q3Rally Code Start - removed
 // void CG_DrawTourneyScoreboard( void );
 // Q3Rally Code END
+
+//
+// cg_ladder.c
+//
+void CG_LadderInit( void );
+void CG_LadderClear( void );
+void CG_LadderBeginLoad( void );
+void CG_LadderMarkReady( void );
+void CG_LadderSetError( const char *message );
+void CG_LadderPushEntry( cg_ladder_source_t source, int sequence, const char *identifier, const char *payload, int serverTime );
+void CG_LadderHandleServerCommand( int sequence, const char *identifier, const char *payload, int serverTime );
+void CG_LadderHandleWebResponse( const char *identifier, const char *payload );
+const cg_ladder_t *CG_LadderState( void );
+qboolean CG_LadderIsLoading( void );
+qboolean CG_LadderHasError( void );
 
 //
 // cg_consolecmds.c

--- a/engine/code/cgame/cg_main.c
+++ b/engine/code/cgame/cg_main.c
@@ -2227,6 +2227,8 @@ void CG_Init( int serverMessageNum, int serverCommandSequence, int clientNum ) {
 
 	CG_InitConsoleCommands();
 
+	CG_LadderInit();
+
 	cg.weaponSelect = WP_MACHINEGUN;
 
 	cgs.redflag = cgs.blueflag = -1; // For compatibily, default to unset for

--- a/engine/code/cgame/cg_servercmds.c
+++ b/engine/code/cgame/cg_servercmds.c
@@ -1338,6 +1338,77 @@ static void CG_ServerCommand( void ) {
 		return;
 	}
 
+	if ( !strcmp( cmd, "ladder_begin" ) ) {
+		CG_LadderBeginLoad();
+		return;
+	}
+
+	if ( !strcmp( cmd, "ladder_entry" ) ) {
+		int argc = trap_Argc();
+
+		if ( argc >= 2 ) {
+			int sequence = atoi( CG_Argv( 1 ) );
+			const char *identifier = "";
+			int payloadStart = 2;
+			char payload[MAX_STRING_CHARS];
+
+			if ( argc >= 3 ) {
+				identifier = CG_Argv( 2 );
+				payloadStart = 3;
+			}
+
+			payload[0] = '\0';
+			if ( payloadStart < argc ) {
+				int i;
+
+				for ( i = payloadStart ; i < argc ; i++ ) {
+					const char *arg = CG_Argv( i );
+
+					if ( payload[0] ) {
+						Q_strcat( payload, sizeof( payload ), " " );
+					}
+
+					Q_strcat( payload, sizeof( payload ), arg );
+				}
+			}
+
+			CG_LadderHandleServerCommand( sequence,
+					identifier,
+					payload,
+					( cg.snap ) ? cg.snap->serverTime : 0 );
+		}
+
+		return;
+	}
+
+	if ( !strcmp( cmd, "ladder_complete" ) ) {
+		CG_LadderMarkReady();
+		return;
+	}
+
+	if ( !strcmp( cmd, "ladder_error" ) ) {
+		char message[MAX_STRING_CHARS];
+		int argc = trap_Argc();
+
+		message[0] = '\0';
+		if ( argc >= 2 ) {
+			int i;
+
+			for ( i = 1 ; i < argc ; i++ ) {
+				const char *arg = CG_Argv( i );
+
+				if ( message[0] ) {
+					Q_strcat( message, sizeof( message ), " " );
+				}
+
+				Q_strcat( message, sizeof( message ), arg );
+			}
+		}
+
+		CG_LadderSetError( message );
+		return;
+	}
+
 	if ( !strcmp( cmd, "map_restart" ) ) {
 		CG_MapRestart();
 		return;

--- a/engine/misc/msvc10/cgame.vcxproj
+++ b/engine/misc/msvc10/cgame.vcxproj
@@ -779,6 +779,28 @@
       <PreprocessorDefinitions Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">WIN32;NDEBUG;_WINDOWS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <PreprocessorDefinitions Condition="'$(Configuration)|$(Platform)'=='Release|x64'">WIN32;NDEBUG;_WINDOWS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
+    <ClCompile Include="..\..\code\cgame\cg_ladder.c">
+      <Optimization Condition="'$(Configuration)|$(Platform)'=='Debug TA|Win32'">Disabled</Optimization>
+      <Optimization Condition="'$(Configuration)|$(Platform)'=='Debug TA|x64'">Disabled</Optimization>
+      <PreprocessorDefinitions Condition="'$(Configuration)|$(Platform)'=='Debug TA|Win32'">WIN32;_DEBUG;_WINDOWS;MISSIONPACK;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions Condition="'$(Configuration)|$(Platform)'=='Debug TA|x64'">WIN32;_DEBUG;_WINDOWS;MISSIONPACK;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <BrowseInformation Condition="'$(Configuration)|$(Platform)'=='Debug TA|Win32'">true</BrowseInformation>
+      <BrowseInformation Condition="'$(Configuration)|$(Platform)'=='Debug TA|x64'">true</BrowseInformation>
+      <Optimization Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">Disabled</Optimization>
+      <Optimization Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">Disabled</Optimization>
+      <PreprocessorDefinitions Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">WIN32;_DEBUG;_WINDOWS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">WIN32;_DEBUG;_WINDOWS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <BrowseInformation Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</BrowseInformation>
+      <BrowseInformation Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</BrowseInformation>
+      <Optimization Condition="'$(Configuration)|$(Platform)'=='Release TA|Win32'">MaxSpeed</Optimization>
+      <Optimization Condition="'$(Configuration)|$(Platform)'=='Release TA|x64'">MaxSpeed</Optimization>
+      <PreprocessorDefinitions Condition="'$(Configuration)|$(Platform)'=='Release TA|Win32'">WIN32;NDEBUG;_WINDOWS;MISSIONPACK;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions Condition="'$(Configuration)|$(Platform)'=='Release TA|x64'">WIN32;NDEBUG;_WINDOWS;MISSIONPACK;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <Optimization Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">MaxSpeed</Optimization>
+      <Optimization Condition="'$(Configuration)|$(Platform)'=='Release|x64'">MaxSpeed</Optimization>
+      <PreprocessorDefinitions Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">WIN32;NDEBUG;_WINDOWS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions Condition="'$(Configuration)|$(Platform)'=='Release|x64'">WIN32;NDEBUG;_WINDOWS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
     <ClCompile Include="..\..\code\cgame\cg_localents.c">
       <Optimization Condition="'$(Configuration)|$(Platform)'=='Debug TA|Win32'">Disabled</Optimization>
       <Optimization Condition="'$(Configuration)|$(Platform)'=='Debug TA|x64'">Disabled</Optimization>

--- a/engine/misc/msvc10/cgame.vcxproj.filters
+++ b/engine/misc/msvc10/cgame.vcxproj.filters
@@ -47,6 +47,9 @@
     <ClCompile Include="..\..\code\cgame\cg_info.c">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\code\cgame\cg_ladder.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\code\cgame\cg_localents.c">
       <Filter>Source Files</Filter>
     </ClCompile>

--- a/engine/misc/msvc142/cgame.vcxproj
+++ b/engine/misc/msvc142/cgame.vcxproj
@@ -355,6 +355,18 @@
       <Optimization Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">MaxSpeed</Optimization>
       <PreprocessorDefinitions Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">WIN32;NDEBUG;_WINDOWS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
+    <ClCompile Include="..\..\code\cgame\cg_ladder.c">
+      <Optimization Condition="'$(Configuration)|$(Platform)'=='Debug TA|Win32'">Disabled</Optimization>
+      <PreprocessorDefinitions Condition="'$(Configuration)|$(Platform)'=='Debug TA|Win32'">WIN32;_DEBUG;_WINDOWS;MISSIONPACK;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <BrowseInformation Condition="'$(Configuration)|$(Platform)'=='Debug TA|Win32'">true</BrowseInformation>
+      <Optimization Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">Disabled</Optimization>
+      <PreprocessorDefinitions Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">WIN32;_DEBUG;_WINDOWS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <BrowseInformation Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</BrowseInformation>
+      <Optimization Condition="'$(Configuration)|$(Platform)'=='Release TA|Win32'">MaxSpeed</Optimization>
+      <PreprocessorDefinitions Condition="'$(Configuration)|$(Platform)'=='Release TA|Win32'">WIN32;NDEBUG;_WINDOWS;MISSIONPACK;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <Optimization Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">MaxSpeed</Optimization>
+      <PreprocessorDefinitions Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">WIN32;NDEBUG;_WINDOWS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
     <ClCompile Include="..\..\code\cgame\cg_localents.c">
       <Optimization Condition="'$(Configuration)|$(Platform)'=='Debug TA|Win32'">Disabled</Optimization>
       <PreprocessorDefinitions Condition="'$(Configuration)|$(Platform)'=='Debug TA|Win32'">WIN32;_DEBUG;_WINDOWS;MISSIONPACK;%(PreprocessorDefinitions)</PreprocessorDefinitions>


### PR DESCRIPTION
## Summary
- add a dedicated cg_ladder module to track ladder entries, loading state, and errors
- expose ladder data structures through cg_local.h and initialize them during CG_Init
- accept ladder-related server commands and include the new module in the MSVC project files

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d4310845e08324bcc102e09e6dfbb5