### PR TITLE
Refactor DNF check into shared helper

### DIFF
--- a/engine/code/cgame/cg_local.h
+++ b/engine/code/cgame/cg_local.h
@@ -1985,6 +1985,7 @@ void CG_Draw3DBezierCurve( vec3_t start, vec3_t startDir, vec3_t end, vec3_t end
 
 float Q3VelocityToRL(float length);
 float Q3DistanceToRL(float length);
+qboolean CG_ClientIsDNF( int clientNum );
 qboolean isRallyRace( void );
 qboolean isRallyNonDMRace( void );
 qboolean isRaceObserver( int clientNum );

--- a/engine/code/cgame/cg_rally_hud.c
+++ b/engine/code/cgame/cg_rally_hud.c
@@ -23,19 +23,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 
 #include "cg_local.h"
 
-static qboolean CG_ClientIsDNF(int clientNum) {
-        int i;
-
-        for (i = 0; i < cg.numScores; i++) {
-                if (cg.scores[i].client == clientNum) {
-                        return (cg.scores[i].scoreFlags & SCORE_FLAG_DNF) ? qtrue : qfalse;
-                }
-        }
-
-        return qfalse;
-}
-
-float colors[4][4] = { 
+float colors[4][4] = {
 //		{ 0.2, 1.0, 0.2, 1.0 } , { 1.0, 0.2, 0.2, 1.0 }, {0.5, 0.5, 0.5, 1} };
 		{ 1.0f, 0.69f, 0.0f, 1.0f } ,	  // normal
 		{ 1.0f, 0.2f, 0.2f, 1.0f },	      // low health

--- a/engine/code/cgame/cg_rally_hud2.c
+++ b/engine/code/cgame/cg_rally_hud2.c
@@ -23,18 +23,6 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 
 #include "cg_local.h"
 
-static qboolean CG_ClientIsDNF(int clientNum) {
-        int i;
-
-        for (i = 0; i < cg.numScores; i++) {
-                if (cg.scores[i].client == clientNum) {
-                        return (cg.scores[i].scoreFlags & SCORE_FLAG_DNF) ? qtrue : qfalse;
-                }
-        }
-
-        return qfalse;
-}
-
 /*
 =================
 CG_DrawHUD_Times

--- a/engine/code/cgame/cg_rally_tools.c
+++ b/engine/code/cgame/cg_rally_tools.c
@@ -24,6 +24,19 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #include "cg_local.h"
 
 
+qboolean CG_ClientIsDNF( int clientNum ) {
+        int i;
+
+        for ( i = 0; i < cg.numScores; i++ ) {
+                if ( cg.scores[i].client == clientNum ) {
+                        return ( cg.scores[i].scoreFlags & SCORE_FLAG_DNF ) ? qtrue : qfalse;
+                }
+        }
+
+        return qfalse;
+}
+
+
 void CG_DrawCheckpointLinks(void)
 {
 	int			i, j;


### PR DESCRIPTION
## Summary
- add a shared `CG_ClientIsDNF` helper in cg_rally_tools and declare it in cg_local
- update both HUD files to call the shared helper and remove their duplicate implementations

## Testing
- make -C engine BUILD_CLIENT=0 BUILD_SERVER=0 BUILD_GAME_SO=0 BUILD_GAME_QVM=1


------
https://chatgpt.com/codex/tasks/task_e_68dd8cba37788324a06298bd974772d8