### PR TITLE
Add shared SCORE_FLAG_DNF constant

### DIFF
--- a/engine/code/game/bg_public.h
+++ b/engine/code/game/bg_public.h
@@ -50,6 +50,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #define LIGHTNING_RANGE         768
 
 #define SCORE_NOT_PRESENT       -9999   // for the CS_SCORES[12] when only one player is present
+#define SCORE_FLAG_DNF          0x00000001     // indicates a racer did not finish
 
 #define VOTE_TIME                       30000   // 30 seconds before vote times out
 


### PR DESCRIPTION
## Summary
- define SCORE_FLAG_DNF in bg_public.h so both game and cgame share the flag definition

## Testing
- `make` *(fails: missing SDL_version.h in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dd848fb79483248e8868a8151fdac0