### PR TITLE
Display DNF status on scoreboard and HUD

### DIFF
--- a/engine/code/cgame/cg_rally_hud.c
+++ b/engine/code/cgame/cg_rally_hud.c
@@ -23,6 +23,18 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 
 #include "cg_local.h"
 
+static qboolean CG_ClientIsDNF(int clientNum) {
+        int i;
+
+        for (i = 0; i < cg.numScores; i++) {
+                if (cg.scores[i].client == clientNum) {
+                        return (cg.scores[i].scoreFlags & SCORE_FLAG_DNF) ? qtrue : qfalse;
+                }
+        }
+
+        return qfalse;
+}
+
 float colors[4][4] = { 
 //		{ 0.2, 1.0, 0.2, 1.0 } , { 1.0, 0.2, 0.2, 1.0 }, {0.5, 0.5, 0.5, 1} };
 		{ 1.0f, 0.69f, 0.0f, 1.0f } ,	  // normal
@@ -500,7 +512,11 @@ static float CG_DrawTimes( float y ) {
 	// Total Time
 	//
 
-	time = getStringForTime(totalTime);
+	if (CG_ClientIsDNF(cg.snap->ps.clientNum)) {
+		time = "DNF";
+	} else {
+		time = getStringForTime(totalTime);
+	}
 
 	{
 		const char *label = "T:";
@@ -874,7 +890,11 @@ void CG_DrawHUD_DerbyList(float x, float y){
 		else if (cent->startRaceTime){
 			playTime = cg.time - cent->startLapTime;
 		}
-		time = getStringForTime(playTime);
+		if (cg.scores[i].scoreFlags & SCORE_FLAG_DNF) {
+			time = "DNF";
+		} else {
+			time = getStringForTime(playTime);
+		}
 
 		// num
 		CG_DrawTinyStringColor( x + 6, y, va("0%i", (i+1)), color);

--- a/engine/code/cgame/cg_rally_hud2.c
+++ b/engine/code/cgame/cg_rally_hud2.c
@@ -23,6 +23,18 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 
 #include "cg_local.h"
 
+static qboolean CG_ClientIsDNF(int clientNum) {
+        int i;
+
+        for (i = 0; i < cg.numScores; i++) {
+                if (cg.scores[i].client == clientNum) {
+                        return (cg.scores[i].scoreFlags & SCORE_FLAG_DNF) ? qtrue : qfalse;
+                }
+        }
+
+        return qfalse;
+}
+
 /*
 =================
 CG_DrawHUD_Times
@@ -86,7 +98,11 @@ void CG_DrawHUD_Times(float x, float y){
 
 	// draw total time
 	CG_DrawSmallDigitalStringColor(x + 12, y, "TOTAL:", colorWhite);
-	time = getStringForTime( totalTime );
+	if (CG_ClientIsDNF(cg.snap->ps.clientNum)) {
+		time = "DNF";
+	} else {
+		time = getStringForTime( totalTime );
+	}
 	CG_DrawSmallDigitalStringColor(x + 102, y, time, colorWhite);
 
 	y += 20;
@@ -537,7 +553,11 @@ void CG_DrawHUD_DerbyList(float x, float y){
 		else if (cent->startRaceTime){
 			playTime = cg.time - cent->startLapTime;
 		}
-		time = getStringForTime(playTime);
+		if (cg.scores[i].scoreFlags & SCORE_FLAG_DNF) {
+			time = "DNF";
+		} else {
+			time = getStringForTime(playTime);
+		}
 
 		// num
 		CG_DrawTinyStringColor( x + 2, y, va("%i", (i+1)), color);

--- a/engine/code/cgame/cg_scoreboard.c
+++ b/engine/code/cgame/cg_scoreboard.c
@@ -1343,6 +1343,10 @@ static int CG_CalculateScoreTotalTime(const score_t *score, qboolean isRacingMod
         return 0;
     }
 
+    if (score->scoreFlags & SCORE_FLAG_DNF) {
+        return INT_MAX;
+    }
+
     cent = &cg_entities[score->client];
 
     if (cent->finishRaceTime) {
@@ -2015,21 +2019,11 @@ static void CG_DrawColumnData(sbColumn_t colType, int x, int y, int width,
             if (ci->team == TEAM_SPECTATOR) {
                 CG_DrawModernText(x, y, "-", 1, width, textColor, qfalse);
             } else {
-                if (cent->finishRaceTime) {
-                    if (isRacingMode && cgs.laplimit <= 1 && cent->startLapTime > 0) {
-                        totalTime = cent->finishRaceTime - cent->startLapTime;
-                    } else {
-                        totalTime = cent->finishRaceTime - score->time;
-                    }
-                } else if (isRacingMode && cgs.laplimit <= 1 && cent->startLapTime > 0) {
-                    totalTime = cg.time - cent->startLapTime;
-                } else if (score->time) {
-                    totalTime = cg.time - score->time;
-                } else {
-                    totalTime = 0;
-                }
-                
-                if (totalTime > 0) {
+                totalTime = CG_CalculateScoreTotalTime(score, isRacingMode);
+
+                if (totalTime == INT_MAX) {
+                    CG_DrawModernText(x, y, "DNF", 1, width, textColor, qfalse);
+                } else if (totalTime > 0) {
                     timeStr = getStringForTime(totalTime);
                     CG_DrawModernText(x, y, timeStr, 1, width, textColor, qfalse);
                 } else {


### PR DESCRIPTION
## Summary
- surface the SCORE_FLAG_DNF state when drawing the scoreboard total time column
- add client-side helpers so HUD time readouts show "DNF" once a racer is eliminated
- ensure derby list entries replace lap totals with the DNF marker

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dd7903c1e083248ffacba35bc1933e