### PR TITLE
Fix g_gametype values in server config presets

### DIFF
--- a/baseq3r/q3r_ctf.cfg
+++ b/baseq3r/q3r_ctf.cfg
@@ -1,4 +1,4 @@
-g_gametype 9
+g_gametype 10
 capturelimit 10
 timelimit 12
 

--- a/baseq3r/q3r_ctf4.cfg
+++ b/baseq3r/q3r_ctf4.cfg
@@ -1,4 +1,4 @@
-g_gametype 9
+g_gametype 11
 capturelimit 10
 timelimit 12
 

--- a/baseq3r/q3r_dm.cfg
+++ b/baseq3r/q3r_dm.cfg
@@ -1,4 +1,4 @@
-g_gametype 5
+g_gametype 6
 fraglimit 30
 timelimit 10
 

--- a/baseq3r/q3r_dom.cfg
+++ b/baseq3r/q3r_dom.cfg
@@ -1,4 +1,4 @@
-g_gametype 10
+g_gametype 12
 capturelimit 100
 timelimit 20
 

--- a/baseq3r/q3r_racing.cfg
+++ b/baseq3r/q3r_racing.cfg
@@ -1,4 +1,4 @@
-g_gametype 2
+g_gametype 0
 timelimit 10
 laplimit 3
 

--- a/baseq3r/q3r_team_dm.cfg
+++ b/baseq3r/q3r_team_dm.cfg
@@ -1,4 +1,4 @@
-g_gametype 6
+g_gametype 7
 fraglimit 30
 timelimit 10
 

--- a/baseq3r/q3r_team_racing.cfg
+++ b/baseq3r/q3r_team_racing.cfg
@@ -1,4 +1,4 @@
-g_gametype 7
+g_gametype 8
 timelimit 10
 laplimit 3
 

--- a/baseq3r/q3r_team_racing_dm.cfg
+++ b/baseq3r/q3r_team_racing_dm.cfg
@@ -1,4 +1,4 @@
-g_gametype 8
+g_gametype 9
 timelimit 10
 laplimit 3
 


### PR DESCRIPTION
## Summary
- update the g_gametype setting in all server presets to match the gametype_t enumeration values

## Testing
- ./run.sh +set dedicated 1 +set fs_game baseq3r +exec q3r_racing.cfg +set logfile 2 +wait +g_gametype +wait +quit *(fails: missing SDL_version.h during build)*

------
https://chatgpt.com/codex/tasks/task_e_68d649a9d7d083249234a05a245399d4