### PR TITLE
Preserve fuel level when resetting flipped cars

### DIFF
--- a/engine/code/game/g_rally_tools.c
+++ b/engine/code/game/g_rally_tools.c
@@ -241,7 +241,9 @@ void G_ResetCar( gentity_t *ent ) {
 	VectorCopy(angles, ent->client->ps.viewangles);
 
 //	PM_InitializeVehicle(&ent->client->car, ent->client->ps.origin, ent->client->ps.viewangles, vec3_origin, car_frontweight_dist.value );
-	ent->client->car.initializeOnNextMove = qtrue;
+        // Preserve the car's current fuel level when respawning after a flip.
+        ent->client->car.preserveFuel = qtrue;
+        ent->client->car.initializeOnNextMove = qtrue;
 
 	ent->client->ps.eFlags ^= EF_TELEPORT_BIT;
 


### PR DESCRIPTION
## Summary
- ensure car fuel state is preserved when triggering a flip reset
- mark vehicles to retain their current fuel before they are reinitialized

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d87ce1ca448324a74487934ac0fc4f