### PR TITLE
Implement out-of-fuel event and adjust HUD messages

### DIFF
--- a/engine/code/cgame/cg_event.c
+++ b/engine/code/cgame/cg_event.c
@@ -513,10 +513,10 @@ static void CG_UseItem( centity_t *cent ) {
 	// print a message if the local player
 	if ( es->number == cg.snap->ps.clientNum ) {
 		if ( !itemNum ) {
-			CG_CenterPrint( "No item in your trunk", SCREEN_HEIGHT * 0.30, BIGCHAR_WIDTH );
+			CG_CenterPrint( "No item in your trunk", SCREEN_HEIGHT * 0.42f, BIGCHAR_WIDTH );
 		} else {
 			item = BG_FindItemForHoldable( itemNum );
-			CG_CenterPrint( va("Use %s", item->pickup_name), SCREEN_HEIGHT * 0.30, BIGCHAR_WIDTH );
+			CG_CenterPrint( va("Use %s", item->pickup_name), SCREEN_HEIGHT * 0.42f, BIGCHAR_WIDTH );
 		}
 	}
 
@@ -1111,6 +1111,14 @@ void CG_EntityEvent( centity_t *cent, vec3_t position ) {
 	case EV_USE_ITEM15:
 		DEBUGNAME("EV_USE_ITEM15");
 		CG_UseItem( cent );
+		break;
+
+	case EV_FUEL_EMPTY:
+		DEBUGNAME("EV_FUEL_EMPTY");
+		if ( es->number == cg.snap->ps.clientNum ) {
+			CG_CenterPrint( "Out of fuel! Vehicle stalled.", SCREEN_HEIGHT * 0.36f, BIGCHAR_WIDTH );
+			trap_S_StartLocalSound( cgs.media.talkSound, CHAN_LOCAL_SOUND );
+		}
 		break;
 
 	//=================================================================

--- a/engine/code/game/bg_physics.c
+++ b/engine/code/game/bg_physics.c
@@ -565,6 +565,7 @@ void PM_InitializeVehicle( car_t *car, vec3_t origin, vec3_t angles, vec3_t velo
 	car->rpm = CP_RPM_MIN;
 	car->fuel = keep ? fuel : CP_MAX_FUEL;
 	car->fuelLeak = keep ? leak : qfalse;
+	car->outOfFuel = (car->fuel <= 0.0f);
 	if ( pm->ps ) pm->ps->stats[STAT_FUEL] = (int)car->fuel;
 	car->preserveFuel = qfalse;
 
@@ -2357,9 +2358,15 @@ void PM_DriveMove( car_t *car, float time, qboolean includeBodies )
 		if ( car->fuelLeak ) {
 			car->fuel -= CP_FUEL_LEAK_RATE * time;
 		}
-		if (car->fuel < 0.0f) {
-			car->fuel = 0.0f;
+	}
+	if ( car->fuel <= 0.0f ) {
+		if ( !car->outOfFuel ) {
+			car->outOfFuel = qtrue;
+			PM_AddEvent( EV_FUEL_EMPTY );
 		}
+		car->fuel = 0.0f;
+	} else {
+		car->outOfFuel = qfalse;
 	}
 	pm->ps->stats[STAT_FUEL] = (int)car->fuel;
 

--- a/engine/code/game/bg_physics.h
+++ b/engine/code/game/bg_physics.h
@@ -309,6 +309,8 @@ typedef struct {
 
 	qboolean	preserveFuel;
 
+	qboolean	outOfFuel;
+
 	qboolean	initializeOnNextMove;
 
 //	float	aCOF;

--- a/engine/code/game/bg_public.h
+++ b/engine/code/game/bg_public.h
@@ -527,6 +527,7 @@ typedef enum {
         EV_USE_ITEM13,
         EV_USE_ITEM14, // 40
         EV_USE_ITEM15,
+        EV_FUEL_EMPTY,
 
         EV_ITEM_RESPAWN,
         EV_ITEM_POP,

--- a/engine/code/game/g_active.c
+++ b/engine/code/game/g_active.c
@@ -873,6 +873,7 @@ void ClientEvents( gentity_t *ent, int oldEventSequence ) {
 
 		case EV_USE_ITEM7:		      // fuel can
 			ent->client->car.fuel = ent->client->car.maxFuel;
+			ent->client->car.outOfFuel = qfalse;
 			ent->client->ps.stats[STAT_FUEL] = (int)ent->client->car.fuel;
 			break;
 

--- a/engine/code/game/g_client.c
+++ b/engine/code/game/g_client.c
@@ -1631,6 +1631,7 @@ client->ps.stats[STAT_WEAPONS] = ( 1u << WP_DERBY_RAM );
 	client->car.maxFuel = CP_MAX_FUEL;
 	client->car.fuel = client->car.maxFuel;
 	client->car.fuelLeak = qfalse;
+	client->car.outOfFuel = qfalse;
 	client->ps.stats[STAT_FUEL] = client->car.maxFuel;
 
 	if ( !ent->frontBounds )

--- a/engine/code/game/g_combat.c
+++ b/engine/code/game/g_combat.c
@@ -636,6 +636,9 @@ void player_die( gentity_t *self, gentity_t *inflictor, gentity_t *attacker, int
                         if ( attacker->client->car.fuel > attacker->client->car.maxFuel ) {
                                 attacker->client->car.fuel = attacker->client->car.maxFuel;
                         }
+                        if ( attacker->client->car.fuel > 0.0f ) {
+                                attacker->client->car.outOfFuel = qfalse;
+                        }
                         attacker->client->ps.stats[STAT_FUEL] = (int)attacker->client->car.fuel;
 
                 }

--- a/engine/code/game/g_trigger.c
+++ b/engine/code/game/g_trigger.c
@@ -441,6 +441,10 @@ void Touch_Fuel( gentity_t *self, gentity_t *other, trace_t *trace ) {
 		other->client->car.fuel = max;
 	}
 
+	if ( other->client->car.fuel > 0.0f ) {
+		other->client->car.outOfFuel = qfalse;
+	}
+
 	other->client->ps.stats[STAT_FUEL] = (int)other->client->car.fuel;
 }
 


### PR DESCRIPTION
## Summary
- add an `EV_FUEL_EMPTY` event raised when a vehicle runs out of fuel and surface it in the HUD
- reset the car `outOfFuel` state whenever fuel is replenished and initialize the new flag across client and server
- move trunk-related centerprint messages lower on the screen to avoid overlapping fuel warnings

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68dd917b670883249137042b32376712