### PR TITLE
Handle missing BSP entity data safely

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@ renderer_opengl2_x86_64.dll
 SDL264.dll
 engine/Commands for cygwin compile.txt
 Cygwin64 Terminal.lnk
+tests/botlib_missing_entity_data_test
+tests/__pycache__/

--- a/engine/code/botlib/be_aas_bspq3.c
+++ b/engine/code/botlib/be_aas_bspq3.c
@@ -477,10 +477,26 @@ void AAS_DumpBSPData(void)
 //===========================================================================
 int AAS_LoadBSPFile(void)
 {
+	char *entdata;
+
 	AAS_DumpBSPData();
-	bspworld.entdatasize = strlen(botimport.BSPEntityData()) + 1;
+
+	entdata = botimport.BSPEntityData();
+	if (!entdata)
+	{
+		botimport.Print(PRT_ERROR, "AAS_LoadBSPFile: BSP entity data is missing\n");
+		return BLERR_MISSINGENTITYDATA;
+	}
+
+	bspworld.entdatasize = strlen(entdata) + 1;
+	if (bspworld.entdatasize <= 1)
+	{
+		botimport.Print(PRT_ERROR, "AAS_LoadBSPFile: BSP entity data is empty\n");
+		return BLERR_MISSINGENTITYDATA;
+	}
+
 	bspworld.dentdata = (char *) GetClearedHunkMemory(bspworld.entdatasize);
-	Com_Memcpy(bspworld.dentdata, botimport.BSPEntityData(), bspworld.entdatasize);
+	Com_Memcpy(bspworld.dentdata, entdata, bspworld.entdatasize);
 	AAS_ParseBSPEntities();
 	bspworld.loaded = qtrue;
 	return BLERR_NOERROR;

--- a/engine/code/botlib/botlib.h
+++ b/engine/code/botlib/botlib.h
@@ -77,6 +77,7 @@ struct weaponinfo_s;
 #define BLERR_CANNOTLOADITEMCONFIG		10	//cannot load item config
 #define BLERR_CANNOTLOADWEAPONWEIGHTS	11	//cannot load weapon weights
 #define BLERR_CANNOTLOADWEAPONCONFIG	12	//cannot load weapon config
+#define BLERR_MISSINGENTITYDATA			13	//BSP entity data missing or empty
 
 //action flags
 #define ACTION_ATTACK			0x00000001

--- a/tests/botlib_missing_entity_data_test.c
+++ b/tests/botlib_missing_entity_data_test.c
@@ -1,0 +1,104 @@
+#include <assert.h>
+#include <stdarg.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "q_shared.h"
+#include "botlib.h"
+#include "l_script.h"
+
+static int g_print_error_count;
+static const char *g_entity_data;
+
+static void TestPrint(int type, char *fmt, ...) {
+    (void)type;
+    (void)fmt;
+    g_print_error_count++;
+}
+
+static char *TestBSPEntityData(void) {
+    return (char *)g_entity_data;
+}
+
+void *GetClearedHunkMemory(int size) {
+    return calloc(1, (size_t)size);
+}
+
+void *GetHunkMemory(int size) {
+    return calloc(1, (size_t)size);
+}
+
+void FreeMemory(void *ptr) {
+    free(ptr);
+}
+
+void StripDoubleQuotes(char *string) {
+    (void)string;
+}
+
+int PS_ExpectTokenType(script_t *script, int type, int subtype, token_t *token) {
+    (void)script;
+    (void)type;
+    (void)subtype;
+    (void)token;
+    return 0;
+}
+
+script_t *LoadScriptMemory(char *ptr, int length, char *name) {
+    (void)ptr;
+    (void)length;
+    (void)name;
+    return NULL;
+}
+
+void FreeScript(script_t *script) {
+    (void)script;
+}
+
+void SetScriptFlags(script_t *script, int flags) {
+    (void)script;
+    (void)flags;
+}
+
+int PS_ReadToken(script_t *script, token_t *token) {
+    (void)script;
+    (void)token;
+    return 0;
+}
+
+void ScriptError(script_t *script, char *str, ...) {
+    (void)script;
+    (void)str;
+}
+
+void ScriptWarning(script_t *script, char *str, ...) {
+    (void)script;
+    (void)str;
+}
+
+botlib_import_t botimport;
+
+int AAS_LoadBSPFile(void);
+
+int main(void) {
+    memset(&botimport, 0, sizeof(botimport));
+    botimport.Print = TestPrint;
+    botimport.BSPEntityData = TestBSPEntityData;
+
+    g_entity_data = NULL;
+    g_print_error_count = 0;
+    int result = AAS_LoadBSPFile();
+    assert(result == BLERR_MISSINGENTITYDATA);
+    assert(g_print_error_count > 0);
+
+    static const char empty[] = "";
+    g_entity_data = empty;
+    g_print_error_count = 0;
+    result = AAS_LoadBSPFile();
+    assert(result == BLERR_MISSINGENTITYDATA);
+    assert(g_print_error_count > 0);
+
+    puts("ok");
+    return 0;
+}

--- a/tests/test_botlib_missing_entity_data.py
+++ b/tests/test_botlib_missing_entity_data.py
@@ -1,0 +1,31 @@
+import pathlib
+import subprocess
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[1]
+TEST_BINARY = REPO_ROOT / "tests" / "botlib_missing_entity_data_test"
+
+COMPILE_ARGS = [
+    "gcc",
+    str(REPO_ROOT / "tests" / "botlib_missing_entity_data_test.c"),
+    str(REPO_ROOT / "engine" / "code" / "botlib" / "be_aas_bspq3.c"),
+    f"-I{REPO_ROOT / 'engine' / 'code' / 'botlib'}",
+    f"-I{REPO_ROOT / 'engine' / 'code' / 'qcommon'}",
+    f"-I{REPO_ROOT / 'engine' / 'code'}",
+    "-DARCH_STRING=\"test\"",
+    "-DOS_STRING=\"linux\"",
+    "-DID_INLINE=inline",
+    "-DPATH_SEP='/'",
+    "-DDLL_EXT=\".so\"",
+    "-DQ3_LITTLE_ENDIAN",
+    "-o",
+    str(TEST_BINARY),
+]
+
+
+def test_missing_entity_data_regression():
+    subprocess.run(COMPILE_ARGS, check=True)
+    try:
+        result = subprocess.run([str(TEST_BINARY)], check=True, capture_output=True, text=True)
+    finally:
+        TEST_BINARY.unlink(missing_ok=True)
+    assert "ok" in result.stdout


### PR DESCRIPTION
## Summary
- guard AAS_LoadBSPFile against null or empty BSP entity data and log a descriptive error
- add a dedicated BLERR_MISSINGENTITYDATA code for this failure mode
- add a standalone regression test that verifies the botlib aborts cleanly when entity data is missing

## Testing
- pytest tests/test_botlib_missing_entity_data.py

------
https://chatgpt.com/codex/tasks/task_e_68d7124e63f4832485c9b5004555c7ba