### PR TITLE
Add ladder tabs to scoreboard

### DIFF
--- a/engine/code/cgame/cg_scoreboard.c
+++ b/engine/code/cgame/cg_scoreboard.c
@@ -23,6 +23,8 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 
 /* cg_scoreboard.c -- Adaptive scoreboard design for Q3Rally */
 #include "cg_local.h"
+#include <ctype.h>
+#include <stdlib.h>
 
 /* Modern scoreboard layout constants */
 #define MODERN_SB_Y             120
@@ -31,6 +33,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #define MODERN_SB_HEADER_HEIGHT 40
 #define MODERN_SB_ROW_HEIGHT    36
 #define MODERN_SB_COMPACT_HEIGHT 20
+#define MODERN_SB_TAB_HEIGHT    28
 
 /* Column definitions - flexible layout */
 #define COL_RANK_WIDTH          64
@@ -52,6 +55,11 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 /* Maximum clients display */
 #define MAX_SCOREBOARD_CLIENTS  12
 #define MAX_COMPACT_CLIENTS     16
+
+/* Ladder tab / layout limits */
+#define MAX_LADDER_TABS         6
+#define MAX_LADDER_COLUMNS      8
+#define MAX_LADDER_DISPLAY_ROWS 16
 
 /* Scoreboard column types */
 typedef enum {
@@ -82,6 +90,47 @@ static int currentScoreboardWidth = 0;
 static int scoreboardX = 0; /* Dynamic X position for centering */
 static int contentStartX = 0; /* Starting X position for centered content */
 static qboolean localClientDrawn;
+
+/* Tab selection state */
+static int scoreboardActiveTab = 0;
+static qboolean scoreboardLeftHeld = qfalse;
+static qboolean scoreboardRightHeld = qfalse;
+
+/* Ladder column handling */
+typedef enum {
+    LADDER_COL_POSITION = 0,
+    LADDER_COL_NAME,
+    LADDER_COL_TEAM,
+    LADDER_COL_BEST_LAP,
+    LADDER_COL_TOTAL_TIME,
+    LADDER_COL_LAPS,
+    LADDER_COL_SCORE,
+    LADDER_COL_FRAGS,
+    LADDER_COL_DEATHS,
+    LADDER_COL_KD,
+    LADDER_COL_DAMAGE_DEALT,
+    LADDER_COL_DAMAGE_TAKEN,
+    LADDER_COL_CAPTURES,
+    LADDER_COL_ASSISTS,
+    LADDER_COL_ZONE_HOLD,
+    LADDER_COL_SURVIVAL,
+    LADDER_COL_ELIM_ROUND,
+    LADDER_COL_ELIM_REMAIN,
+    LADDER_COL_SOURCE,
+    LADDER_COL__COUNT
+} ladderColumnType_t;
+
+typedef struct {
+    ladderColumnType_t type;
+    const char *header;
+    int width;
+    int align;
+} ladderColumnDef_t;
+
+typedef struct {
+    char identifier[MAX_LADDER_IDENTIFIER];
+    char label[32];
+} ladderTabInfo_t;
 
 /*
 =================
@@ -465,6 +514,893 @@ static void CG_GetModernTeamColor(team_t team, vec4_t color) {
 }
 
 
+static void CG_FormatLadderTabLabel(const char *identifier, char *out, int outSize) {
+    char working[MAX_LADDER_IDENTIFIER];
+    int i, j;
+    qboolean capitalize;
+
+    if (!out || outSize <= 0) {
+        return;
+    }
+
+    if (!identifier || !identifier[0]) {
+        Q_strncpyz(out, "LADDER", outSize);
+        return;
+    }
+
+    Q_strncpyz(working, identifier, sizeof(working));
+
+    for (i = 0; working[i]; i++) {
+        unsigned char ch = (unsigned char)working[i];
+        if (ch == '_' || ch == '.' || ch == '-') {
+            working[i] = ' ';
+        } else {
+            working[i] = (char)tolower(ch);
+        }
+    }
+
+    capitalize = qtrue;
+    j = 0;
+    for (i = 0; working[i] && j < outSize - 1; i++) {
+        char ch = working[i];
+
+        if (ch == ' ') {
+            if (!capitalize && j < outSize - 1) {
+                out[j++] = ' ';
+                capitalize = qtrue;
+            }
+            continue;
+        }
+
+        if (capitalize && ch >= 'a' && ch <= 'z') {
+            ch = (char)(ch - 'a' + 'A');
+        }
+        out[j++] = ch;
+        capitalize = qfalse;
+    }
+
+    out[j] = '\0';
+
+    if (!out[0]) {
+        Q_strncpyz(out, "LADDER", outSize);
+    }
+}
+
+static int CG_BuildLadderTabs(const cg_ladder_t *ladder, ladderTabInfo_t *tabs, int maxTabs) {
+    int count;
+    int i, j;
+    qboolean hasDefault;
+
+    if (!ladder || !tabs || maxTabs <= 0) {
+        return 0;
+    }
+
+    count = 0;
+    hasDefault = qfalse;
+
+    if (ladder->numEntries <= 0) {
+        tabs[0].identifier[0] = '\0';
+        CG_FormatLadderTabLabel("", tabs[0].label, sizeof(tabs[0].label));
+        return 1;
+    }
+
+    for (i = 0; i < ladder->numEntries && count < maxTabs; i++) {
+        const cg_ladder_entry_t *entry = &ladder->entries[i];
+        const char *identifier = entry->identifier;
+        qboolean exists;
+
+        if (!identifier || !identifier[0]) {
+            if (!hasDefault && count < maxTabs) {
+                tabs[count].identifier[0] = '\0';
+                CG_FormatLadderTabLabel("", tabs[count].label, sizeof(tabs[count].label));
+                count++;
+                hasDefault = qtrue;
+            }
+            continue;
+        }
+
+        exists = qfalse;
+        for (j = 0; j < count; j++) {
+            if (!Q_stricmp(identifier, tabs[j].identifier)) {
+                exists = qtrue;
+                break;
+            }
+        }
+
+        if (exists) {
+            continue;
+        }
+
+        Q_strncpyz(tabs[count].identifier, identifier, sizeof(tabs[count].identifier));
+        CG_FormatLadderTabLabel(identifier, tabs[count].label, sizeof(tabs[count].label));
+        count++;
+    }
+
+    if (count == 0) {
+        tabs[0].identifier[0] = '\0';
+        CG_FormatLadderTabLabel("", tabs[0].label, sizeof(tabs[0].label));
+        count = 1;
+    }
+
+    return count;
+}
+
+static void CG_HandleScoreboardTabInput(int tabCount) {
+    qboolean leftDown;
+    qboolean rightDown;
+
+    if (tabCount <= 1) {
+        scoreboardActiveTab = 0;
+        scoreboardLeftHeld = qfalse;
+        scoreboardRightHeld = qfalse;
+        return;
+    }
+
+    leftDown = trap_Key_IsDown(K_LEFTARROW) || trap_Key_IsDown(K_KP_LEFTARROW);
+    rightDown = trap_Key_IsDown(K_RIGHTARROW) || trap_Key_IsDown(K_KP_RIGHTARROW);
+
+    if (leftDown && !scoreboardLeftHeld) {
+        scoreboardActiveTab--;
+        if (scoreboardActiveTab < 0) {
+            scoreboardActiveTab = tabCount - 1;
+        }
+    }
+
+    if (rightDown && !scoreboardRightHeld) {
+        scoreboardActiveTab++;
+        if (scoreboardActiveTab >= tabCount) {
+            scoreboardActiveTab = 0;
+        }
+    }
+
+    scoreboardLeftHeld = leftDown;
+    scoreboardRightHeld = rightDown;
+}
+
+static int CG_DrawScoreboardTabs(int y, int totalTabs, const ladderTabInfo_t *ladderTabs,
+                                 int ladderTabCount, float fade) {
+    int tabWidth;
+    int i;
+    int tabX;
+    vec4_t barColor;
+    vec4_t inactiveColor;
+    vec4_t activeColor;
+    vec4_t textColor;
+    const char *label;
+
+    if (totalTabs <= 1) {
+        return y;
+    }
+
+    barColor[0] = 0.05f; barColor[1] = 0.06f; barColor[2] = 0.08f; barColor[3] = MODERN_SB_ALPHA * fade;
+    inactiveColor[0] = 0.10f; inactiveColor[1] = 0.12f; inactiveColor[2] = 0.16f; inactiveColor[3] = MODERN_SB_ALPHA * fade * 0.9f;
+    activeColor[0] = 0.18f; activeColor[1] = 0.22f; activeColor[2] = 0.28f; activeColor[3] = MODERN_SB_ALPHA * fade;
+    textColor[0] = 0.85f; textColor[1] = 0.85f; textColor[2] = 0.85f; textColor[3] = fade;
+
+    CG_FillRect(scoreboardX, y, currentScoreboardWidth, MODERN_SB_TAB_HEIGHT, barColor);
+
+    if (totalTabs <= 0) {
+        totalTabs = 1;
+    }
+
+    tabWidth = currentScoreboardWidth / totalTabs;
+    if (tabWidth <= 0) {
+        tabWidth = currentScoreboardWidth;
+    }
+
+    for (i = 0; i < totalTabs; i++) {
+        tabX = scoreboardX + i * tabWidth;
+
+        if (i == scoreboardActiveTab) {
+            CG_FillRect(tabX, y, tabWidth, MODERN_SB_TAB_HEIGHT, activeColor);
+        } else {
+            CG_FillRect(tabX, y, tabWidth, MODERN_SB_TAB_HEIGHT, inactiveColor);
+        }
+
+        if (i == 0) {
+            label = "MATCH";
+        } else if (i - 1 < ladderTabCount) {
+            label = ladderTabs[i - 1].label;
+        } else {
+            label = "LADDER";
+        }
+
+        CG_DrawModernText(tabX,
+                          y + (MODERN_SB_TAB_HEIGHT - SMALLCHAR_HEIGHT) / 2,
+                          label,
+                          1,
+                          tabWidth,
+                          textColor,
+                          (i == scoreboardActiveTab) ? qtrue : qfalse);
+    }
+
+    return y + MODERN_SB_TAB_HEIGHT + 12;
+}
+
+static qboolean CG_LadderCopyValue(const char *payload, const char *const *keys,
+                                   int keyCount, char *out, int outSize) {
+    int i;
+    const char *value;
+
+    if (!payload || !out || outSize <= 0) {
+        return qfalse;
+    }
+
+    for (i = 0; i < keyCount; i++) {
+        value = Info_ValueForKey(payload, keys[i]);
+        if (value && value[0]) {
+            Q_strncpyz(out, value, outSize);
+            return qtrue;
+        }
+    }
+
+    return qfalse;
+}
+
+static qboolean CG_LadderParseInt(const char *payload, const char *const *keys,
+                                  int keyCount, int *out) {
+    char buffer[MAX_STRING_CHARS];
+    char *endPtr;
+    long value;
+
+    if (!out) {
+        return qfalse;
+    }
+
+    if (!CG_LadderCopyValue(payload, keys, keyCount, buffer, sizeof(buffer))) {
+        return qfalse;
+    }
+
+    value = strtol(buffer, &endPtr, 10);
+    if (endPtr == buffer) {
+        return qfalse;
+    }
+
+    *out = (int)value;
+    return qtrue;
+}
+
+static qboolean CG_LadderParseFloat(const char *payload, const char *const *keys,
+                                    int keyCount, float *out) {
+    char buffer[MAX_STRING_CHARS];
+    char *endPtr;
+    double value;
+
+    if (!out) {
+        return qfalse;
+    }
+
+    if (!CG_LadderCopyValue(payload, keys, keyCount, buffer, sizeof(buffer))) {
+        return qfalse;
+    }
+
+    value = strtod(buffer, &endPtr);
+    if (endPtr == buffer) {
+        return qfalse;
+    }
+
+    *out = (float)value;
+    return qtrue;
+}
+
+static qboolean CG_LadderFormatTimeValue(const char *payload, const char *const *keys,
+                                         int keyCount, char *out, int outSize) {
+    int timeValue;
+
+    if (CG_LadderParseInt(payload, keys, keyCount, &timeValue) && timeValue > 0) {
+        const char *formatted = getStringForTime(timeValue);
+        if (formatted) {
+            Q_strncpyz(out, formatted, outSize);
+            return qtrue;
+        }
+    }
+
+    return CG_LadderCopyValue(payload, keys, keyCount, out, outSize);
+}
+
+static qboolean CG_LadderExtractName(const cg_ladder_entry_t *entry, char *out, int outSize) {
+    static const char *nameKeys[] = { "name", "player", "displayName" };
+
+    if (!entry || !out || outSize <= 0) {
+        return qfalse;
+    }
+
+    if (CG_LadderCopyValue(entry->payload, nameKeys, sizeof(nameKeys) / sizeof(nameKeys[0]), out, outSize)) {
+        return qtrue;
+    }
+
+    if (entry->identifier[0]) {
+        Q_strncpyz(out, entry->identifier, outSize);
+        return qtrue;
+    }
+
+    return qfalse;
+}
+
+static void CG_LadderFormatColumnValue(const cg_ladder_entry_t *entry, ladderColumnType_t type,
+                                       char *out, int outSize) {
+    static const char *posKeys[] = { "position", "rank", "place" };
+    static const char *bestLapKeys[] = { "bestLapMs", "bestLap", "bestLapTime" };
+    static const char *totalTimeKeys[] = { "totalRaceMs", "totalTime", "raceTime", "durationMs" };
+    static const char *lapKeys[] = { "lapCount", "laps" };
+    static const char *scoreKeys[] = { "score", "points", "rawScore" };
+    static const char *fragKeys[] = { "kills", "frags", "score" };
+    static const char *deathKeys[] = { "deaths" };
+    static const char *kdKeys[] = { "kdRatio", "kdr" };
+    static const char *damageKeys[] = { "damageDealt", "damage" };
+    static const char *damageTakenKeys[] = { "damageTaken" };
+    static const char *captureKeys[] = { "captures", "caps" };
+    static const char *assistKeys[] = { "assistCount", "assists" };
+    static const char *zoneKeys[] = { "zoneHoldMs", "zoneTime" };
+    static const char *survivalKeys[] = { "survivalMs", "survival" };
+    static const char *elimRoundKeys[] = { "eliminationRound", "round" };
+    static const char *elimRemainKeys[] = { "eliminationPlayersRemaining", "remaining", "playersLeft" };
+    char buffer[MAX_STRING_CHARS];
+    int value;
+    float fvalue;
+
+    if (!out || outSize <= 0) {
+        return;
+    }
+
+    out[0] = '\0';
+
+    switch (type) {
+        case LADDER_COL_POSITION:
+            if (CG_LadderParseInt(entry->payload, posKeys, sizeof(posKeys) / sizeof(posKeys[0]), &value) && value > 0) {
+                Com_sprintf(out, outSize, "%d", value);
+            } else {
+                Com_sprintf(out, outSize, "%d", entry->sequence + 1);
+            }
+            break;
+
+        case LADDER_COL_NAME:
+            if (!CG_LadderExtractName(entry, out, outSize)) {
+                Q_strncpyz(out, "--", outSize);
+            }
+            break;
+
+        case LADDER_COL_TEAM: {
+            static const char *teamKeys[] = { "teamName", "team" };
+            if (CG_LadderCopyValue(entry->payload, teamKeys, sizeof(teamKeys) / sizeof(teamKeys[0]), buffer, sizeof(buffer))) {
+                char *endPtr;
+                int teamNum;
+
+                teamNum = (int)strtol(buffer, &endPtr, 10);
+                while (endPtr && *endPtr && isspace((unsigned char)*endPtr)) {
+                    endPtr++;
+                }
+
+                if (endPtr && *endPtr == '\0') {
+                    Q_strncpyz(out, CG_GetTeamName((team_t)teamNum), outSize);
+                } else {
+                    Q_strncpyz(out, buffer, outSize);
+                }
+            }
+            break;
+        }
+
+        case LADDER_COL_BEST_LAP:
+            CG_LadderFormatTimeValue(entry->payload, bestLapKeys, sizeof(bestLapKeys) / sizeof(bestLapKeys[0]), out, outSize);
+            break;
+
+        case LADDER_COL_TOTAL_TIME:
+            CG_LadderFormatTimeValue(entry->payload, totalTimeKeys, sizeof(totalTimeKeys) / sizeof(totalTimeKeys[0]), out, outSize);
+            break;
+
+        case LADDER_COL_LAPS:
+            if (CG_LadderParseInt(entry->payload, lapKeys, sizeof(lapKeys) / sizeof(lapKeys[0]), &value)) {
+                Com_sprintf(out, outSize, "%d", value);
+            }
+            break;
+
+        case LADDER_COL_SCORE:
+            if (CG_LadderParseInt(entry->payload, scoreKeys, sizeof(scoreKeys) / sizeof(scoreKeys[0]), &value)) {
+                Com_sprintf(out, outSize, "%d", value);
+            }
+            break;
+
+        case LADDER_COL_FRAGS:
+            if (CG_LadderParseInt(entry->payload, fragKeys, sizeof(fragKeys) / sizeof(fragKeys[0]), &value)) {
+                Com_sprintf(out, outSize, "%d", value);
+            }
+            break;
+
+        case LADDER_COL_DEATHS:
+            if (CG_LadderParseInt(entry->payload, deathKeys, sizeof(deathKeys) / sizeof(deathKeys[0]), &value)) {
+                Com_sprintf(out, outSize, "%d", value);
+            }
+            break;
+
+        case LADDER_COL_KD:
+            if (CG_LadderParseFloat(entry->payload, kdKeys, sizeof(kdKeys) / sizeof(kdKeys[0]), &fvalue)) {
+                Com_sprintf(out, outSize, "%.2f", fvalue);
+            }
+            break;
+
+        case LADDER_COL_DAMAGE_DEALT:
+            if (CG_LadderParseInt(entry->payload, damageKeys, sizeof(damageKeys) / sizeof(damageKeys[0]), &value)) {
+                Com_sprintf(out, outSize, "%d", value);
+            }
+            break;
+
+        case LADDER_COL_DAMAGE_TAKEN:
+            if (CG_LadderParseInt(entry->payload, damageTakenKeys, sizeof(damageTakenKeys) / sizeof(damageTakenKeys[0]), &value)) {
+                Com_sprintf(out, outSize, "%d", value);
+            }
+            break;
+
+        case LADDER_COL_CAPTURES:
+            if (CG_LadderParseInt(entry->payload, captureKeys, sizeof(captureKeys) / sizeof(captureKeys[0]), &value)) {
+                Com_sprintf(out, outSize, "%d", value);
+            }
+            break;
+
+        case LADDER_COL_ASSISTS:
+            if (CG_LadderParseInt(entry->payload, assistKeys, sizeof(assistKeys) / sizeof(assistKeys[0]), &value)) {
+                Com_sprintf(out, outSize, "%d", value);
+            }
+            break;
+
+        case LADDER_COL_ZONE_HOLD:
+            CG_LadderFormatTimeValue(entry->payload, zoneKeys, sizeof(zoneKeys) / sizeof(zoneKeys[0]), out, outSize);
+            break;
+
+        case LADDER_COL_SURVIVAL:
+            CG_LadderFormatTimeValue(entry->payload, survivalKeys, sizeof(survivalKeys) / sizeof(survivalKeys[0]), out, outSize);
+            break;
+
+        case LADDER_COL_ELIM_ROUND:
+            if (CG_LadderParseInt(entry->payload, elimRoundKeys, sizeof(elimRoundKeys) / sizeof(elimRoundKeys[0]), &value)) {
+                Com_sprintf(out, outSize, "%d", value);
+            }
+            break;
+
+        case LADDER_COL_ELIM_REMAIN:
+            if (CG_LadderParseInt(entry->payload, elimRemainKeys, sizeof(elimRemainKeys) / sizeof(elimRemainKeys[0]), &value)) {
+                Com_sprintf(out, outSize, "%d", value);
+            }
+            break;
+
+        case LADDER_COL_SOURCE:
+            switch (entry->source) {
+                case LADDER_SOURCE_SERVER:
+                    Q_strncpyz(out, "SRV", outSize);
+                    break;
+                case LADDER_SOURCE_WEBSERVICE:
+                    Q_strncpyz(out, "WEB", outSize);
+                    break;
+                default:
+                    break;
+            }
+            break;
+
+        default:
+            break;
+    }
+
+    if (!out[0]) {
+        Q_strncpyz(out, "--", outSize);
+    }
+}
+
+static int CG_GetLadderColumns(ladderColumnDef_t *columns, int maxColumns) {
+    int count;
+    qboolean isTeam;
+
+    if (!columns || maxColumns <= 0) {
+        return 0;
+    }
+
+    count = 0;
+    isTeam = CG_IsTeamGametype();
+
+    if (count < maxColumns) {
+        columns[count].type = LADDER_COL_POSITION;
+        columns[count].header = "POS";
+        columns[count].width = 56;
+        columns[count].align = 1;
+        count++;
+    }
+
+    if (isTeam && count < maxColumns) {
+        columns[count].type = LADDER_COL_TEAM;
+        columns[count].header = "TEAM";
+        columns[count].width = 72;
+        columns[count].align = 1;
+        count++;
+    }
+
+    if (count < maxColumns) {
+        columns[count].type = LADDER_COL_NAME;
+        columns[count].header = "PLAYER";
+        columns[count].width = isTeam ? 188 : 220;
+        columns[count].align = 0;
+        count++;
+    }
+
+    switch (cgs.gametype) {
+        case GT_RACING:
+        case GT_TEAM_RACING:
+            if (count < maxColumns) {
+                columns[count].type = LADDER_COL_BEST_LAP;
+                columns[count].header = "BEST";
+                columns[count].width = 104;
+                columns[count].align = 1;
+                count++;
+            }
+            if (count < maxColumns) {
+                columns[count].type = LADDER_COL_TOTAL_TIME;
+                columns[count].header = "TOTAL";
+                columns[count].width = 112;
+                columns[count].align = 1;
+                count++;
+            }
+            if (cgs.laplimit > 1 && count < maxColumns) {
+                columns[count].type = LADDER_COL_LAPS;
+                columns[count].header = "LAPS";
+                columns[count].width = 72;
+                columns[count].align = 1;
+                count++;
+            }
+            break;
+
+        case GT_RACING_DM:
+        case GT_TEAM_RACING_DM:
+            if (count < maxColumns) {
+                columns[count].type = LADDER_COL_BEST_LAP;
+                columns[count].header = "BEST";
+                columns[count].width = 88;
+                columns[count].align = 1;
+                count++;
+            }
+            if (count < maxColumns) {
+                columns[count].type = LADDER_COL_TOTAL_TIME;
+                columns[count].header = "TOTAL";
+                columns[count].width = 88;
+                columns[count].align = 1;
+                count++;
+            }
+            if (count < maxColumns) {
+                columns[count].type = LADDER_COL_FRAGS;
+                columns[count].header = "FRAGS";
+                columns[count].width = 64;
+                columns[count].align = 1;
+                count++;
+            }
+            if (count < maxColumns) {
+                columns[count].type = LADDER_COL_DAMAGE_DEALT;
+                columns[count].header = "DMG";
+                columns[count].width = 80;
+                columns[count].align = 1;
+                count++;
+            }
+            break;
+
+        case GT_ELIMINATION:
+        case GT_LCS:
+            if (count < maxColumns) {
+                columns[count].type = LADDER_COL_SURVIVAL;
+                columns[count].header = "SURVIVAL";
+                columns[count].width = 112;
+                columns[count].align = 1;
+                count++;
+            }
+            if (count < maxColumns) {
+                columns[count].type = LADDER_COL_ELIM_ROUND;
+                columns[count].header = "ROUND";
+                columns[count].width = 80;
+                columns[count].align = 1;
+                count++;
+            }
+            if (count < maxColumns) {
+                columns[count].type = LADDER_COL_ELIM_REMAIN;
+                columns[count].header = "LEFT";
+                columns[count].width = 80;
+                columns[count].align = 1;
+                count++;
+            }
+            if (cgs.laplimit > 1 && count < maxColumns) {
+                columns[count].type = LADDER_COL_LAPS;
+                columns[count].header = "LAPS";
+                columns[count].width = 72;
+                columns[count].align = 1;
+                count++;
+            }
+            break;
+
+        case GT_DERBY:
+            if (count < maxColumns) {
+                columns[count].type = LADDER_COL_SCORE;
+                columns[count].header = "SCORE";
+                columns[count].width = 88;
+                columns[count].align = 1;
+                count++;
+            }
+            if (count < maxColumns) {
+                columns[count].type = LADDER_COL_DAMAGE_DEALT;
+                columns[count].header = "DMG";
+                columns[count].width = 96;
+                columns[count].align = 1;
+                count++;
+            }
+            if (count < maxColumns) {
+                columns[count].type = LADDER_COL_DAMAGE_TAKEN;
+                columns[count].header = "TAKEN";
+                columns[count].width = 96;
+                columns[count].align = 1;
+                count++;
+            }
+            break;
+
+        case GT_DOMINATION:
+            if (count < maxColumns) {
+                columns[count].type = LADDER_COL_SCORE;
+                columns[count].header = "POINTS";
+                columns[count].width = 80;
+                columns[count].align = 1;
+                count++;
+            }
+            if (count < maxColumns) {
+                columns[count].type = LADDER_COL_ZONE_HOLD;
+                columns[count].header = "ZONE";
+                columns[count].width = 110;
+                columns[count].align = 1;
+                count++;
+            }
+            if (count < maxColumns) {
+                columns[count].type = LADDER_COL_DAMAGE_DEALT;
+                columns[count].header = "DMG";
+                columns[count].width = 92;
+                columns[count].align = 1;
+                count++;
+            }
+            break;
+
+        case GT_CTF:
+        case GT_CTF4:
+            if (count < maxColumns) {
+                columns[count].type = LADDER_COL_SCORE;
+                columns[count].header = "SCORE";
+                columns[count].width = 80;
+                columns[count].align = 1;
+                count++;
+            }
+            if (count < maxColumns) {
+                columns[count].type = LADDER_COL_CAPTURES;
+                columns[count].header = "CAPS";
+                columns[count].width = 80;
+                columns[count].align = 1;
+                count++;
+            }
+            if (count < maxColumns) {
+                columns[count].type = LADDER_COL_ASSISTS;
+                columns[count].header = "ASSISTS";
+                columns[count].width = 80;
+                columns[count].align = 1;
+                count++;
+            }
+            if (count < maxColumns) {
+                columns[count].type = LADDER_COL_DEATHS;
+                columns[count].header = "DEATHS";
+                columns[count].width = 72;
+                columns[count].align = 1;
+                count++;
+            }
+            break;
+
+        default:
+            if (count < maxColumns) {
+                columns[count].type = LADDER_COL_FRAGS;
+                columns[count].header = isTeam ? "SCORE" : "FRAGS";
+                columns[count].width = 72;
+                columns[count].align = 1;
+                count++;
+            }
+            if (count < maxColumns) {
+                columns[count].type = LADDER_COL_DEATHS;
+                columns[count].header = "DEATHS";
+                columns[count].width = 72;
+                columns[count].align = 1;
+                count++;
+            }
+            if (count < maxColumns) {
+                columns[count].type = LADDER_COL_KD;
+                columns[count].header = "K/D";
+                columns[count].width = 70;
+                columns[count].align = 1;
+                count++;
+            }
+            if (count < maxColumns) {
+                columns[count].type = LADDER_COL_DAMAGE_DEALT;
+                columns[count].header = "DMG";
+                columns[count].width = 92;
+                columns[count].align = 1;
+                count++;
+            }
+            break;
+    }
+
+    return count;
+}
+
+static void CG_DrawLadderStatusMessage(int x, int y, int width, float fade, const char *message) {
+    vec4_t textColor;
+    char buffer[128];
+
+    if (!message || !message[0]) {
+        message = "No ladder data";
+    }
+
+    Q_strncpyz(buffer, message, sizeof(buffer));
+
+    textColor[0] = 0.85f; textColor[1] = 0.85f; textColor[2] = 0.85f; textColor[3] = fade;
+
+    CG_DrawModernBackground(x, y, width, MODERN_SB_HEADER_HEIGHT, MODERN_SB_ALPHA * fade, qfalse);
+    CG_DrawModernText(x,
+                     y + (MODERN_SB_HEADER_HEIGHT - BIGCHAR_HEIGHT) / 2,
+                     buffer,
+                     1,
+                     width,
+                     textColor,
+                     qtrue);
+}
+
+static void CG_DrawLadderView(int y, float fade, const cg_ladder_t *ladder,
+                              int selectedTab, const ladderTabInfo_t *tabs, int tabCount) {
+    ladderColumnDef_t columnDefs[MAX_LADDER_COLUMNS];
+    const cg_ladder_entry_t *visibleEntries[MAX_LADDER_DISPLAY_ROWS];
+    int columnCount;
+    int totalWidth;
+    int columnX[MAX_LADDER_COLUMNS];
+    int currentX;
+    int rowHeight;
+    int entryCount;
+    int i;
+    int j;
+    vec4_t textColor;
+    vec4_t rowHighlight;
+    char identifier[MAX_LADDER_IDENTIFIER];
+    char localName[MAX_NAME_LENGTH];
+    char localClean[MAX_NAME_LENGTH];
+    qboolean haveLocal;
+
+    if (!ladder) {
+        CG_DrawLadderStatusMessage(scoreboardX, y, currentScoreboardWidth, fade, "No ladder data");
+        return;
+    }
+
+    if (selectedTab >= 0 && selectedTab < tabCount) {
+        Q_strncpyz(identifier, tabs[selectedTab].identifier, sizeof(identifier));
+    } else {
+        identifier[0] = '\0';
+    }
+
+    if (ladder->status == LADDER_STATUS_LOADING) {
+        CG_DrawLadderStatusMessage(scoreboardX, y, currentScoreboardWidth, fade, "Loading ladder data...");
+        return;
+    }
+
+    if (ladder->status == LADDER_STATUS_ERROR) {
+        if (ladder->errorMessage[0]) {
+            CG_DrawLadderStatusMessage(scoreboardX, y, currentScoreboardWidth, fade,
+                                       va("Ladder error: %s", ladder->errorMessage));
+        } else {
+            CG_DrawLadderStatusMessage(scoreboardX, y, currentScoreboardWidth, fade, "Ladder error");
+        }
+        return;
+    }
+
+    entryCount = 0;
+    for (i = 0; i < ladder->numEntries && entryCount < MAX_LADDER_DISPLAY_ROWS; i++) {
+        const cg_ladder_entry_t *entry = &ladder->entries[i];
+
+        if (identifier[0]) {
+            if (Q_stricmp(identifier, entry->identifier)) {
+                continue;
+            }
+        } else if (tabs && tabCount > 1) {
+            if (entry->identifier[0]) {
+                continue;
+            }
+        }
+
+        visibleEntries[entryCount++] = entry;
+    }
+
+    if (entryCount <= 0) {
+        if (ladder->status == LADDER_STATUS_READY) {
+            CG_DrawLadderStatusMessage(scoreboardX, y, currentScoreboardWidth, fade, "No results for this tab");
+        } else {
+            CG_DrawLadderStatusMessage(scoreboardX, y, currentScoreboardWidth, fade, "No ladder results yet");
+        }
+        return;
+    }
+
+    columnCount = CG_GetLadderColumns(columnDefs, MAX_LADDER_COLUMNS);
+    if (columnCount <= 0) {
+        CG_DrawLadderStatusMessage(scoreboardX, y, currentScoreboardWidth, fade, "No ladder columns");
+        return;
+    }
+
+    totalWidth = 0;
+    for (i = 0; i < columnCount; i++) {
+        totalWidth += columnDefs[i].width;
+    }
+
+    currentX = scoreboardX + (currentScoreboardWidth - totalWidth) / 2;
+    if (currentX < scoreboardX + MODERN_SB_PADDING) {
+        currentX = scoreboardX + MODERN_SB_PADDING;
+    }
+
+    for (i = 0; i < columnCount; i++) {
+        columnX[i] = currentX;
+        currentX += columnDefs[i].width;
+    }
+
+    textColor[0] = 0.90f; textColor[1] = 0.90f; textColor[2] = 0.90f; textColor[3] = fade;
+    rowHighlight[0] = 0.2f; rowHighlight[1] = 0.4f; rowHighlight[2] = 0.8f; rowHighlight[3] = 0.25f * fade;
+
+    localName[0] = '\0';
+    localClean[0] = '\0';
+    haveLocal = qfalse;
+
+    if (cg.snap) {
+        int clientNum = cg.snap->ps.clientNum;
+        if (clientNum >= 0 && clientNum < cgs.maxclients) {
+            Q_strncpyz(localName, cgs.clientinfo[clientNum].name, sizeof(localName));
+            Q_strncpyz(localClean, localName, sizeof(localClean));
+            Q_CleanStr(localClean);
+            if (localClean[0]) {
+                haveLocal = qtrue;
+            }
+        }
+    }
+
+    CG_DrawModernBackground(scoreboardX, y, currentScoreboardWidth, MODERN_SB_HEADER_HEIGHT,
+                           MODERN_SB_ALPHA, qtrue);
+
+    for (i = 0; i < columnCount; i++) {
+        CG_DrawModernText(columnX[i], y + 8, columnDefs[i].header, columnDefs[i].align,
+                         columnDefs[i].width, textColor, qtrue);
+    }
+
+    y += MODERN_SB_HEADER_HEIGHT + 4;
+    rowHeight = MODERN_SB_ROW_HEIGHT;
+
+    for (i = 0; i < entryCount; i++) {
+        const cg_ladder_entry_t *entry = visibleEntries[i];
+        int rowY = y + i * rowHeight;
+        int textY = rowY + (rowHeight - SMALLCHAR_HEIGHT) / 2;
+        qboolean isLocal = qfalse;
+        char entryName[MAX_STRING_CHARS];
+
+        if (haveLocal && CG_LadderExtractName(entry, entryName, sizeof(entryName))) {
+            char cleanName[MAX_STRING_CHARS];
+            Q_strncpyz(cleanName, entryName, sizeof(cleanName));
+            Q_CleanStr(cleanName);
+            if (!Q_stricmp(cleanName, localClean)) {
+                isLocal = qtrue;
+            }
+        }
+
+        if (isLocal) {
+            CG_FillRect(scoreboardX, rowY, currentScoreboardWidth, rowHeight, rowHighlight);
+        }
+
+        CG_DrawModernBackground(scoreboardX, rowY, currentScoreboardWidth, rowHeight,
+                               MODERN_SB_ALPHA * fade, qfalse);
+
+        for (j = 0; j < columnCount; j++) {
+            char value[128];
+            CG_LadderFormatColumnValue(entry, columnDefs[j].type, value, sizeof(value));
+            CG_DrawModernText(columnX[j], textY, value, columnDefs[j].align,
+                             columnDefs[j].width, textColor, qfalse);
+        }
+    }
+}
+
+
 /*
 =================
 CG_DrawModernTeamHeaderRow
@@ -828,6 +1764,11 @@ qboolean CG_DrawModernScoreboard(void) {
     qboolean isCompact;
     score_t *score;
     clientInfo_t *ci;
+    const cg_ladder_t *ladder;
+    ladderTabInfo_t ladderTabs[MAX_LADDER_TABS];
+    int ladderTabCount;
+    int totalTabs;
+    qboolean ladderEnabled;
 
     
     CG_SetScreenPlacement(PLACE_CENTER, PLACE_CENTER);
@@ -851,6 +1792,34 @@ qboolean CG_DrawModernScoreboard(void) {
     
     /* Initialize columns for current gametype */
     CG_InitScoreboardColumns();
+
+    ladder = CG_LadderState();
+    ladderTabCount = 0;
+    ladderEnabled = qfalse;
+
+    if (ladder && (ladder->status != LADDER_STATUS_EMPTY || ladder->numEntries > 0)) {
+        ladderTabCount = CG_BuildLadderTabs(ladder, ladderTabs, MAX_LADDER_TABS);
+        if (ladderTabCount > 0) {
+            ladderEnabled = qtrue;
+        }
+    }
+
+    totalTabs = 1 + (ladderEnabled ? ladderTabCount : 0);
+    if (scoreboardActiveTab >= totalTabs) {
+        scoreboardActiveTab = totalTabs - 1;
+    }
+    if (scoreboardActiveTab < 0) {
+        scoreboardActiveTab = 0;
+    }
+
+    CG_HandleScoreboardTabInput(totalTabs);
+
+    if (scoreboardActiveTab >= totalTabs) {
+        scoreboardActiveTab = totalTabs - 1;
+    }
+    if (scoreboardActiveTab < 0) {
+        scoreboardActiveTab = 0;
+    }
     
     /* Calculate fade */
     if (cg.showScores || cg.predictedPlayerState.pm_type == PM_DEAD ||
@@ -874,13 +1843,27 @@ qboolean CG_DrawModernScoreboard(void) {
     }
     
     y = 80;
-    
+
+    if (totalTabs > 1) {
+        y = CG_DrawScoreboardTabs(y, totalTabs, ladderTabs, ladderTabCount, fade);
+    }
+
+    if (ladderEnabled && scoreboardActiveTab > 0) {
+        CG_DrawLadderView(y, fade, ladder, scoreboardActiveTab - 1, ladderTabs, ladderTabCount);
+
+        if (++cg.deferredPlayerLoading > 10) {
+            CG_LoadDeferredPlayers();
+        }
+
+        return qtrue;
+    }
+
     /* Draw "Fragged by" message */
     if (cg.killerName[0]) {
         char *fragMsg;
         int w, x;
         vec4_t fragColor;
-        
+
         /* Different message based on gametype */
         if (cgs.gametype == GT_DERBY) {
             fragMsg = va("Wrecked by %s", cg.killerName);
@@ -889,31 +1872,31 @@ qboolean CG_DrawModernScoreboard(void) {
         } else {
             fragMsg = va("Eliminated by %s", cg.killerName);
         }
-        
+
         w = CG_DrawStrlen(fragMsg) * BIGCHAR_WIDTH;
         x = (SCREEN_WIDTH - w) / 2;
-        
+
         fragColor[0] = 1.0f; fragColor[1] = 0.3f; fragColor[2] = 0.3f; fragColor[3] = fade;
         CG_DrawBigStringColor(x, y, fragMsg, fragColor);
         y += BIGCHAR_HEIGHT + 16;
     }
-    
+
     /* Draw game info */
     CG_DrawModernGameInfo(y, fade);
     y += BIGCHAR_HEIGHT + 24;
-    
+
     /* Determine layout mode */
     isCompact = (cg.numScores > MAX_SCOREBOARD_CLIENTS) || CG_IsTeamGametype();
     maxClients = isCompact ? MAX_COMPACT_CLIENTS : MAX_SCOREBOARD_CLIENTS;
     rowHeight = isCompact ? MODERN_SB_COMPACT_HEIGHT : MODERN_SB_ROW_HEIGHT;
-    
+
     /* Draw header */
     CG_DrawModernHeader(y);
     y += MODERN_SB_HEADER_HEIGHT + 4;
-    
+
     localClientDrawn = qfalse;
     drawnClients = 0;
-    
+
     if (CG_IsTeamGametype()) {
         /* Team-based scoreboard */
         for (i = 0; i < 4 && drawnClients < maxClients; i++) {


### PR DESCRIPTION
## Summary
- introduce ladder tab metadata, parsing helpers, and column definitions to the scoreboard implementation
- render a tab bar that switches between match and ladder views with per-gametype ladder columns and robust fallbacks for missing values
- adjust the scoreboard flow to draw ladder data or the original player list depending on the active tab

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d43505d3b4832492951bb361c39c87