### PR TITLE
Fix scoreboard input keys and deaths parsing

### DIFF
--- a/engine/code/cgame/cg_local.h
+++ b/engine/code/cgame/cg_local.h
@@ -407,6 +407,7 @@ typedef struct {
 	int				damageDealt;
 	int				damageTaken;
 	int				position;
+	int				deaths;
 } score_t;
 
 // each client has an associated clientInfo_t

--- a/engine/code/cgame/cg_scoreboard.c
+++ b/engine/code/cgame/cg_scoreboard.c
@@ -23,6 +23,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 
 /* cg_scoreboard.c -- Adaptive scoreboard design for Q3Rally */
 #include "cg_local.h"
+#include "../client/keycodes.h"
 #include <ctype.h>
 #include <stdlib.h>
 #include <limits.h>

--- a/engine/code/cgame/cg_servercmds.c
+++ b/engine/code/cgame/cg_servercmds.c
@@ -122,27 +122,28 @@ static void CG_ParseScores( void ) {
 	memset( cg.scores, 0, sizeof( cg.scores ) );
 	for ( i = 0 ; i < cg.numScores ; i++ ) {
 		//
-// STONELANCE changed i * 14 to i * 18, added 4
-		cg.scores[i].client = atoi( CG_Argv( i * 18 + 6 ) );
-		cg.scores[i].score = atoi( CG_Argv( i * 18 + 7 ) );
-		cg.scores[i].ping = atoi( CG_Argv( i * 18 + 8 ) );
-		cg.scores[i].time = atoi( CG_Argv( i * 18 + 9 ) );
-		cg.scores[i].scoreFlags = atoi( CG_Argv( i * 18 + 10 ) );
-		powerups = atoi( CG_Argv( i * 18 + 11 ) );
-		cg.scores[i].accuracy = atoi(CG_Argv(i * 18 + 12));
-		cg.scores[i].impressiveCount = atoi(CG_Argv(i * 18 + 13));
-		cg.scores[i].impressiveTelefragCount = atoi(CG_Argv(i * 18 + 14));
-		cg.scores[i].excellentCount = atoi(CG_Argv(i * 18 + 15));
-		cg.scores[i].guantletCount = atoi(CG_Argv(i * 18 + 16));
-		cg.scores[i].defendCount = atoi(CG_Argv(i * 18 + 17));
-		cg.scores[i].assistCount = atoi(CG_Argv(i * 18 + 18));
-		cg.scores[i].perfect = atoi(CG_Argv(i * 18 + 19));
-		cg.scores[i].captures = atoi(CG_Argv(i * 18 + 20));
+// STONELANCE changed i * 14 to i * 19, added scoreboard fields
+		cg.scores[i].client = atoi( CG_Argv( i * 19 + 6 ) );
+		cg.scores[i].score = atoi( CG_Argv( i * 19 + 7 ) );
+		cg.scores[i].ping = atoi( CG_Argv( i * 19 + 8 ) );
+		cg.scores[i].time = atoi( CG_Argv( i * 19 + 9 ) );
+		cg.scores[i].scoreFlags = atoi( CG_Argv( i * 19 + 10 ) );
+		powerups = atoi( CG_Argv( i * 19 + 11 ) );
+		cg.scores[i].accuracy = atoi(CG_Argv(i * 19 + 12));
+		cg.scores[i].impressiveCount = atoi(CG_Argv(i * 19 + 13));
+		cg.scores[i].impressiveTelefragCount = atoi(CG_Argv(i * 19 + 14));
+		cg.scores[i].excellentCount = atoi(CG_Argv(i * 19 + 15));
+		cg.scores[i].guantletCount = atoi(CG_Argv(i * 19 + 16));
+		cg.scores[i].defendCount = atoi(CG_Argv(i * 19 + 17));
+		cg.scores[i].assistCount = atoi(CG_Argv(i * 19 + 18));
+		cg.scores[i].perfect = atoi(CG_Argv(i * 19 + 19));
+		cg.scores[i].captures = atoi(CG_Argv(i * 19 + 20));
 // END
-// STONELANCE add two more score parts
-		cg.scores[i].damageDealt = atoi(CG_Argv(i * 18 + 21));
-		cg.scores[i].damageTaken = atoi(CG_Argv(i * 18 + 22));
-		cg.scores[i].position = atoi(CG_Argv(i * 18 + 23));
+// STONELANCE add additional score parts
+                cg.scores[i].damageDealt = atoi(CG_Argv(i * 19 + 21));
+                cg.scores[i].damageTaken = atoi(CG_Argv(i * 19 + 22));
+                cg.scores[i].position = atoi(CG_Argv(i * 19 + 23));
+                cg.scores[i].deaths = atoi(CG_Argv(i * 19 + 24));
 // END
 
 		if ( cg.scores[i].client < 0 || cg.scores[i].client >= MAX_CLIENTS ) {
@@ -163,9 +164,10 @@ static void CG_ParseScores( void ) {
 		cg.scores[i].score = 0;
 		cg.scores[i].ping = 0;
 		cg.scores[i].time = 0;
-		cg.scores[i].scoreFlags = -1;
-		cg.scores[i].position = -1;
-		powerups = 0;
+                cg.scores[i].scoreFlags = -1;
+                cg.scores[i].position = -1;
+                cg.scores[i].deaths = 0;
+                powerups = 0;
 
 		if ( cg.scores[i].client < 0 || cg.scores[i].client >= MAX_CLIENTS ) {
 			cg.scores[i].client = 0;

--- a/engine/code/game/g_cmds.c
+++ b/engine/code/game/g_cmds.c
@@ -85,7 +85,7 @@ void DeathmatchScoreboardMessage( gentity_t *ent ) {
 
 		Com_sprintf (entry, sizeof(entry),
 
-			" %i %i %i %i %i %i %i %i %i %i %i %i %i %i %i %i %i %i", level.sortedClients[i],
+			" %i %i %i %i %i %i %i %i %i %i %i %i %i %i %i %i %i %i %i", level.sortedClients[i],
 			cl->ps.persistant[PERS_SCORE], ping, time,
 			scoreFlags, g_entities[level.sortedClients[i]].s.powerups, accuracy, 
 			cl->ps.persistant[PERS_IMPRESSIVE_COUNT],
@@ -98,7 +98,8 @@ void DeathmatchScoreboardMessage( gentity_t *ent ) {
 			cl->ps.persistant[PERS_CAPTURES],
 			cl->ps.stats[STAT_DAMAGE_DEALT],
 			cl->ps.stats[STAT_DAMAGE_TAKEN],
-			cl->ps.stats[STAT_POSITION]
+			cl->ps.stats[STAT_POSITION],
+			cl->ps.persistant[PERS_KILLED]
 			);
 
 


### PR DESCRIPTION
## Summary
- include the shared keycode definitions in the cgame scoreboard so the new input checks compile
- track player deaths in the cgame score data parsed from the server
- extend the scoreboard message sent by the game code to append each player's death count

## Testing
- make release *(fails: missing SDL_version.h in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d44a687054832482409533dfccbe17