### PR TITLE
Add vehicle and bot metadata to ladder payload

### DIFF
--- a/engine/code/game/g_main.c
+++ b/engine/code/game/g_main.c
@@ -1775,6 +1775,7 @@ void LogExit( const char *string ) {
 			Com_Memset( entry, 0, sizeof( *entry ) );
 			entry->clientNum = level.sortedClients[i];
 			entry->team = cl->sess.sessionTeam;
+			entry->isBot = ( g_entities[level.sortedClients[i]].r.svFlags & SVF_BOT ) ? qtrue : qfalse;
 			entry->score = cl->ps.persistant[PERS_SCORE];
 			entry->ping = ping;
 			entry->time = timePlayed;
@@ -1830,6 +1831,7 @@ void LogExit( const char *string ) {
 			}
 			if ( model ) {
 				Q_strncpyz( entry->model, model, sizeof( entry->model ) );
+				Q_strncpyz( entry->vehicle, model, sizeof( entry->vehicle ) );
 			}
 			G_LadderComputePlayerId( entry->guid, entry->cleanName, entry->playerId, sizeof( entry->playerId ) );
 		}

--- a/engine/code/game/g_public.h
+++ b/engine/code/game/g_public.h
@@ -36,6 +36,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #define	LADDER_MAX_GUID			64
 #define	LADDER_MAX_PLAYER_NAME	64
 #define	LADDER_MAX_MODEL_NAME	64
+#define	LADDER_MAX_VEHICLE_NAME	64
 
 #ifndef RACE_MAX_RECORDED_LAPS
 #define RACE_MAX_RECORDED_LAPS	64
@@ -121,7 +122,9 @@ typedef struct {
 	char	name[LADDER_MAX_PLAYER_NAME];
 	char	cleanName[LADDER_MAX_PLAYER_NAME];
 	char	model[LADDER_MAX_MODEL_NAME];
+	char	vehicle[LADDER_MAX_VEHICLE_NAME];
 	int				team;
+	qboolean			isBot;
 	int				score;
 	int				ping;
 	int				time;

--- a/engine/code/server/sv_ladder.c
+++ b/engine/code/server/sv_ladder.c
@@ -429,8 +429,16 @@ static qboolean SV_LadderJsonAppendPlayer( ladderJsonBuilder_t *builder, const l
              !SV_LadderJsonAppendString( builder, player->model ) ) {
                 return qfalse;
         }
+        if ( !SV_LadderJsonAppendKey( builder, "vehicle", &first ) ||
+             !SV_LadderJsonAppendString( builder, player->vehicle ) ) {
+                return qfalse;
+        }
         if ( !SV_LadderJsonAppendKey( builder, "team", &first ) ||
              !SV_LadderJsonAppendInt( builder, player->team ) ) {
+                return qfalse;
+        }
+        if ( !SV_LadderJsonAppendKey( builder, "isBot", &first ) ||
+             !SV_LadderJsonAppendBoolean( builder, player->isBot ) ) {
                 return qfalse;
         }
         if ( !SV_LadderJsonAppendKey( builder, "score", &first ) ||


### PR DESCRIPTION
## Summary
- extend ladder player payloads with vehicle and isBot fields
- populate the new fields from userinfo/model data when matches end
- serialize vehicle and bot status in ladder JSON output

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68daec65b3d48324aeea495056b36b46