### PR TITLE
Expose bot_enable to sv_game

### DIFF
--- a/engine/code/server/sv_game.c
+++ b/engine/code/server/sv_game.c
@@ -27,6 +27,8 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 
 botlib_export_t	*botlib_export;
 
+extern int	bot_enable;
+
 // these functions must be used instead of pointer arithmetic, because
 // the game allocates gentities with private information after the server shared part
 int	SV_NumForGentity( sharedEntity_t *ent ) {
@@ -929,7 +931,6 @@ Called on a normal map change, not on a map_restart
 void SV_InitGameProgs( void ) {
 	cvar_t	*var;
 	//FIXME these are temp while I make bots run in vm
-	extern int	bot_enable;
 
 	var = Cvar_Get( "bot_enable", "1", CVAR_LATCH );
 	if ( var ) {


### PR DESCRIPTION
## Summary
- declare the `bot_enable` cvar at file scope so both server game entry points can reference it
- drop the redundant local extern inside `SV_InitGameProgs`

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d6f78e93488324a851c16bf53dd43e