### PR TITLE
Fix closing quotes in racing mapcycle configs

### DIFF
--- a/baseq3r/q3r_racing.cfg
+++ b/baseq3r/q3r_racing.cfg
@@ -21,5 +21,5 @@ set d4 "map q3r_lavafalls ; set nextmap vstr d5"
 set d5 "map q3r_nightcity ; set nextmap vstr d6"
 set d6 "map q3r_ridgeracer ; set nextmap vstr d7"
 set d7 "map q3r_sk1 ; set nextmap vstr d8"
-set d8 "map q3r_valley ; set nextmap vstr d1“
+set d8 "map q3r_valley ; set nextmap vstr d1"
 vstr d1

--- a/baseq3r/q3r_team_racing.cfg
+++ b/baseq3r/q3r_team_racing.cfg
@@ -21,5 +21,5 @@ set d4 "map q3r_lavafalls ; set nextmap vstr d5"
 set d5 "map q3r_nightcity ; set nextmap vstr d6"
 set d6 "map q3r_ridgeracer ; set nextmap vstr d7"
 set d7 "map q3r_sk1 ; set nextmap vstr d8"
-set d8 "map q3r_valley ; set nextmap vstr d1“
+set d8 "map q3r_valley ; set nextmap vstr d1"
 vstr d1


### PR DESCRIPTION
## Summary
- replace the smart quote in the `set d8` command of the racing config so the mapcycle parses correctly
- perform the same fix for the team racing config

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d64dd034288324aaa0c614ddf8876b