### PR TITLE
Fix MinGW dedicated server link order

### DIFF
--- a/engine/Makefile
+++ b/engine/Makefile
@@ -2688,7 +2688,7 @@ endif
 
 $(B)/$(SERVERBIN)$(FULLBINEXT): $(Q3DOBJ)
 	$(echo_cmd) "LD $@"
-	$(Q)$(CC) $(CFLAGS) $(LDFLAGS) $(NOTSHLIBLDFLAGS) -o $@ $(Q3DOBJ) $(LIBS) $(SERVER_LIBS)
+	$(Q)$(CC) $(CFLAGS) $(LDFLAGS) $(NOTSHLIBLDFLAGS) -o $@ $(Q3DOBJ) $(SERVER_LIBS) $(LIBS)
 
 
 


### PR DESCRIPTION
## Summary
- ensure the dedicated server link command places the MinGW-specific server libraries before the shared library list so the Winsock symbols resolve during static linking

## Testing
- make BUILD_SERVER=1 ARCH=x86_64 PLATFORM=mingw32 *(fails: Cannot find a suitable cross compiler for mingw32)*

------
https://chatgpt.com/codex/tasks/task_e_68d62e77ab608324ac8a13ca61c27878