### PR TITLE
Add forward declaration for RallyStarter_Think

### DIFF
--- a/engine/code/game/g_rally_racetools.c
+++ b/engine/code/game/g_rally_racetools.c
@@ -24,6 +24,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #include "g_local.h"
 
 static void G_PromotePendingBots( void );
+void RallyStarter_Think( gentity_t *ent );
 
 static void G_ResetRaceTimingForClients( int raceStartTime ) {
 	int i;


### PR DESCRIPTION
## Summary
- add the missing RallyStarter_Think prototype so RallyRace_Think can reference it

## Testing
- make *(fails: SDL_version.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68d722be382083249cfad86fbf7a4fd1