### PR TITLE
Handle BSP entity parsing failures

### DIFF
--- a/engine/code/botlib/be_aas_bspq3.c
+++ b/engine/code/botlib/be_aas_bspq3.c
@@ -376,7 +376,7 @@ void AAS_FreeBSPEntities(void)
 // Returns:				-
 // Changes Globals:		-
 //===========================================================================
-void AAS_ParseBSPEntities(void)
+qboolean AAS_ParseBSPEntities(void)
 {
 	script_t *script;
 	token_t token;
@@ -395,7 +395,7 @@ void AAS_ParseBSPEntities(void)
 			ScriptError(script, "invalid %s", token.string);
 			AAS_FreeBSPEntities();
 			FreeScript(script);
-			return;
+			return qfalse;
 		} //end if
 		if (bspworld.numentities >= MAX_BSPENTITIES)
 		{
@@ -416,7 +416,7 @@ void AAS_ParseBSPEntities(void)
 				ScriptError(script, "invalid %s", token.string);
 				AAS_FreeBSPEntities();
 				FreeScript(script);
-				return;
+				return qfalse;
 			} //end if
 			StripDoubleQuotes(token.string);
 			epair->key = (char *) GetHunkMemory(strlen(token.string) + 1);
@@ -425,7 +425,7 @@ void AAS_ParseBSPEntities(void)
 			{
 				AAS_FreeBSPEntities();
 				FreeScript(script);
-				return;
+				return qfalse;
 			} //end if
 			StripDoubleQuotes(token.string);
 			epair->value = (char *) GetHunkMemory(strlen(token.string) + 1);
@@ -436,10 +436,11 @@ void AAS_ParseBSPEntities(void)
 			ScriptError(script, "missing }");
 			AAS_FreeBSPEntities();
 			FreeScript(script);
-			return;
+			return qfalse;
 		} //end if
 	} //end while
 	FreeScript(script);
+	return qtrue;
 } //end of the function AAS_ParseBSPEntities
 //===========================================================================
 //
@@ -497,7 +498,12 @@ int AAS_LoadBSPFile(void)
 
 	bspworld.dentdata = (char *) GetClearedHunkMemory(bspworld.entdatasize);
 	Com_Memcpy(bspworld.dentdata, entdata, bspworld.entdatasize);
-	AAS_ParseBSPEntities();
+	if (!AAS_ParseBSPEntities())
+	{
+		botimport.Print(PRT_ERROR, "AAS_LoadBSPFile: failed to parse BSP entity data\n");
+		AAS_DumpBSPData();
+		return BLERR_MISSINGENTITYDATA;
+	}
 	bspworld.loaded = qtrue;
 	return BLERR_NOERROR;
 } //end of the function AAS_LoadBSPFile

--- a/engine/code/botlib/be_aas_main.c
+++ b/engine/code/botlib/be_aas_main.c
@@ -228,7 +228,9 @@ int AAS_LoadFiles(const char *mapname)
 	// AAS file and BSP file are loaded
 	AAS_ResetEntityLinks();
 	// load bsp info
-	AAS_LoadBSPFile();
+	errnum = AAS_LoadBSPFile();
+	if (errnum != BLERR_NOERROR)
+		return errnum;
 
 	//load the aas file
 	Com_sprintf(aasfile, sizeof(aasfile), "maps/%s.aas", mapname);


### PR DESCRIPTION
## Summary
- return a qboolean from `AAS_ParseBSPEntities` and propagate failures instead of silently returning
- ensure `AAS_LoadBSPFile` logs parse errors, frees the copied entity buffer, and exits early with `BLERR_MISSINGENTITYDATA`
- bail out of `AAS_LoadFiles` when BSP parsing fails so map loading reports the error up the stack

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d847bed1508324ac1479552d7a19ab