### PR TITLE
Add DNF scoreboard flag propagation

### DIFF
--- a/engine/code/game/g_client.c
+++ b/engine/code/game/g_client.c
@@ -1262,6 +1262,7 @@ void ClientBegin( int clientNum ) {
 	client->ladderEliminationRound = 0;
 	client->ladderEliminationPlayersRemaining = 0;
 	client->ladderEliminationMetric = 0.0f;
+	client->didNotFinish = qfalse;
 
 	// save eflags around this, because changing teams will
 	// cause this to happen with a valid entity, and we

--- a/engine/code/game/g_cmds.c
+++ b/engine/code/game/g_cmds.c
@@ -49,7 +49,6 @@ void DeathmatchScoreboardMessage( gentity_t *ent ) {
 	// send the latest information on all clients
 	string[0] = 0;
 	stringlength = 0;
-	scoreFlags = 0;
 
 	numSorted = level.numConnectedClients;
 	
@@ -60,6 +59,11 @@ void DeathmatchScoreboardMessage( gentity_t *ent ) {
 // END
 
 		cl = &level.clients[level.sortedClients[i]];
+
+		scoreFlags = 0;
+		if ( cl->didNotFinish ) {
+			scoreFlags |= SCORE_FLAG_DNF;
+		}
 
 // STONELANCE
 		if ( isRallyRace() || g_gametype.integer == GT_DERBY || g_gametype.integer == GT_LCS ) {

--- a/engine/code/game/g_local.h
+++ b/engine/code/game/g_local.h
@@ -409,6 +409,7 @@ struct gclient_s {
 
 	// race variables
 	int			finishRaceTime;
+	qboolean		didNotFinish;
 	int			ladderBestLapMs;
 	int			ladderTotalRaceMs;
 	int			ladderLastLapStartMs;

--- a/engine/code/game/g_main.c
+++ b/engine/code/game/g_main.c
@@ -1662,6 +1662,27 @@ void LogExit( const char *string ) {
 
 	trap_SetConfigstring( CS_INTERMISSION, "1" );
 
+	if ( isRallyRace() && level.startRaceTime ) {
+		for ( i = 0; i < level.maxclients; i++ ) {
+			gclient_t *client = &level.clients[i];
+
+			if ( client->pers.connected != CON_CONNECTED ) {
+				continue;
+			}
+
+			if ( client->sess.sessionTeam == TEAM_SPECTATOR || isRaceObserver( i ) ) {
+				client->didNotFinish = qfalse;
+				continue;
+			}
+
+			if ( client->finishRaceTime > 0 ) {
+				client->didNotFinish = qfalse;
+			} else {
+				client->didNotFinish = qtrue;
+			}
+		}
+	}
+
 	numSorted = level.numConnectedClients;
 	if ( numSorted > 32 ) {
 		numSorted = 32;
@@ -1778,6 +1799,7 @@ void LogExit( const char *string ) {
 			entry->isBot = ( g_entities[level.sortedClients[i]].r.svFlags & SVF_BOT ) ? qtrue : qfalse;
 			entry->score = cl->ps.persistant[PERS_SCORE];
 			entry->ping = ping;
+			entry->scoreFlags = cl->didNotFinish ? SCORE_FLAG_DNF : 0;
 			entry->time = timePlayed;
 			entry->powerUps = g_entities[level.sortedClients[i]].s.powerups;
 			entry->accuracy = cl->accuracy_shots ? ( cl->accuracy_hits * 100 / cl->accuracy_shots ) : 0;

--- a/engine/code/game/g_rally_racetools.c
+++ b/engine/code/game/g_rally_racetools.c
@@ -35,6 +35,7 @@ static void G_ResetRaceTimingForClients( int raceStartTime ) {
 
                 cl->ladderBestLapMs = 0;
                 cl->ladderTotalRaceMs = 0;
+                cl->didNotFinish = qfalse;
                 cl->ladderLapCount = 0;
                 cl->ladderLastLapStartMs = raceStartTime;
                 Com_Memset( cl->ladderLapTimes, 0, sizeof( cl->ladderLapTimes ) );


### PR DESCRIPTION
## Summary
- recompute per-client scoreboard flags in `DeathmatchScoreboardMessage` and send the DNF bit when marked
- track a `didNotFinish` flag on `gclient_t`, resetting it on race start and setting it for racers who miss the finish
- include the flag in ladder payloads so downstream consumers receive the same state

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dd85856fe88324b01e00359b7f0212