### PR TITLE
Fix random bot selection index calculation

### DIFF
--- a/engine/code/game/g_bot.c
+++ b/engine/code/game/g_bot.c
@@ -308,8 +308,13 @@ int G_SelectRandomBotInfo( int team ) {
 	}
 
 	if ( num > 0 ) {
-		num = random() * ( num - 1 );
-		return selection[num];
+		int index;
+
+		index = (int)( random() * num );
+		if ( index >= num ) {
+			index = num - 1;
+		}
+		return selection[index];
 	}
 
 	return -1;


### PR DESCRIPTION
## Summary
- ensure the random bot selector uses a uniform index calculation
- guard against rounding edge cases so the selection index always stays within range

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d6f982ff588324b24986776eb004e0