### PR TITLE
Extend pause menu frame and improve ladder visibility

### DIFF
--- a/engine/code/q3_ui/ui_ingame.c
+++ b/engine/code/q3_ui/ui_ingame.c
@@ -184,7 +184,7 @@ void InGame_MenuInit( void ) {
 	s_ingame.frame.generic.x			= 320-233;//142;
 	s_ingame.frame.generic.y			= 240-166;//118;
 	s_ingame.frame.width				= 466;//359;
-	s_ingame.frame.height				= 332;//256;
+	s_ingame.frame.height				= 360;//256;
 
 	//y = 96;
 	y = 88;
@@ -278,8 +278,8 @@ void InGame_MenuInit( void ) {
 	s_ingame.ladder.generic.id			= ID_LADDER;
 	s_ingame.ladder.generic.callback	= InGame_Event;
 	s_ingame.ladder.string				= "LADDER";
-	s_ingame.ladder.color				= color_red;
-	s_ingame.ladder.style				= UI_CENTER|UI_SMALLFONT;
+	s_ingame.ladder.color				= color_white;
+	s_ingame.ladder.style				= UI_CENTER|UI_SMALLFONT|UI_DROPSHADOW;
 
 	y += INGAME_MENU_VERTICAL_SPACING;
 	s_ingame.restart.generic.type		= MTYPE_PTEXT;


### PR DESCRIPTION
## Summary
- extend the in-game pause menu frame to cover the additional menu entry
- adjust the ladder entry styling so it stays legible against gameplay backgrounds

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d46659ee4c8324b2c2e49c1facba28