### PR TITLE
Add FastAPI-based ladder webservice

### DIFF
--- a/ladder_service/.gitignore
+++ b/ladder_service/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+ladder.db
+.venv/

--- a/ladder_service/README.md
+++ b/ladder_service/README.md
@@ -1,0 +1,40 @@
+# Q3Rally Ladder Service
+
+Ein leichtgewichtiger Webservice, der die in `docs/ladder-service.md` beschriebene REST-Schnittstelle bereitstellt. Er sammelt Matches über `POST /api/v1/matches`, speichert die Nutzdaten in einer SQLite-Datenbank und stellt Abfragen über `GET /api/v1/matches` sowie `GET /api/v1/matches/{matchId}` bereit.
+
+## Anforderungen
+
+* Python 3.11
+* Abhängigkeiten aus `requirements.txt`
+
+Installation (am besten in einem virtuellen Umfeld):
+
+```bash
+cd ladder_service
+python -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+```
+
+## Entwicklung starten
+
+```bash
+uvicorn ladder_service.main:app --reload
+```
+
+Standardmäßig wird eine Datei `ladder.db` im Arbeitsverzeichnis genutzt. Über die Umgebungsvariable `LADDER_DB_PATH` kann ein alternativer Pfad vorgegeben werden.
+
+## Endpunkte
+
+| Methode | Pfad | Beschreibung |
+| --- | --- | --- |
+| `POST` | `/api/v1/matches` | Legt ein neues Match ab. Gibt bei Erfolg `{ "matchId": "…" }` zurück. |
+| `GET` | `/api/v1/matches` | Listet Matches, optional gefiltert nach `mode`, mit Pagination über `limit`/`offset`. |
+| `GET` | `/api/v1/matches/{matchId}` | Liefert die ursprünglich gesendeten Daten plus `createdAt`-Zeitstempel. |
+| `DELETE` | `/api/v1/matches/{matchId}` | Entfernt ein Match. |
+
+## Tests
+
+```bash
+pytest
+```

--- a/ladder_service/__init__.py
+++ b/ladder_service/__init__.py
@@ -1,0 +1,5 @@
+"""Expose the Ladder service application package."""
+
+from .ladder_service.main import app, delete_match, get_match, list_matches, create_match
+
+__all__ = ["app", "create_match", "list_matches", "get_match", "delete_match"]

--- a/ladder_service/ladder_service/db.py
+++ b/ladder_service/ladder_service/db.py
@@ -1,0 +1,41 @@
+"""Database setup for the Ladder service."""
+from __future__ import annotations
+
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Iterator
+
+from sqlalchemy import Engine, create_engine
+from sqlalchemy.orm import Session, sessionmaker
+
+
+def _database_url(db_path: str | Path | None) -> str:
+    if db_path is None:
+        return "sqlite:///./ladder.db"
+    path = Path(db_path)
+    if path.is_dir():
+        path = path / "ladder.db"
+    return f"sqlite:///{path}"
+
+
+def create_session_factory(
+    db_path: str | Path | None = None,
+) -> tuple[Engine, sessionmaker[Session]]:
+    engine = create_engine(
+        _database_url(db_path), connect_args={"check_same_thread": False}
+    )
+    factory = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+    return engine, factory
+
+
+@contextmanager
+def session_scope(session_factory: sessionmaker[Session]) -> Iterator[Session]:
+    session = session_factory()
+    try:
+        yield session
+        session.commit()
+    except Exception:
+        session.rollback()
+        raise
+    finally:
+        session.close()

--- a/ladder_service/ladder_service/main.py
+++ b/ladder_service/ladder_service/main.py
@@ -1,0 +1,130 @@
+"""FastAPI application exposing the Ladder webservice."""
+from __future__ import annotations
+
+import json
+import os
+from contextlib import asynccontextmanager
+from typing import AsyncIterator
+
+from fastapi import Depends, FastAPI, HTTPException, Path, Query, status
+from fastapi.responses import JSONResponse
+from sqlalchemy import Engine, select
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import Session, sessionmaker
+
+from .db import create_session_factory, session_scope
+from .models import Base, Match
+from .schemas import MatchCreate
+
+
+def _init_session_factory() -> tuple[sessionmaker[Session], Engine]:
+    db_path = os.getenv("LADDER_DB_PATH")
+    engine, factory = create_session_factory(db_path)
+    Base.metadata.create_all(bind=engine)
+    return factory, engine
+
+
+SessionFactory, Engine = _init_session_factory()
+
+
+def get_session() -> Session:
+    """Provide a scoped SQLAlchemy session for FastAPI dependencies."""
+
+    with session_scope(SessionFactory) as session:
+        yield session
+
+
+@asynccontextmanager
+async def lifespan(_: FastAPI) -> AsyncIterator[None]:
+    Base.metadata.create_all(bind=Engine)
+    yield
+
+
+app = FastAPI(
+    title="Q3Rally Ladder Service",
+    version="0.1.0",
+    lifespan=lifespan,
+)
+
+
+@app.post(
+    "/api/v1/matches",
+    status_code=status.HTTP_201_CREATED,
+    response_class=JSONResponse,
+)
+def create_match(match: MatchCreate, session: Session = Depends(get_session)) -> dict[str, str]:
+    """Store a reported match in the database."""
+
+    db_match = Match(
+        match_id=match.matchId,
+        mode=match.mode,
+        start_time=match.startTime,
+        end_time=match.endTime,
+        payload=match.json(),
+    )
+    session.add(db_match)
+    try:
+        session.flush()
+    except IntegrityError as exc:  # pragma: no cover - defensive path
+        session.rollback()
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="matchId already exists",
+        ) from exc
+
+    return {"matchId": match.matchId}
+
+
+@app.get("/api/v1/matches")
+def list_matches(
+    session: Session = Depends(get_session),
+    mode: str | None = Query(default=None, description="Filter by gametype"),
+    limit: int = Query(default=50, ge=1, le=200),
+    offset: int = Query(default=0, ge=0),
+) -> dict[str, list[dict[str, object]]]:
+    """Return a paginated list of matches."""
+
+    query = select(Match).order_by(Match.start_time.desc()).offset(offset).limit(limit)
+    if mode:
+        query = query.filter(Match.mode == mode)
+
+    rows = session.execute(query).scalars().all()
+    matches = [json.loads(row.payload) for row in rows]
+    return {"matches": matches}
+
+
+@app.get("/api/v1/matches/{match_id}")
+def get_match(
+    match_id: str = Path(..., description="The matchId that was originally submitted"),
+    session: Session = Depends(get_session),
+) -> dict[str, object]:
+    """Return a single match payload."""
+
+    query = select(Match).where(Match.match_id == match_id)
+    result = session.execute(query).scalar_one_or_none()
+    if result is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Match not found")
+
+    payload = json.loads(result.payload)
+    payload["createdAt"] = result.created_at.isoformat()
+    return payload
+
+
+@app.delete(
+    "/api/v1/matches/{match_id}",
+    status_code=status.HTTP_204_NO_CONTENT,
+)
+def delete_match(
+    match_id: str = Path(..., description="The matchId to delete"),
+    session: Session = Depends(get_session),
+) -> JSONResponse:
+    """Delete a match from the database."""
+
+    query = select(Match).where(Match.match_id == match_id)
+    result = session.execute(query).scalar_one_or_none()
+    if result is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Match not found")
+
+    session.delete(result)
+    session.flush()
+    return JSONResponse(status_code=status.HTTP_204_NO_CONTENT, content={})

--- a/ladder_service/ladder_service/models.py
+++ b/ladder_service/ladder_service/models.py
@@ -1,0 +1,24 @@
+"""SQLAlchemy models for the Ladder service."""
+from __future__ import annotations
+
+from datetime import datetime
+
+from sqlalchemy import Column, DateTime, Integer, String, Text
+from sqlalchemy.orm import declarative_base
+
+
+Base = declarative_base()
+
+
+class Match(Base):
+    """Represents a single match reported by a Q3Rally server."""
+
+    __tablename__ = "matches"
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    match_id = Column(String(64), unique=True, nullable=False, index=True)
+    mode = Column(String(32), nullable=False, index=True)
+    start_time = Column(DateTime(timezone=True), nullable=False)
+    end_time = Column(DateTime(timezone=True), nullable=False)
+    payload = Column(Text, nullable=False)
+    created_at = Column(DateTime(timezone=True), default=datetime.utcnow, nullable=False)

--- a/ladder_service/ladder_service/schemas.py
+++ b/ladder_service/ladder_service/schemas.py
@@ -1,0 +1,102 @@
+"""Pydantic schemas for request and response payloads."""
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any, Literal, Optional
+
+from pydantic import BaseModel, Field, HttpUrl, validator
+
+
+Gametype = Literal[
+    "GT_RACING",
+    "GT_RACING_DM",
+    "GT_TEAM_RACING",
+    "GT_TEAM_RACING_DM",
+    "GT_ELIMINATION",
+    "GT_LCS",
+    "GT_DERBY",
+    "GT_DEATHMATCH",
+    "GT_TEAM",
+    "GT_CTF",
+    "GT_CTF4",
+    "GT_DOMINATION",
+    "GT_SINGLE_PLAYER",
+]
+
+
+class ServerInfo(BaseModel):
+    name: str = Field(..., description="Human readable server name")
+    host: str = Field(..., description="Host:port of the reporting server")
+    build: Optional[str] = Field(
+        default=None, description="Build identifier reported by the server"
+    )
+
+
+class Settings(BaseModel):
+    g_gametype: int
+
+    class Config:
+        extra = "allow"
+
+
+class Player(BaseModel):
+    playerId: str
+    displayName: Optional[str]
+    team: Optional[str]
+    rawScore: int
+    totalTime: Optional[str]
+    position: Optional[int]
+    damageDealt: Optional[int]
+    damageTaken: Optional[int]
+
+    class Config:
+        extra = "allow"
+
+
+class Team(BaseModel):
+    team: str
+    rawScore: Optional[int]
+    normalizedScore: Optional[float]
+
+    class Config:
+        extra = "allow"
+
+
+class Event(BaseModel):
+    timestamp: datetime
+    type: str
+
+    class Config:
+        extra = "allow"
+
+
+class MatchCreate(BaseModel):
+    matchId: str
+    mode: Gametype
+    startTime: datetime
+    endTime: datetime
+    duration: Optional[str]
+    map: Optional[str]
+    server: Optional[ServerInfo]
+    serverUrl: Optional[HttpUrl] = Field(
+        default=None, description="Optional public URL of the reporting server"
+    )
+    settings: Settings
+    players: list[Player] = Field(..., min_items=1)
+    teams: list[Team] | None = None
+    events: list[Event] | None = None
+
+    @validator("players")
+    def ensure_player_ids(cls, value: list[Player]) -> list[Player]:
+        missing_id = any(not player.playerId for player in value)
+        if missing_id:
+            raise ValueError("All players must provide a playerId")
+        return value
+
+
+class MatchRead(MatchCreate):
+    id: int
+    createdAt: datetime
+
+    class Config:
+        orm_mode = True

--- a/ladder_service/requirements.txt
+++ b/ladder_service/requirements.txt
@@ -1,0 +1,5 @@
+fastapi==0.110.0
+uvicorn[standard]==0.27.1
+sqlalchemy==2.0.28
+pydantic==1.10.14
+pytest==8.1.1

--- a/ladder_service/tests/test_api.py
+++ b/ladder_service/tests/test_api.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from ladder_service.ladder_service import main
+from ladder_service.ladder_service.db import session_scope
+from ladder_service.ladder_service.models import Base
+
+
+@pytest.fixture(scope="module", autouse=True)
+def override_db(tmp_path_factory: pytest.TempPathFactory) -> None:
+    db_path = tmp_path_factory.mktemp("db") / "test.db"
+    engine = create_engine(
+        f"sqlite:///{db_path}", connect_args={"check_same_thread": False}
+    )
+    TestingSession = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+    Base.metadata.create_all(bind=engine)
+
+    def _override_get_session():
+        with session_scope(TestingSession) as session:
+            yield session
+
+    main.app.dependency_overrides[main.get_session] = _override_get_session
+    yield
+    main.app.dependency_overrides.pop(main.get_session, None)
+
+
+client = TestClient(main.app)
+
+
+MATCH_TEMPLATE = {
+    "matchId": "srv-20240405-183011-42",
+    "mode": "GT_RACING",
+    "startTime": datetime(2024, 4, 5, 18, 30, 11, tzinfo=timezone.utc).isoformat(),
+    "endTime": datetime(2024, 4, 5, 18, 42, 39, tzinfo=timezone.utc).isoformat(),
+    "duration": "PT12M28S",
+    "map": "q3r_country01",
+    "server": {"name": "Q3Rally EU #1", "host": "203.0.113.10:27960", "build": "1.3.0"},
+    "settings": {"g_gametype": 141},
+    "players": [
+        {
+            "playerId": "sha256:abc",
+            "displayName": "PlayerOne",
+            "team": "red",
+            "rawScore": 123,
+        }
+    ],
+}
+
+
+def test_create_match() -> None:
+    response = client.post("/api/v1/matches", json=MATCH_TEMPLATE)
+    assert response.status_code == 201, response.text
+    assert response.json() == {"matchId": MATCH_TEMPLATE["matchId"]}
+
+
+def test_get_match() -> None:
+    response = client.get(f"/api/v1/matches/{MATCH_TEMPLATE['matchId']}")
+    assert response.status_code == 200
+    data = response.json()
+    assert data["matchId"] == MATCH_TEMPLATE["matchId"]
+    assert "createdAt" in data
+
+
+def test_list_matches() -> None:
+    response = client.get("/api/v1/matches?limit=10")
+    assert response.status_code == 200
+    data = response.json()
+    assert len(data["matches"]) >= 1
+
+
+def test_delete_match() -> None:
+    response = client.delete(f"/api/v1/matches/{MATCH_TEMPLATE['matchId']}")
+    assert response.status_code == 204
+    follow_up = client.get(f"/api/v1/matches/{MATCH_TEMPLATE['matchId']}")
+    assert follow_up.status_code == 404


### PR DESCRIPTION
## Summary
- add a standalone FastAPI web service that stores reported Q3Rally matches in SQLite and exposes CRUD endpoints
- define Pydantic request schemas and SQLAlchemy models for match payloads
- document setup in ladder_service/README, capture Python dependencies, and cover the API with integration-style tests

## Testing
- pytest ladder_service/tests/test_api.py *(fails: fastapi dependency is unavailable in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d4c02c5aec832483d53a8facbc93c0