### PR TITLE
Guard car point unlinking after race

### DIFF
--- a/engine/code/game/g_active.c
+++ b/engine/code/game/g_active.c
@@ -1162,10 +1162,11 @@ void ClientThink_real( gentity_t *ent ) {
     if( ent->rearBounds )
       trap_UnlinkEntity( ent->rearBounds ); 
 
-		trap_UnlinkEntity( client->carPoints[0] );
-		trap_UnlinkEntity( client->carPoints[1] );
-		trap_UnlinkEntity( client->carPoints[2] );
-		trap_UnlinkEntity( client->carPoints[3] );
+                for ( i = 0; i < 4; i++ ) {
+                        if ( client->carPoints[i] ) {
+                                trap_UnlinkEntity( client->carPoints[i] );
+                        }
+                }
 
 		return;
 	}


### PR DESCRIPTION
## Summary
- avoid unlinking null race car point entities when switching to observer mode after finishing a race
- iterate through the expected car point slots and only unlink when an entity pointer exists

## Testing
- not run (not provided)

------
https://chatgpt.com/codex/tasks/task_e_68d455907d408324af602bc14c1dd0fa