### PR TITLE
Add ladder reporting CVars to server configs

### DIFF
--- a/baseq3r/q3r_ctf.cfg
+++ b/baseq3r/q3r_ctf.cfg
@@ -6,6 +6,11 @@ sv_maxClients 16
 sv_hostname "Q3R CTF Server"
 g_motd "Happy Flagging!"
 
+// Ladder reporting
+sv_ladderEnabled 1
+sv_ladderUrl "https://ladder.q3rally.com/index.php/matches"
+sv_ladderApiKey ""
+
 sv_maxRate 25000
 sv_dlRate 1000
 

--- a/baseq3r/q3r_ctf4.cfg
+++ b/baseq3r/q3r_ctf4.cfg
@@ -6,6 +6,11 @@ sv_maxClients 16
 sv_hostname "Q3R 4-Team CTF Server"
 g_motd "Happy Flagging! (4-Teams)"
 
+// Ladder reporting
+sv_ladderEnabled 1
+sv_ladderUrl "https://ladder.q3rally.com/index.php/matches"
+sv_ladderApiKey ""
+
 sv_maxRate 25000
 sv_dlRate 1000
 

--- a/baseq3r/q3r_derby.cfg
+++ b/baseq3r/q3r_derby.cfg
@@ -6,6 +6,11 @@ sv_maxClients 16
 sv_hostname "Q3R Derby Server"
 g_motd "Happy Smashing!"
 
+// Ladder reporting
+sv_ladderEnabled 1
+sv_ladderUrl "https://ladder.q3rally.com/index.php/matches"
+sv_ladderApiKey ""
+
 sv_maxRate 25000
 sv_dlRate 1000
 

--- a/baseq3r/q3r_dm.cfg
+++ b/baseq3r/q3r_dm.cfg
@@ -6,6 +6,11 @@ sv_maxClients 16
 sv_hostname "Q3R DM Server"
 g_motd "Happy Fragging!"
 
+// Ladder reporting
+sv_ladderEnabled 1
+sv_ladderUrl "https://ladder.q3rally.com/index.php/matches"
+sv_ladderApiKey ""
+
 sv_maxRate 25000
 sv_dlRate 1000
 

--- a/baseq3r/q3r_dom.cfg
+++ b/baseq3r/q3r_dom.cfg
@@ -6,6 +6,11 @@ sv_maxClients 16
 sv_hostname "Q3R DOM Server"
 g_motd "Happy Domination!"
 
+// Ladder reporting
+sv_ladderEnabled 1
+sv_ladderUrl "https://ladder.q3rally.com/index.php/matches"
+sv_ladderApiKey ""
+
 sv_maxRate 25000
 sv_dlRate 1000
 

--- a/baseq3r/q3r_lcs.cfg
+++ b/baseq3r/q3r_lcs.cfg
@@ -6,6 +6,11 @@ sv_maxClients 16
 sv_hostname "Q3R Last Car Standing Server"
 g_motd "Happy Surviving!"
 
+// Ladder reporting
+sv_ladderEnabled 1
+sv_ladderUrl "https://ladder.q3rally.com/index.php/matches"
+sv_ladderApiKey ""
+
 sv_maxRate 25000
 sv_dlRate 1000
 

--- a/baseq3r/q3r_racing.cfg
+++ b/baseq3r/q3r_racing.cfg
@@ -6,6 +6,11 @@ sv_maxClients 16
 sv_hostname "Q3R Racing Server"
 g_motd "Happy Racing!"
 
+// Ladder reporting
+sv_ladderEnabled 1
+sv_ladderUrl "https://ladder.q3rally.com/index.php/matches"
+sv_ladderApiKey ""
+
 sv_maxRate 25000
 sv_dlRate 1000
 

--- a/baseq3r/q3r_racing_dm.cfg
+++ b/baseq3r/q3r_racing_dm.cfg
@@ -6,6 +6,11 @@ sv_maxClients 16
 sv_hostname "Q3R Racing DM Server"
 g_motd "Happy Racing!"
 
+// Ladder reporting
+sv_ladderEnabled 1
+sv_ladderUrl "https://ladder.q3rally.com/index.php/matches"
+sv_ladderApiKey ""
+
 sv_maxRate 25000
 sv_dlRate 1000
 

--- a/baseq3r/q3r_team_dm.cfg
+++ b/baseq3r/q3r_team_dm.cfg
@@ -6,6 +6,11 @@ sv_maxClients 16
 sv_hostname "Q3R Team DM Server"
 g_motd "Happy Fragging!"
 
+// Ladder reporting
+sv_ladderEnabled 1
+sv_ladderUrl "https://ladder.q3rally.com/index.php/matches"
+sv_ladderApiKey ""
+
 sv_maxRate 25000
 sv_dlRate 1000
 

--- a/baseq3r/q3r_team_racing.cfg
+++ b/baseq3r/q3r_team_racing.cfg
@@ -6,6 +6,11 @@ sv_maxClients 16
 sv_hostname "Q3R Team Racing Server"
 g_motd "Happy Racing!"
 
+// Ladder reporting
+sv_ladderEnabled 1
+sv_ladderUrl "https://ladder.q3rally.com/index.php/matches"
+sv_ladderApiKey ""
+
 sv_maxRate 25000
 sv_dlRate 1000
 

--- a/baseq3r/q3r_team_racing_dm.cfg
+++ b/baseq3r/q3r_team_racing_dm.cfg
@@ -6,6 +6,11 @@ sv_maxClients 16
 sv_hostname "Q3R Team Racing DM Server"
 g_motd "Happy Racing!"
 
+// Ladder reporting
+sv_ladderEnabled 1
+sv_ladderUrl "https://ladder.q3rally.com/index.php/matches"
+sv_ladderApiKey ""
+
 sv_maxRate 25000
 sv_dlRate 1000
 

--- a/baseq3r/server_example.cfg
+++ b/baseq3r/server_example.cfg
@@ -44,6 +44,15 @@
 //	Message of the Day
 	g_motd "Sample Text"
 
+//	Ladder Webservice Integration
+//	sv_ladderEnabled - send completed matches to the ladder service
+//	0 = off, 1 = on (Default: 0)
+	sv_ladderEnabled 1
+//	sv_ladderUrl - endpoint for POST /matches
+	sv_ladderUrl "https://ladder.q3rally.com/index.php/matches"
+//	sv_ladderApiKey - optional authentication token (leave empty for public service)
+	sv_ladderApiKey ""
+
 //	sv_allowdownload - Allows download from server of missing assets
 //	0 = off, 1 = on (Default: 0)
 	sv_allowdownload "0"


### PR DESCRIPTION
## Summary
- enable the ladder reporting CVars across all dedicated server presets
- document the ladder integration block in the sample server configuration

## Testing
- not run (config change only)


------
https://chatgpt.com/codex/tasks/task_e_68d4c95160188324a382eafa89053f37