### PR TITLE
Guard silent item pickup sounds

### DIFF
--- a/engine/code/cgame/cg_event.c
+++ b/engine/code/cgame/cg_event.c
@@ -978,7 +978,7 @@ void CG_EntityEvent( centity_t *cent, vec3_t position ) {
 					break;
 				}
 #endif
-			} else {
+			} else if ( item->pickup_sound && item->pickup_sound[0] ) {
 				trap_S_StartSound (NULL, es->number, CHAN_AUTO,	trap_S_RegisterSound( item->pickup_sound, qfalse ) );
 			}
 


### PR DESCRIPTION
## Summary
- guard the EV_ITEM_PICKUP sound registration so silent items no longer attempt to register null pickup sounds

## Testing
- make *(fails: missing SDL_version.h in build environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dcab44dd3083248c592c60dbc8b2e7