### PR TITLE
Align UI API version with ladder syscalls

### DIFF
--- a/engine/code/q3_ui/ui_local.h
+++ b/engine/code/q3_ui/ui_local.h
@@ -29,9 +29,9 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 //NOTE: include the ui_public.h from the new UI
 #include "../ui/ui_public.h"
 #include "../ui/ui_shared.h"
-//redefine to old API version
+// Use the extended API so the engine can verify ladder syscall support
 #undef UI_API_VERSION
-#define UI_API_VERSION	4
+#define UI_API_VERSION	6
 #include "../client/keycodes.h"
 #include "../game/bg_public.h"
 


### PR DESCRIPTION
## Summary
- update the q3_ui API version constant to 6 so the engine can verify ladder syscall support before loading the UI

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d45bed668083248748724e60879b5a