### PR TITLE
Fix cg_scoreboard standard library includes for Q3 VM

### DIFF
--- a/engine/code/cgame/cg_scoreboard.c
+++ b/engine/code/cgame/cg_scoreboard.c
@@ -24,9 +24,13 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 /* cg_scoreboard.c -- Adaptive scoreboard design for Q3Rally */
 #include "cg_local.h"
 #include "../client/keycodes.h"
+#ifdef Q3_VM
+#include "../game/bg_lib.h"
+#else
 #include <ctype.h>
 #include <stdlib.h>
 #include <limits.h>
+#endif
 
 /* Modern scoreboard layout constants */
 #define MODERN_SB_Y             120


### PR DESCRIPTION
## Summary
- add a Q3_VM conditional include to cg_scoreboard so VM builds use bg_lib and native builds use standard headers

## Testing
- make release (fails: missing SDL_version.h in environment)


------
https://chatgpt.com/codex/tasks/task_e_68d451cfc6f083248b0ece71dbecc2eb