### PR TITLE
Remove trailing comma in g_session sscanf call

### DIFF
--- a/engine/code/game/g_session.c
+++ b/engine/code/game/g_session.c
@@ -93,7 +93,7 @@ void G_ReadSessionData( gclient_t *client ) {
 		&client->sess.losses,
 		&teamLeader,
 			&headlights,
-			&pendingParticipant,
+			&pendingParticipant
 			);
 
 	client->sess.sessionTeam = (team_t)sessionTeam;


### PR DESCRIPTION
## Summary
- remove the stray trailing comma from the G_ReadSessionData sscanf invocation to fix formatting

## Testing
- `make` *(fails: missing SDL_version.h header in build environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d70940a18c8324ab6a9b080e5abd9d