### PR TITLE
Avoid redundant client configstring updates

### DIFF
--- a/engine/Makefile
+++ b/engine/Makefile
@@ -2818,6 +2818,7 @@ Q3GOBJ_ = \
   $(B)/$(BASEGAME)/game/g_arenas.o \
   $(B)/$(BASEGAME)/game/g_bot.o \
   $(B)/$(BASEGAME)/game/g_client.o \
+  $(B)/$(BASEGAME)/game/g_client_userinfo.o \
   $(B)/$(BASEGAME)/game/g_cmds.o \
   $(B)/$(BASEGAME)/game/g_combat.o \
   $(B)/$(BASEGAME)/game/g_items.o \
@@ -2879,6 +2880,7 @@ MPGOBJ_ = \
   $(B)/$(MISSIONPACK)/game/g_arenas.o \
   $(B)/$(MISSIONPACK)/game/g_bot.o \
   $(B)/$(MISSIONPACK)/game/g_client.o \
+  $(B)/$(MISSIONPACK)/game/g_client_userinfo.o \
   $(B)/$(MISSIONPACK)/game/g_cmds.o \
   $(B)/$(MISSIONPACK)/game/g_combat.o \
   $(B)/$(MISSIONPACK)/game/g_items.o \

--- a/engine/code/game/g_client.c
+++ b/engine/code/game/g_client.c
@@ -22,6 +22,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 */
 //
 #include "g_local.h"
+#include "g_client_userinfo.h"
 #include "../botlib/be_aas.h"
 
 extern vmCvar_t g_dominationSpawnStyle;
@@ -1101,10 +1102,10 @@ void ClientUserinfoChanged( int clientNum ) {
 // END
 	}
 
-	trap_SetConfigstring( CS_PLAYERS+clientNum, s );
-
-	// this is not the userinfo, more like the configstring actually
-	G_LogPrintf( "ClientUserinfoChanged: %i %s\n", clientNum, s );
+        if ( G_SetClientConfigstringIfChanged( clientNum, s ) ) {
+                // this is not the userinfo, more like the configstring actually
+                G_LogPrintf( "ClientUserinfoChanged: %i %s\n", clientNum, s );
+        }
 	G_BalanceVehicleStats();
 }
 

--- a/engine/code/game/g_client_userinfo.c
+++ b/engine/code/game/g_client_userinfo.c
@@ -1,0 +1,17 @@
+#include "g_local.h"
+#include "g_client_userinfo.h"
+
+#include <string.h>
+
+qboolean G_SetClientConfigstringIfChanged( int clientNum, const char *playerConfigString ) {
+    char currentConfigString[MAX_INFO_STRING];
+
+    trap_GetConfigstring( CS_PLAYERS + clientNum, currentConfigString, sizeof( currentConfigString ) );
+
+    if ( strcmp( currentConfigString, playerConfigString ) == 0 ) {
+        return qfalse;
+    }
+
+    trap_SetConfigstring( CS_PLAYERS + clientNum, playerConfigString );
+    return qtrue;
+}

--- a/engine/code/game/g_client_userinfo.h
+++ b/engine/code/game/g_client_userinfo.h
@@ -1,0 +1,9 @@
+#ifndef G_CLIENT_USERINFO_H
+#define G_CLIENT_USERINFO_H
+
+#include "../qcommon/q_shared.h"
+#include "bg_public.h"
+
+qboolean G_SetClientConfigstringIfChanged( int clientNum, const char *playerConfigString );
+
+#endif // G_CLIENT_USERINFO_H

--- a/engine/misc/msvc/game.vcproj
+++ b/engine/misc/msvc/game.vcproj
@@ -1040,6 +1040,48 @@
 					/>
 				</FileConfiguration>
 			</File>
+				<File
+					RelativePath="..\\..\\code\\game\\g_client_userinfo.c"
+					>
+					<FileConfiguration
+						Name="Debug TA|Win32"
+						>
+						<Tool
+							Name="VCCLCompilerTool"
+							Optimization="0"
+							PreprocessorDefinitions="WIN32;_DEBUG;_WINDOWS;BUILDING_REF_GL;DEBUG;MISSIONPACK;QAGAME;"
+							BrowseInformation="1"
+						/>
+					</FileConfiguration>
+					<FileConfiguration
+						Name="Debug|Win32"
+						>
+						<Tool
+							Name="VCCLCompilerTool"
+							Optimization="0"
+							PreprocessorDefinitions="WIN32;_DEBUG;_WINDOWS;BUILDING_REF_GL;DEBUG;GLOBALRANK;"
+							BrowseInformation="1"
+						/>
+					</FileConfiguration>
+					<FileConfiguration
+						Name="Release|Win32"
+						>
+						<Tool
+							Name="VCCLCompilerTool"
+							Optimization="2"
+							PreprocessorDefinitions="WIN32;NDEBUG;_WINDOWS;GLOBALRANK;"
+						/>
+					</FileConfiguration>
+					<FileConfiguration
+						Name="Release TA|Win32"
+						>
+						<Tool
+							Name="VCCLCompilerTool"
+							Optimization="2"
+							PreprocessorDefinitions="WIN32;NDEBUG;_WINDOWS;MISSIONPACK;"
+						/>
+					</FileConfiguration>
+				</File>
 			<File
 				RelativePath="..\..\code\game\g_cmds.c"
 				>

--- a/engine/misc/msvc10/game.vcxproj
+++ b/engine/misc/msvc10/game.vcxproj
@@ -550,6 +550,28 @@
       <PreprocessorDefinitions Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">WIN32;NDEBUG;_WINDOWS;GLOBALRANK;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <PreprocessorDefinitions Condition="'$(Configuration)|$(Platform)'=='Release|x64'">WIN32;NDEBUG;_WINDOWS;GLOBALRANK;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
+    <ClCompile Include="..\\..\\code\\game\\g_client_userinfo.c">
+      <Optimization Condition="'$(Configuration)|$(Platform)'=='Debug TA|Win32'">Disabled</Optimization>
+      <Optimization Condition="'$(Configuration)|$(Platform)'=='Debug TA|x64'">Disabled</Optimization>
+      <PreprocessorDefinitions Condition="'$(Configuration)|$(Platform)'=='Debug TA|Win32'">WIN32;_DEBUG;_WINDOWS;BUILDING_REF_GL;DEBUG;MISSIONPACK;QAGAME;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions Condition="'$(Configuration)|$(Platform)'=='Debug TA|x64'">WIN32;_DEBUG;_WINDOWS;BUILDING_REF_GL;DEBUG;MISSIONPACK;QAGAME;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <BrowseInformation Condition="'$(Configuration)|$(Platform)'=='Debug TA|Win32'">true</BrowseInformation>
+      <BrowseInformation Condition="'$(Configuration)|$(Platform)'=='Debug TA|x64'">true</BrowseInformation>
+      <Optimization Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">Disabled</Optimization>
+      <Optimization Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">Disabled</Optimization>
+      <PreprocessorDefinitions Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">WIN32;_DEBUG;_WINDOWS;BUILDING_REF_GL;DEBUG;GLOBALRANK;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">WIN32;_DEBUG;_WINDOWS;BUILDING_REF_GL;DEBUG;GLOBALRANK;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <BrowseInformation Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</BrowseInformation>
+      <BrowseInformation Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</BrowseInformation>
+      <Optimization Condition="'$(Configuration)|$(Platform)'=='Release TA|Win32'">MaxSpeed</Optimization>
+      <Optimization Condition="'$(Configuration)|$(Platform)'=='Release TA|x64'">MaxSpeed</Optimization>
+      <PreprocessorDefinitions Condition="'$(Configuration)|$(Platform)'=='Release TA|Win32'">WIN32;NDEBUG;_WINDOWS;MISSIONPACK;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions Condition="'$(Configuration)|$(Platform)'=='Release TA|x64'">WIN32;NDEBUG;_WINDOWS;MISSIONPACK;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <Optimization Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">MaxSpeed</Optimization>
+      <Optimization Condition="'$(Configuration)|$(Platform)'=='Release|x64'">MaxSpeed</Optimization>
+      <PreprocessorDefinitions Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">WIN32;NDEBUG;_WINDOWS;GLOBALRANK;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions Condition="'$(Configuration)|$(Platform)'=='Release|x64'">WIN32;NDEBUG;_WINDOWS;GLOBALRANK;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
     <ClCompile Include="..\..\code\game\ai_cmd.c">
       <Optimization Condition="'$(Configuration)|$(Platform)'=='Debug TA|Win32'">Disabled</Optimization>
       <Optimization Condition="'$(Configuration)|$(Platform)'=='Debug TA|x64'">Disabled</Optimization>

--- a/engine/misc/msvc142/game.vcxproj
+++ b/engine/misc/msvc142/game.vcxproj
@@ -454,6 +454,18 @@
       <Optimization Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">MaxSpeed</Optimization>
       <PreprocessorDefinitions Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">WIN32;NDEBUG;_WINDOWS;GLOBALRANK;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
+    <ClCompile Include="..\..\code\game\g_client_userinfo.c">
+      <Optimization Condition="'$(Configuration)|$(Platform)'=='Debug TA|Win32'">Disabled</Optimization>
+      <PreprocessorDefinitions Condition="'$(Configuration)|$(Platform)'=='Debug TA|Win32'">WIN32;_DEBUG;_WINDOWS;BUILDING_REF_GL;DEBUG;MISSIONPACK;QAGAME;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <BrowseInformation Condition="'$(Configuration)|$(Platform)'=='Debug TA|Win32'">true</BrowseInformation>
+      <Optimization Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">Disabled</Optimization>
+      <PreprocessorDefinitions Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">WIN32;_DEBUG;_WINDOWS;BUILDING_REF_GL;DEBUG;GLOBALRANK;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <BrowseInformation Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</BrowseInformation>
+      <Optimization Condition="'$(Configuration)|$(Platform)'=='Release TA|Win32'">MaxSpeed</Optimization>
+      <PreprocessorDefinitions Condition="'$(Configuration)|$(Platform)'=='Release TA|Win32'">WIN32;NDEBUG;_WINDOWS;MISSIONPACK;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <Optimization Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">MaxSpeed</Optimization>
+      <PreprocessorDefinitions Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">WIN32;NDEBUG;_WINDOWS;GLOBALRANK;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
     <ClCompile Include="..\..\code\game\g_cmds.c">
       <Optimization Condition="'$(Configuration)|$(Platform)'=='Debug TA|Win32'">Disabled</Optimization>
       <PreprocessorDefinitions Condition="'$(Configuration)|$(Platform)'=='Debug TA|Win32'">WIN32;_DEBUG;_WINDOWS;BUILDING_REF_GL;DEBUG;MISSIONPACK;QAGAME;%(PreprocessorDefinitions)</PreprocessorDefinitions>

--- a/tests/clientuserinfochanged_test.c
+++ b/tests/clientuserinfochanged_test.c
@@ -1,0 +1,47 @@
+#include <assert.h>
+#include <stdio.h>
+#include <string.h>
+
+#include "g_client_userinfo.h"
+
+static char g_configstring[MAX_INFO_STRING];
+static int g_last_config_index;
+static int g_set_call_count;
+
+void trap_GetConfigstring( int num, char *buffer, int bufferSize ) {
+    assert( num == CS_PLAYERS + g_last_config_index );
+    (void)bufferSize;
+    strncpy( buffer, g_configstring, (size_t)bufferSize );
+    buffer[bufferSize - 1] = '\0';
+}
+
+void trap_SetConfigstring( int num, const char *string ) {
+    assert( num == CS_PLAYERS + g_last_config_index );
+    strncpy( g_configstring, string, sizeof( g_configstring ) );
+    g_configstring[sizeof( g_configstring ) - 1] = '\0';
+    g_set_call_count++;
+}
+
+int main( void ) {
+    static const char first_value[] = "n\\Player\\t\\1";
+    static const char second_value[] = "n\\Player\\t\\2";
+
+    memset( g_configstring, 0, sizeof( g_configstring ) );
+    g_last_config_index = 0;
+    g_set_call_count = 0;
+
+    assert( G_SetClientConfigstringIfChanged( g_last_config_index, first_value ) );
+    assert( g_set_call_count == 1 );
+    assert( strcmp( g_configstring, first_value ) == 0 );
+
+    assert( !G_SetClientConfigstringIfChanged( g_last_config_index, first_value ) );
+    assert( g_set_call_count == 1 );
+    assert( strcmp( g_configstring, first_value ) == 0 );
+
+    assert( G_SetClientConfigstringIfChanged( g_last_config_index, second_value ) );
+    assert( g_set_call_count == 2 );
+    assert( strcmp( g_configstring, second_value ) == 0 );
+
+    puts( "ok" );
+    return 0;
+}

--- a/tests/test_clientuserinfochanged.py
+++ b/tests/test_clientuserinfochanged.py
@@ -1,0 +1,31 @@
+import pathlib
+import subprocess
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[1]
+TEST_BINARY = REPO_ROOT / "tests" / "clientuserinfochanged_test"
+
+COMPILE_ARGS = [
+    "gcc",
+    str(REPO_ROOT / "tests" / "clientuserinfochanged_test.c"),
+    str(REPO_ROOT / "engine" / "code" / "game" / "g_client_userinfo.c"),
+    "-I" + str(REPO_ROOT / "engine" / "code" / "game"),
+    "-I" + str(REPO_ROOT / "engine" / "code" / "qcommon"),
+    "-I" + str(REPO_ROOT / "engine" / "code"),
+    "-DARCH_STRING=\"test\"",
+    "-DOS_STRING=\"linux\"",
+    "-DID_INLINE=inline",
+    "-DPATH_SEP='/'",
+    "-DDLL_EXT=\".so\"",
+    "-DQ3_LITTLE_ENDIAN",
+    "-o",
+    str(TEST_BINARY),
+]
+
+
+def test_clientuserinfochanged_configstring_updates_only_on_changes():
+    subprocess.run(COMPILE_ARGS, check=True)
+    try:
+        result = subprocess.run([str(TEST_BINARY)], check=True, capture_output=True, text=True)
+    finally:
+        TEST_BINARY.unlink(missing_ok=True)
+    assert "ok" in result.stdout


### PR DESCRIPTION
## Summary
- compare the generated client configstring with the current value and only push/log when it changes
- add a helper module plus regression test infrastructure to cover the configstring update behavior

## Testing
- pytest tests/test_clientuserinfochanged.py

------
https://chatgpt.com/codex/tasks/task_e_68d9668e76f08324b600fd7ff6c78377