### PR TITLE
Add ladder menu entries to main and pause menus

### DIFF
--- a/engine/code/q3_ui/ui_ingame.c
+++ b/engine/code/q3_ui/ui_ingame.c
@@ -47,6 +47,7 @@ INGAME MENU
 #define ID_QUIT					17
 #define ID_RESUME				18
 #define ID_TEAMORDERS			19
+#define ID_LADDER				20
 
 
 typedef struct {
@@ -56,6 +57,7 @@ typedef struct {
 	menutext_s		team;
 	menutext_s		setup;
 	menutext_s		server;
+	menutext_s		ladder;
 	menutext_s		leave;
 	menutext_s		restart;
 	menutext_s		addbots;
@@ -133,6 +135,10 @@ void InGame_Event( void *ptr, int notification ) {
 
 	case ID_SERVERINFO:
 		UI_ServerInfoMenu();
+		break;
+
+	case ID_LADDER:
+		UI_LadderMenu();
 		break;
 
 	case ID_ADDBOTS:
@@ -265,6 +271,17 @@ void InGame_MenuInit( void ) {
 	s_ingame.server.style				= UI_CENTER|UI_SMALLFONT;
 
 	y += INGAME_MENU_VERTICAL_SPACING;
+	s_ingame.ladder.generic.type		= MTYPE_PTEXT;
+	s_ingame.ladder.generic.flags		= QMF_CENTER_JUSTIFY|QMF_PULSEIFFOCUS;
+	s_ingame.ladder.generic.x			= 320;
+	s_ingame.ladder.generic.y			= y;
+	s_ingame.ladder.generic.id			= ID_LADDER;
+	s_ingame.ladder.generic.callback	= InGame_Event;
+	s_ingame.ladder.string				= "LADDER";
+	s_ingame.ladder.color				= color_red;
+	s_ingame.ladder.style				= UI_CENTER|UI_SMALLFONT;
+
+	y += INGAME_MENU_VERTICAL_SPACING;
 	s_ingame.restart.generic.type		= MTYPE_PTEXT;
 	s_ingame.restart.generic.flags		= QMF_CENTER_JUSTIFY|QMF_PULSEIFFOCUS;
 	s_ingame.restart.generic.x			= 320;
@@ -318,6 +335,7 @@ void InGame_MenuInit( void ) {
 	Menu_AddItem( &s_ingame.menu, &s_ingame.teamorders );
 	Menu_AddItem( &s_ingame.menu, &s_ingame.setup );
 	Menu_AddItem( &s_ingame.menu, &s_ingame.server );
+	Menu_AddItem( &s_ingame.menu, &s_ingame.ladder );
 	Menu_AddItem( &s_ingame.menu, &s_ingame.restart );
 	Menu_AddItem( &s_ingame.menu, &s_ingame.resume );
 	Menu_AddItem( &s_ingame.menu, &s_ingame.leave );

--- a/engine/code/q3_ui/ui_menu.c
+++ b/engine/code/q3_ui/ui_menu.c
@@ -41,6 +41,7 @@ MAIN MENU
 
 #define ID_MODS                         16
 #define ID_GARAGE                       17
+#define ID_LADDER                       19
 #define ID_EXIT                         18
 
 #define MAIN_BANNER_MODEL               "models/mapobjects/q3rtitle/q3rtitle.md3"
@@ -59,6 +60,7 @@ typedef struct {
         menutext_s              cinematics;
         menutext_s              mods;
         menutext_s              garage;
+        menutext_s              ladder;
         menutext_s              exit;
 
         menutext_s              banner;
@@ -200,6 +202,7 @@ void Main_MenuEvent (void* ptr, int event) {
         case ID_MULTIPLAYER:
         case ID_SETUP:
         case ID_GARAGE:
+        case ID_LADDER:
         case ID_DEMOS:
         case ID_CINEMATICS:
         case ID_MODS:
@@ -238,6 +241,10 @@ void MainMenu_ChangeMenu( int menuId ){
                 UI_BotsMenu();
                 break;
 
+        case ID_LADDER:
+                UI_LadderMenu();
+                break;
+
         case ID_DEMOS:
                 UI_DemosMenu();
                 break;
@@ -269,6 +276,7 @@ void MainMenu_RunTransition( float frac ) {
         s_main.singleplayer.color = uis.text_color;
         s_main.multiplayer.color = uis.text_color;
         s_main.setup.color = uis.text_color;
+        s_main.ladder.color = uis.text_color;
         s_main.garage.color = uis.text_color;
         s_main.cinematics.color = uis.text_color;
         s_main.demos.color = uis.text_color;
@@ -434,12 +442,16 @@ void UI_MainMenu( void ) {
 	InitMenuText(&s_main.setup, ID_SETUP, "CONFIG", x - 10, y + 12);
 
 
-	y += MAIN_MENU_VERTICAL_SPACING;
-	InitMenuText(&s_main.garage, ID_GARAGE, "THE GARAGE", x - 10, y + 12);
-        
-        
-	y += MAIN_MENU_VERTICAL_SPACING;
-	InitMenuText(&s_main.demos, ID_DEMOS, "DEMOS", x - 10, y + 12);
+        y += MAIN_MENU_VERTICAL_SPACING;
+        InitMenuText(&s_main.ladder, ID_LADDER, "LADDER", x - 10, y + 12);
+
+
+        y += MAIN_MENU_VERTICAL_SPACING;
+        InitMenuText(&s_main.garage, ID_GARAGE, "THE GARAGE", x - 10, y + 12);
+
+
+        y += MAIN_MENU_VERTICAL_SPACING;
+        InitMenuText(&s_main.demos, ID_DEMOS, "DEMOS", x - 10, y + 12);
 
 
         s_main.carlogo.generic.type                     = MTYPE_BITMAP;
@@ -459,6 +471,7 @@ void UI_MainMenu( void ) {
         Menu_AddItem( &s_main.menu,     &s_main.singleplayer );
         Menu_AddItem( &s_main.menu,     &s_main.multiplayer );
         Menu_AddItem( &s_main.menu,     &s_main.setup );
+        Menu_AddItem( &s_main.menu,     &s_main.ladder );
         Menu_AddItem( &s_main.menu,     &s_main.garage );
         Menu_AddItem( &s_main.menu,     &s_main.demos );
         Menu_AddItem( &s_main.menu,     &s_main.exit );            


### PR DESCRIPTION
## Summary
- add a Ladder shortcut to the main menu with transition handling
- expose the Ladder screen from the in-game pause menu alongside other utilities

## Testing
- not run (UI-only change)


------
https://chatgpt.com/codex/tasks/task_e_68d4575f19b88324ae857cbcba86710a