### PR TITLE
Ensure bot_enable toggles rebuild BotLib

### DIFF
--- a/engine/code/game/g_main.c
+++ b/engine/code/game/g_main.c
@@ -326,7 +326,7 @@ static void G_HandleBotEnable( int botEnable, qboolean restart ) {
 
 	trap_Cvar_Update( &g_dedicated );
 
-	if ( g_botsInitialized && g_dedicated.integer ) {
+	if ( g_botsInitialized && g_dedicated.integer && !restart ) {
 		return;
 	}
 

--- a/engine/code/server/sv_game.c
+++ b/engine/code/server/sv_game.c
@@ -952,6 +952,8 @@ void SV_InitGameProgs( void ) {
 void SV_GameCheckBotInit( void ) {
 	cvar_t	*var;
 	int			desiredValue;
+	int			previousValue;
+	qboolean			forceRestart;
 	char	latchedValue[MAX_CVAR_VALUE_STRING];
 
 	if ( !gvm ) {
@@ -967,7 +969,9 @@ void SV_GameCheckBotInit( void ) {
 		return;
 	}
 
+	previousValue = bot_enable;
 	desiredValue = var->integer;
+	forceRestart = qfalse;
 
 	if ( var->latchedString ) {
 		Q_strncpyz( latchedValue, var->latchedString, sizeof( latchedValue ) );
@@ -981,7 +985,11 @@ void SV_GameCheckBotInit( void ) {
 
 	bot_enable = desiredValue;
 
-	VM_Call( gvm, GAME_ENABLE_BOTS, bot_enable, qfalse );
+	if ( bot_enable && !previousValue ) {
+		forceRestart = qtrue;
+	}
+
+	VM_Call( gvm, GAME_ENABLE_BOTS, bot_enable, forceRestart );
 
 	if ( !bot_enable ) {
 		return;


### PR DESCRIPTION
## Summary
- ensure `SV_GameCheckBotInit` issues a forced restart when `bot_enable` transitions from 0 to 1 during an active match so the game VM rebuilds BotLib
- allow `G_HandleBotEnable` to treat the restart flag as a forced rebuild and bypass the dedicated-server early return so bot initialization always runs when requested

## Testing
- not run (environment does not support launching the dedicated server with game assets)


------
https://chatgpt.com/codex/tasks/task_e_68d711113ec88324a3efed4e4f5a961c