### PR TITLE
Darken ladder menu backdrop

### DIFF
--- a/engine/code/q3_ui/ui_ingame.c
+++ b/engine/code/q3_ui/ui_ingame.c
@@ -184,7 +184,7 @@ void InGame_MenuInit( void ) {
 	s_ingame.frame.generic.x			= 320-233;//142;
 	s_ingame.frame.generic.y			= 240-166;//118;
 	s_ingame.frame.width				= 466;//359;
-	s_ingame.frame.height				= 332;//256;
+	s_ingame.frame.height				= 360;//256;
 
 	//y = 96;
 	y = 88;
@@ -278,8 +278,8 @@ void InGame_MenuInit( void ) {
 	s_ingame.ladder.generic.id			= ID_LADDER;
 	s_ingame.ladder.generic.callback	= InGame_Event;
 	s_ingame.ladder.string				= "LADDER";
-	s_ingame.ladder.color				= color_red;
-	s_ingame.ladder.style				= UI_CENTER|UI_SMALLFONT;
+	s_ingame.ladder.color				= color_white;
+	s_ingame.ladder.style				= UI_CENTER|UI_SMALLFONT|UI_DROPSHADOW;
 
 	y += INGAME_MENU_VERTICAL_SPACING;
 	s_ingame.restart.generic.type		= MTYPE_PTEXT;

--- a/engine/code/q3_ui/ui_ladder.c
+++ b/engine/code/q3_ui/ui_ladder.c
@@ -28,6 +28,8 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 
 #define LADDER_FRAME                            "menu/art/cut_frame"
 
+static const vec4_t ladderBackdropColor = { 0.f, 0.f, 0.f, 0.6f };
+
 #define ID_MODE                                 100
 #define ID_TIMEFRAME                            101
 #define ID_REGION                               102
@@ -296,6 +298,7 @@ static void LadderMenu_MenuEvent( void *ptr, int event ) {
 }
 
 static void LadderMenu_MenuDraw( void ) {
+        UI_FillRect( -uis.bias, 0, SCREEN_WIDTH + 2 * uis.bias, SCREEN_HEIGHT, ladderBackdropColor );
         LadderMenu_UpdateFromBackend();
         Menu_Draw( &s_ladderMenu.menu );
 }


### PR DESCRIPTION
## Summary
- add a semi-transparent black fill behind the ladder menu to improve contrast against the game scene

## Testing
- not run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68d46659ee4c8324b2c2e49c1facba28