### PR TITLE
Align botlib gametype definitions with shared header

### DIFF
--- a/engine/code/botlib/be_ai_goal.c
+++ b/engine/code/botlib/be_ai_goal.c
@@ -30,6 +30,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
  *****************************************************************************/
 
 #include "../qcommon/q_shared.h"
+#include "../game/bg_public.h"
 #include "l_utils.h"
 #include "l_libvar.h"
 #include "l_memory.h"
@@ -87,24 +88,6 @@ typedef struct campspot_s
 	float random;
 	struct campspot_s *next;
 } campspot_t;
-
-//FIXME: these are game specific
-typedef enum {
-	GT_FFA,				// free for all
-	GT_TOURNAMENT,		// one on one tournament
-	GT_SINGLE_PLAYER,	// single player tournament
-
-	//-- team games go after this --
-
-	GT_TEAM,			// team deathmatch
-	GT_CTF,				// capture the flag
-#ifdef MISSIONPACK
-	GT_1FCTF,
-	GT_OBELISK,
-	GT_HARVESTER,
-#endif
-	GT_MAX_GAME_TYPE
-} gametype_t;
 
 typedef struct levelitem_s
 {

--- a/engine/code/botlib/be_ai_weap.c
+++ b/engine/code/botlib/be_ai_weap.c
@@ -30,6 +30,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
  *****************************************************************************/
 
 #include "../qcommon/q_shared.h"
+#include "../game/bg_public.h"
 #include "l_libvar.h"
 #include "l_log.h"
 #include "l_memory.h"
@@ -130,11 +131,6 @@ static weaponconfig_t *weaponconfig;
 
 // global gametype variable declared in be_ai_goal.c
 extern int g_gametype;
-
-// Q3Rally specific game type not defined in botlib headers
-#ifndef GT_DERBY
-#define GT_DERBY 3
-#endif
 
 //========================================================================
 //


### PR DESCRIPTION
## Summary
- include `bg_public.h` in the botlib so it uses Q3Rally's shared gametype definitions
- remove botlib-local fallbacks for `gametype_t`/`GT_DERBY` so all GT comparisons read the authoritative constants

## Testing
- `make BUILD_CLIENT=0`
- `./build/release-linux-x86_64/q3rally-server.x86_64 +set vm_game 0 +set dedicated 2 +set fs_basepath .. +set fs_homepath ./build/release-linux-x86_64 +set fs_game baseq3r +set g_gametype 3 +map Race_Bot_Test` (checked `serverinfo`)
- `./build/release-linux-x86_64/q3rally-server.x86_64 +set vm_game 0 +set dedicated 2 +set fs_basepath .. +set fs_homepath ./build/release-linux-x86_64 +set fs_game baseq3r +set g_gametype 4 +map Race_Bot_Test` (checked `serverinfo`)


------
https://chatgpt.com/codex/tasks/task_e_68d83461b2748324a815711a4b7fb7d1