### PR TITLE
Handle runtime bot_enable toggles

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -4,6 +4,7 @@ New and fixed since we are standalone (0.0.1.2)
 
 Fixed:
 
+- Bots now honour runtime `bot_enable` changes by initializing AI support without requiring a map restart.
 - Telefrag Gun doesn't work correctly
 - Flattened numbers & "Wrong way" is not on center
 - Gone is the Machinegun as a starting weapon

--- a/engine/code/game/g_local.h
+++ b/engine/code/game/g_local.h
@@ -1051,6 +1051,7 @@ extern	vmCvar_t	g_singlePlayer;
 extern	vmCvar_t	g_proxMineTimeout;
 extern	vmCvar_t	g_localTeamPref;
 extern  vmCvar_t	g_humanplayers;
+extern  vmCvar_t	bot_minplayers;
 // STONELANCE
 extern	vmCvar_t	g_forceEngineStart;
 extern	vmCvar_t	g_finishRaceDelay;

--- a/engine/code/game/g_main.c
+++ b/engine/code/game/g_main.c
@@ -40,6 +40,8 @@ typedef struct {
 gentity_t		g_entities[MAX_GENTITIES];
 gclient_t		g_clients[MAX_CLIENTS];
 
+static qboolean		g_botsInitialized = qfalse;
+
 vmCvar_t	g_gametype;
 vmCvar_t	g_dmflags;
 vmCvar_t	g_fraglimit;
@@ -314,6 +316,27 @@ static void G_SetEliminationSchedule( int referenceTime, int interval );
 static void G_HandleEliminationCvarChanges( int oldStartDelay, int oldInterval, qboolean startDelayChanged, qboolean intervalChanged, qboolean warningChanged );
 
 
+static void G_HandleBotEnable( int botEnable, qboolean restart ) {
+	trap_Cvar_Register( &bot_minplayers, "bot_minplayers", "0", CVAR_SERVERINFO );
+
+	if ( !botEnable ) {
+		g_botsInitialized = qfalse;
+		return;
+	}
+
+	trap_Cvar_Update( &g_dedicated );
+
+	if ( g_botsInitialized && g_dedicated.integer ) {
+		return;
+	}
+
+	BotAISetup( restart );
+	BotAILoadMap( restart );
+	G_InitBots( restart );
+
+	g_botsInitialized = qtrue;
+}
+
 /*
 ================
 vmMain
@@ -380,6 +403,9 @@ Q_EXPORT intptr_t vmMain( int command, int arg0, int arg1, int arg2, int arg3, i
 //		G_DebugLogPrintf("CONSOLE COMMAND\n");
 // END
 		return ConsoleCommand();
+	case GAME_ENABLE_BOTS:
+		G_HandleBotEnable( arg0, arg1 );
+		return 0;
 	case BOTAI_START_FRAME:
 // STONELANCE
 //		if (level.intermissiontime)
@@ -740,11 +766,7 @@ void G_InitGame( int levelTime, int randomSeed, int restart ) {
 		G_ModelIndex( SP_PODIUM_MODEL );
 	}
 
-	if ( trap_Cvar_VariableIntegerValue( "bot_enable" ) ) {
-		BotAISetup( restart );
-		BotAILoadMap( restart );
-		G_InitBots( restart );
-	}
+	G_HandleBotEnable( trap_Cvar_VariableIntegerValue( "bot_enable" ), restart );
 
 	G_RemapTeamShaders();
 
@@ -781,6 +803,8 @@ G_ShutdownGame
 */
 void G_ShutdownGame( int restart ) {
 	G_Printf ("==== ShutdownGame ====\n");
+
+	g_botsInitialized = qfalse;
 
 	if ( level.logFile ) {
 		G_LogPrintf("ShutdownGame:\n" );

--- a/engine/code/game/g_public.h
+++ b/engine/code/game/g_public.h
@@ -516,6 +516,8 @@ typedef enum {
 	// The game can issue trap_argc() / trap_argv() commands to get the command
 	// and parameters.  Return qfalse if the game doesn't recognize it as a command.
 
+	GAME_ENABLE_BOTS,			// ( int botEnable, qboolean restart );
+
 	BOTAI_START_FRAME				// ( int time );
 } gameExport_t;
 

--- a/engine/code/server/server.h
+++ b/engine/code/server/server.h
@@ -416,6 +416,7 @@ sharedEntity_t *SV_GEntityForSvEntity( svEntity_t *svEnt );
 void		SV_InitGameProgs ( void );
 void		SV_ShutdownGameProgs ( void );
 void		SV_RestartGameProgs( void );
+void		SV_GameCheckBotInit( void );
 qboolean	SV_inPVS (const vec3_t p1, const vec3_t p2);
 void	SV_LadderInit( void );
 void	SV_LadderShutdown( void );

--- a/engine/code/server/sv_game.c
+++ b/engine/code/server/sv_game.c
@@ -948,6 +948,46 @@ void SV_InitGameProgs( void ) {
 	SV_InitGameVM( qfalse );
 }
 
+void SV_GameCheckBotInit( void ) {
+	cvar_t	*var;
+	int			desiredValue;
+	char	latchedValue[MAX_CVAR_VALUE_STRING];
+
+	if ( !gvm ) {
+		return;
+	}
+
+	if ( sv.state != SS_GAME ) {
+		return;
+	}
+
+	var = Cvar_Get( "bot_enable", "1", CVAR_LATCH );
+	if ( !var ) {
+		return;
+	}
+
+	desiredValue = var->integer;
+
+	if ( var->latchedString ) {
+		Q_strncpyz( latchedValue, var->latchedString, sizeof( latchedValue ) );
+		desiredValue = atoi( latchedValue );
+		Cvar_Set( "bot_enable", latchedValue );
+	}
+
+	if ( desiredValue == bot_enable ) {
+		return;
+	}
+
+	bot_enable = desiredValue;
+
+	VM_Call( gvm, GAME_ENABLE_BOTS, bot_enable, qfalse );
+
+	if ( !bot_enable ) {
+		return;
+	}
+}
+
+
 
 /*
 ====================

--- a/engine/code/server/sv_main.c
+++ b/engine/code/server/sv_main.c
@@ -1098,6 +1098,8 @@ void SV_Frame( int msec ) {
 
 	sv.timeResidual += msec;
 
+	SV_GameCheckBotInit();
+
 	if (!com_dedicated->integer) SV_BotFrame (sv.time + sv.timeResidual);
 
 	// if time is about to hit the 32nd bit, kick all clients


### PR DESCRIPTION
## Summary
- expose a GAME_ENABLE_BOTS export that the server uses to re-run bot initialisation when bot_enable is toggled after map load
- centralise bot setup in G_HandleBotEnable so bot_minplayers is registered and repeated startup on dedicated servers is avoided
- document for operators that bots now honour runtime bot_enable changes

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d6bc48daf88324b8243203a067c668