### PR TITLE
Fix synchronous clients cvar name in server config

### DIFF
--- a/baseq3r/server_example.cfg
+++ b/baseq3r/server_example.cfg
@@ -114,7 +114,7 @@
 
 //	allow recording of demo files
 //	1 = on, 0 = off (Default: 0)
-	g_syncronousClients 1
+	g_synchronousClients 1
 
 //	Additional Infos
 	sets "Administrator" ""


### PR DESCRIPTION
## Summary
- correct the misspelled `g_synchronousClients` cvar name in the sample server configuration

## Testing
- not run (no Quake III server available in the container environment)

------
https://chatgpt.com/codex/tasks/task_e_68d64f1a3c188324a1f1750532ff4d99