### PR TITLE
Document all gametypes in server example config

### DIFF
--- a/baseq3r/server_example.cfg
+++ b/baseq3r/server_example.cfg
@@ -7,17 +7,20 @@
 	seta r_smp "0"
 
 //	Gametype
-//	1 = "Racing Deatmatch"
-//	2 = "Racing"
+//	0 = "Racing"
+//	1 = "Racing Deathmatch"
+//	2 = "Single Player"
 //	3 = "Demolition Derby"
 //	4 = "Last Car Standing"
-//	5 = "Deathmatch"
-//	6 = "Team Deathmatch"
-//	7 = "Team Racing"
-//	8 = "Team Racing Deathmatch"
-//	9 = "Capture the Flag"
-//	10 = "Domination"
-	g_gametype "2"
+//	5 = "Elimination"
+//	6 = "Deathmatch"
+//	7 = "Team Deathmatch"
+//	8 = "Team Racing"
+//	9 = "Team Racing Deathmatch"
+//	10 = "Capture the Flag"
+//	11 = "Four-Team Capture the Flag (CTF4)"
+//	12 = "Domination"
+	g_gametype "0"
 
 //	bot_enable - are Bots allowed ?
 //	0 = off, 1 = on (Default: 0)


### PR DESCRIPTION
## Summary
- list every gametype value from 0 through 12 in the sample server configuration comments
- set the example g_gametype value to the default racing mode and note additional variants such as CTF4 and Domination

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d64e53b9588324b5bc45a35aad507f