### PR TITLE
Guard g_client_userinfo string header for VM builds

### DIFF
--- a/engine/code/game/g_client_userinfo.c
+++ b/engine/code/game/g_client_userinfo.c
@@ -1,7 +1,11 @@
 #include "g_local.h"
 #include "g_client_userinfo.h"
 
+#ifdef Q3_VM
+#include "bg_lib.h"
+#else
 #include <string.h>
+#endif
 
 qboolean G_SetClientConfigstringIfChanged( int clientNum, const char *playerConfigString ) {
     char currentConfigString[MAX_INFO_STRING];


### PR DESCRIPTION
## Summary
- conditionally include bg_lib.h in g_client_userinfo when compiling for the Quake III VM, falling back to string.h for native builds

## Testing
- make release *(fails: missing SDL_version.h in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d96e82b588832491e3f96396258bab