### PR TITLE
Queue bots that join mid-race

### DIFF
--- a/engine/code/cgame/cg_local.h
+++ b/engine/code/cgame/cg_local.h
@@ -523,6 +523,7 @@ typedef struct {
 	int				clientNum;
 	qboolean		manualShift;
 	qboolean		oppositeRoll;
+	qboolean		pendingParticipant;
 
 	int				position;
 	// vehicle attributes

--- a/engine/code/cgame/cg_main.c
+++ b/engine/code/cgame/cg_main.c
@@ -1982,6 +1982,9 @@ static const char *CG_FeederItemText(float feederID, int index, int column, qhan
 				if ( cg.snap->ps.stats[ STAT_CLIENTS_READY ] & ( 1 << sp->client ) ) {
 					return "Ready";
 				}
+				if ( info->pendingParticipant ) {
+					return "Queued";
+				}
 				if (team == -1) {
 					if (cgs.gametype == GT_TOURNAMENT) {
 						return va("%i/%i", info->wins, info->losses);

--- a/engine/code/cgame/cg_players.c
+++ b/engine/code/cgame/cg_players.c
@@ -1386,6 +1386,8 @@ void CG_NewClientInfo( int clientNum ) {
 	// team leader
 	v = Info_ValueForKey( configstring, "tl" );
 	newInfo.teamLeader = atoi(v);
+	v = Info_ValueForKey( configstring, "pending" );
+	newInfo.pendingParticipant = atoi( v ) ? qtrue : qfalse;
 
 	v = Info_ValueForKey( configstring, "g_redteam" );
 	Q_strncpyz(newInfo.redTeam, v, MAX_TEAMNAME);

--- a/engine/code/game/g_client.c
+++ b/engine/code/game/g_client.c
@@ -1081,18 +1081,18 @@ void ClientUserinfoChanged( int clientNum ) {
 	if (ent->r.svFlags & SVF_BOT)
 	{
 // STONELANCE - UPDATE: change the userinfo string for bots?
-		s = va("n\\%s\\t\\%i\\model\\%s\\hmodel\\%s\\c1\\%s\\c2\\%s\\hc\\%i\\w\\%i\\l\\%i\\skill\\%s\\tt\\%d\\tl\\%d",
+		s = va("n\\%s\\t\\%i\\model\\%s\\hmodel\\%s\\c1\\%s\\c2\\%s\\hc\\%i\\w\\%i\\l\\%i\\skill\\%s\\pending\\%i\\tt\\%d\\tl\\%d",
 			client->pers.netname, client->sess.sessionTeam, model, headModel, c1, c2,
 			client->pers.maxHealth, client->sess.wins, client->sess.losses,
-			Info_ValueForKey( userinfo, "skill" ), teamTask, teamLeader );
+			Info_ValueForKey( userinfo, "skill" ), client->sess.pendingParticipant ? 1 : 0, teamTask, teamLeader );
 	}
 	else
 	{
 // STONELANCE
-		s = va("n\\%s\\t\\%i\\model\\%s\\hmodel\\%s\\rim\\%s\\plate\\%s\\g_redteam\\%s\\g_blueteam\\%s\\c1\\%s\\c2\\%s\\hc\\%i\\w\\%i\\l\\%i\\cm\\%i\\ms\\%i\\tt\\%d\\tl\\%d",
+		s = va("n\\%s\\t\\%i\\model\\%s\\hmodel\\%s\\rim\\%s\\plate\\%s\\g_redteam\\%s\\g_blueteam\\%s\\c1\\%s\\c2\\%s\\hc\\%i\\w\\%i\\l\\%i\\cm\\%i\\ms\\%i\\pending\\%i\\tt\\%d\\tl\\%d",
 			client->pers.netname, client->sess.sessionTeam, model, headModel, rim, plate, redTeam, blueTeam, c1, c2, 
 			client->pers.maxHealth, client->sess.wins, client->sess.losses, 
-			client->pers.controlMode, client->pers.manualShift, teamTask, teamLeader);
+			client->pers.controlMode, client->pers.manualShift, client->sess.pendingParticipant ? 1 : 0, teamTask, teamLeader);
 /*
 		s = va("n\\%s\\t\\%i\\model\\%s\\hmodel\\%s\\g_redteam\\%s\\g_blueteam\\%s\\c1\\%s\\c2\\%s\\hc\\%i\\w\\%i\\l\\%i\\tt\\%d\\tl\\%d",
 			client->pers.netname, client->sess.sessionTeam, model, headModel, redTeam, blueTeam, c1, c2, 
@@ -1135,6 +1135,7 @@ char *ClientConnect( int clientNum, qboolean firstTime, qboolean isBot ) {
 	gclient_t	*client;
 	char		userinfo[MAX_INFO_STRING];
 	gentity_t	*ent;
+	qboolean        raceLocked;
 
 	ent = &g_entities[ clientNum ];
 
@@ -1175,6 +1176,8 @@ char *ClientConnect( int clientNum, qboolean firstTime, qboolean isBot ) {
 	memset( client, 0, sizeof(*client) );
 
 	client->pers.connected = CON_CONNECTING;
+	raceLocked = ( (isRallyRace() || g_gametype.integer == GT_DERBY || g_gametype.integer == GT_LCS) &&
+		level.startRaceTime && level.time >= level.startRaceTime );
 
 	// check for local client
 	value = Info_ValueForKey( userinfo, "ip" );
@@ -1221,6 +1224,9 @@ char *ClientConnect( int clientNum, qboolean firstTime, qboolean isBot ) {
 	// get and distribute relevant parameters
 	G_LogPrintf( "ClientConnect: %i\n", clientNum );
 	ClientUserinfoChanged( clientNum );
+	if ( client->sess.pendingParticipant && isBot && raceLocked ) {
+		CenterPrint_All( va("%s will join on the next restart.", client->pers.netname) );
+	}
 
 	// don't do the "xxx connected" messages if they were caried over from previous level
 	if ( firstTime ) {

--- a/engine/code/game/g_cmds.c
+++ b/engine/code/game/g_cmds.c
@@ -780,6 +780,9 @@ void SetTeam( gentity_t *ent, const char *s ) {
 		AddTournamentQueue(client);
 
 	client->sess.sessionTeam = team;
+	if ( team != TEAM_SPECTATOR ) {
+		client->sess.pendingParticipant = qfalse;
+	}
 	client->sess.spectatorState = specState;
 	client->sess.spectatorClient = specClient;
 // STONELANCE

--- a/engine/code/game/g_local.h
+++ b/engine/code/game/g_local.h
@@ -301,6 +301,7 @@ typedef struct {
 	int			wins, losses;		// tournament stats
 	qboolean	teamLeader;			// true when this client is a team leader
 	qboolean	headlights;			// headlight state persists across restarts
+	qboolean	pendingParticipant;	// queued to join once the next race grid is formed
 } clientSession_t;
 
 //

--- a/engine/code/game/g_rally_racetools.c
+++ b/engine/code/game/g_rally_racetools.c
@@ -636,6 +636,43 @@ void RaceCountdown( char *s, int secondsLeft ){
 	trap_SendServerCommand( -1, va("rc \"%s\" %d", s, secondsLeft) );
 }
 
+static void G_PromotePendingBots( void ) {
+	int	i;
+
+	for ( i = 0; i < level.maxclients; i++ ) {
+		gclient_t *cl = &level.clients[i];
+		gentity_t *bot;
+
+		if ( !cl->sess.pendingParticipant ) {
+			continue;
+		}
+
+		bot = &g_entities[i];
+		if ( !bot->inuse || !bot->client ) {
+			cl->sess.pendingParticipant = qfalse;
+			continue;
+		}
+
+		if ( !( bot->r.svFlags & SVF_BOT ) ) {
+			cl->sess.pendingParticipant = qfalse;
+			continue;
+		}
+
+		if ( bot->client->pers.connected != CON_CONNECTED ) {
+			continue;
+		}
+
+		if ( bot->client->sess.sessionTeam != TEAM_SPECTATOR ) {
+			cl->sess.pendingParticipant = qfalse;
+			continue;
+		}
+
+		cl->sess.pendingParticipant = qfalse;
+		SetTeam( bot, "free" );
+		bot->ready = qtrue;
+	}
+}
+
 void RallyStarter_Think( gentity_t *ent ){
 	gentity_t		*player, *t;
 	int				i, count;
@@ -644,6 +681,8 @@ void RallyStarter_Think( gentity_t *ent ){
 	if (level.startRaceTime){
 		return;
 	}
+
+	G_PromotePendingBots();
 
 	// if no checkpoints dont do start sequence
 	if (isRallyRace()){

--- a/engine/code/game/g_session.c
+++ b/engine/code/game/g_session.c
@@ -45,7 +45,7 @@ void G_WriteClientSessionData( gclient_t *client ) {
 	const char	*s;
 	const char	*var;
 
-	s = va("%i %i %i %i %i %i %i %i", 
+	s = va("%i %i %i %i %i %i %i %i %i", 
 		client->sess.sessionTeam,
 		client->sess.spectatorNum,
 		client->sess.spectatorState,
@@ -53,7 +53,8 @@ void G_WriteClientSessionData( gclient_t *client ) {
 		client->sess.wins,
 		client->sess.losses,
 		client->sess.teamLeader,
-			client->sess.headlights
+			client->sess.headlights,
+			client->sess.pendingParticipant
 			);
 
 	var = va( "session%i", (int)(client - level.clients) );
@@ -75,11 +76,15 @@ void G_ReadSessionData( gclient_t *client ) {
 	int spectatorState;
 	int sessionTeam;
 	int headlights = 0;
+	int pendingParticipant = 0;
+	int parsed;
 
 	var = va( "session%i", (int)(client - level.clients) );
 	trap_Cvar_VariableStringBuffer( var, s, sizeof(s) );
 
-	sscanf( s, "%i %i %i %i %i %i %i %i",
+	client->sess.pendingParticipant = qfalse;
+
+	parsed = sscanf( s, "%i %i %i %i %i %i %i %i %i",
 		&sessionTeam,
 		&client->sess.spectatorNum,
 		&spectatorState,
@@ -87,13 +92,17 @@ void G_ReadSessionData( gclient_t *client ) {
 		&client->sess.wins,
 		&client->sess.losses,
 		&teamLeader,
-			&headlights
+			&headlights,
+			&pendingParticipant,
 			);
 
 	client->sess.sessionTeam = (team_t)sessionTeam;
 	client->sess.spectatorState = (spectatorState_t)spectatorState;
 	client->sess.teamLeader = (qboolean)teamLeader;
 	client->sess.headlights = (qboolean)headlights;
+	if ( parsed >= 9 ) {
+		client->sess.pendingParticipant = (qboolean)pendingParticipant;
+	}
 }
 
 
@@ -107,10 +116,18 @@ Called on a first-time connect
 void G_InitSessionData( gclient_t *client, char *userinfo ) {
 	clientSession_t	*sess;
 	const char		*value;
+	qboolean	raceLocked;
+	qboolean	isBot;
+	gentity_t	*ent;
 
 	sess = &client->sess;
+	ent = &g_entities[client - level.clients];
+	isBot = (ent->r.svFlags & SVF_BOT) ? qtrue : qfalse;
+	raceLocked = ( (isRallyRace() || g_gametype.integer == GT_DERBY || g_gametype.integer == GT_LCS) &&
+		level.startRaceTime && level.time >= level.startRaceTime );
 
 	sess->headlights = qfalse;
+	sess->pendingParticipant = qfalse;
 	// check for team preference, mainly for bots
 	value = Info_ValueForKey( userinfo, "teampref" );
 
@@ -131,9 +148,11 @@ void G_InitSessionData( gclient_t *client, char *userinfo ) {
 // STONELANCE
 		// can only spawn as spectator after race starts
 //		if ( value[0] || g_teamAutoJoin.integer ) {
-		if ( ( value[0] || g_teamAutoJoin.integer ) && !( isRallyRace() && level.startRaceTime ) ) {
+		if ( ( value[0] || g_teamAutoJoin.integer ) && !raceLocked ) {
 // END
 			SetTeam( &g_entities[client - level.clients], value );
+		} else if ( raceLocked && isBot ) {
+			sess->pendingParticipant = qtrue;
 		}
 	} else {
 // STONELANCE
@@ -157,6 +176,9 @@ void G_InitSessionData( gclient_t *client, char *userinfo ) {
                                 }
 				else if (level.startRaceTime){
 					sess->sessionTeam = TEAM_SPECTATOR;
+					if ( raceLocked && isBot ) {
+						sess->pendingParticipant = qtrue;
+					}
 				} else {
 					sess->sessionTeam = TEAM_FREE;
 				}
@@ -169,6 +191,9 @@ void G_InitSessionData( gclient_t *client, char *userinfo ) {
 				}
 				else if (level.startRaceTime){
 					sess->sessionTeam = TEAM_SPECTATOR;
+					if ( raceLocked && isBot ) {
+						sess->pendingParticipant = qtrue;
+					}
 				} else {
 					sess->sessionTeam = TEAM_FREE;
 				}


### PR DESCRIPTION
## Summary
- add a session-level pending participant flag that tracks bots joining mid-race and persists across saves
- promote pending bots onto the grid at the next restart and mark them as ready automatically
- surface the queued state through client configstrings so the HUD and scoreboard indicate when a bot will join

## Testing
- Not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d6fa63ea908324a11c54c203c4e808