### PR TITLE
Fix MinGW curl linkage for dedicated server

### DIFF
--- a/engine/Makefile
+++ b/engine/Makefile
@@ -794,11 +794,14 @@ ifdef MINGW
         SERVER_CFLAGS += -DCURL_STATICLIB
         ifeq ($(ARCH),x86_64)
           CLIENT_LIBS += $(LIBSDIR)/win64/libcurl.a -lcrypt32
+          SERVER_LIBS += $(LIBSDIR)/win64/libcurl.a -lcrypt32
         else
           CLIENT_LIBS += $(LIBSDIR)/win32/libcurl.a -lcrypt32
+          SERVER_LIBS += $(LIBSDIR)/win32/libcurl.a -lcrypt32
         endif
       else
         CLIENT_LIBS += $(CURL_LIBS)
+        SERVER_LIBS += $(CURL_LIBS)
       endif
     endif
   endif


### PR DESCRIPTION
## Summary
- add the curl static and dynamic library flags to SERVER_LIBS in the MinGW build so the dedicated binary links curl

## Testing
- make BUILD_SERVER=1 ARCH=x86_64 PLATFORM=mingw32 *(fails: Makefile:718: *** Cannot find a suitable cross compiler for mingw32.  Stop.)*

------
https://chatgpt.com/codex/tasks/task_e_68d62c3ef010832486989b0c25c934ad