### PR TITLE
Expose ladder queue configuration for web service

### DIFF
--- a/engine/code/server/server.h
+++ b/engine/code/server/server.h
@@ -273,6 +273,7 @@ extern	cvar_t	*sv_allowDownload;
 extern	cvar_t	*sv_ladderEnabled;
 extern	cvar_t	*sv_ladderUrl;
 extern	cvar_t	*sv_ladderApiKey;
+extern	cvar_t	*sv_telemetryMaxBatch;
 extern	cvar_t	*sv_maxclients;
 
 extern	cvar_t	*sv_privateClients;

--- a/engine/code/server/sv_init.c
+++ b/engine/code/server/sv_init.c
@@ -683,6 +683,8 @@ void SV_Init (void)
 	Cvar_CheckRange( sv_ladderEnabled, 0, 1, qtrue );
 	sv_ladderUrl = Cvar_Get ("sv_ladderUrl", "", CVAR_ARCHIVE);
 	sv_ladderApiKey = Cvar_Get ("sv_ladderApiKey", "", CVAR_TEMP | CVAR_PROTECTED);
+	sv_telemetryMaxBatch = Cvar_Get ("sv_telemetryMaxBatch", "8", CVAR_ARCHIVE);
+	Cvar_CheckRange( sv_telemetryMaxBatch, 1, 64, qtrue );
 	Cvar_Get ("sv_dlURL", "", CVAR_SERVERINFO | CVAR_ARCHIVE);
 	
 	sv_master[0] = Cvar_Get("sv_master1", MASTER_SERVER_NAME, 0);

--- a/engine/code/server/sv_ladder.c
+++ b/engine/code/server/sv_ladder.c
@@ -34,7 +34,9 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #include <float.h>
 #endif
 
-#define LADDER_SPOOL_LIMIT                      8
+#define LADDER_SPOOL_LIMIT_DEFAULT       8
+#define LADDER_SPOOL_LIMIT_MIN           1
+#define LADDER_SPOOL_LIMIT_MAX           64
 #define LADDER_JSON_INITIAL_CAPACITY    (16 * 1024)
 #define LADDER_BACKOFF_BASE_MS          5000
 #define LADDER_BACKOFF_MAX_MS           300000
@@ -132,6 +134,26 @@ static void (*sv_curl_slist_free_all)(struct curl_slist *list);
 #define sv_curl_slist_free_all curl_slist_free_all
 #endif
 #endif
+
+static int SV_LadderClampQueueLimit( int value ) {
+        if ( value < LADDER_SPOOL_LIMIT_MIN ) {
+                return LADDER_SPOOL_LIMIT_MIN;
+        }
+        if ( value > LADDER_SPOOL_LIMIT_MAX ) {
+                return LADDER_SPOOL_LIMIT_MAX;
+        }
+        return value;
+}
+
+static void SV_LadderRefreshQueueLimit( void ) {
+        int requested = LADDER_SPOOL_LIMIT_DEFAULT;
+
+        if ( sv_telemetryMaxBatch ) {
+                requested = sv_telemetryMaxBatch->integer;
+        }
+
+        sv_ladder.maxQueue = SV_LadderClampQueueLimit( requested );
+}
 
 static qboolean SV_LadderJsonInit( ladderJsonBuilder_t *builder, size_t capacity ) {
         builder->length = 0;
@@ -657,6 +679,11 @@ static char *SV_LadderSerializeMatch( const ladderMatchPayload_t *payload, size_
         }
         {
                 qboolean settingsFirst = qtrue;
+                if ( !SV_LadderJsonAppendKey( &builder, "g_gametype", &settingsFirst ) ||
+                     !SV_LadderJsonAppendInt( &builder, payload->gametype ) ) {
+                        Z_Free( builder.data );
+                        return NULL;
+                }
                 if ( !SV_LadderJsonAppendKey( &builder, "levelStartTime", &settingsFirst ) ||
                      !SV_LadderJsonAppendInt( &builder, payload->levelStartTime ) ) {
                         Z_Free( builder.data );
@@ -986,6 +1013,8 @@ static void SV_LadderLoadSpool( void ) {
         if ( !sv_ladder.spoolReady ) {
                 return;
         }
+
+        SV_LadderRefreshQueueLimit();
 
         files = Sys_ListFiles( sv_ladder.spoolDirectory, ".json", NULL, &count, qfalse );
         if ( !files || count <= 0 ) {
@@ -1522,6 +1551,7 @@ static void SV_LadderResetState( void ) {
         sv_ladder.warnedNoCurl = qfalse;
         sv_ladder.warnedNoUrl = qfalse;
         sv_ladder.nextFileId = 1;
+        SV_LadderRefreshQueueLimit();
 }
 
 void SV_LadderInit( void ) {
@@ -1530,7 +1560,7 @@ void SV_LadderInit( void ) {
         }
 
         Com_Memset( &sv_ladder, 0, sizeof( sv_ladder ) );
-        sv_ladder.maxQueue = LADDER_SPOOL_LIMIT;
+        SV_LadderRefreshQueueLimit();
         sv_ladder.initialized = qtrue;
 
         if ( SV_LadderEnsureSpoolDirectory() ) {
@@ -1588,6 +1618,8 @@ void SV_LadderSubmit( const ladderMatchPayload_t *payload ) {
                 }
                 return;
         }
+
+        SV_LadderRefreshQueueLimit();
 
         total = sv_ladder.queueSize + ( sv_ladder.active ? 1 : 0 );
         if ( total >= sv_ladder.maxQueue ) {

--- a/engine/code/server/sv_main.c
+++ b/engine/code/server/sv_main.c
@@ -40,6 +40,7 @@ cvar_t	*sv_allowDownload;
 cvar_t	*sv_ladderEnabled;
 cvar_t	*sv_ladderUrl;
 cvar_t	*sv_ladderApiKey;
+cvar_t	*sv_telemetryMaxBatch;
 cvar_t	*sv_maxclients;
 
 cvar_t	*sv_privateClients;		// number of clients reserved for password


### PR DESCRIPTION
## Summary
- add a dedicated `sv_telemetryMaxBatch` cvar so operators can tune how many ladder payloads are queued
- clamp and refresh the ladder queue based on the cvar and include the game type inside the serialized settings payload

## Testing
- make -C engine *(fails: missing SDL_version.h in container image)*

------
https://chatgpt.com/codex/tasks/task_e_68d4be275b1c8324b598fb3dd5fa49fd