### PR TITLE
Delay fuel DNFs until cars stop

### DIFF
--- a/engine/code/cgame/cg_event.c
+++ b/engine/code/cgame/cg_event.c
@@ -513,10 +513,10 @@ static void CG_UseItem( centity_t *cent ) {
 	// print a message if the local player
 	if ( es->number == cg.snap->ps.clientNum ) {
 		if ( !itemNum ) {
-			CG_CenterPrint( "No item in your trunk", SCREEN_HEIGHT * 0.30, BIGCHAR_WIDTH );
+			CG_CenterPrint( "No item in your trunk", SCREEN_HEIGHT * 0.42f, BIGCHAR_WIDTH );
 		} else {
 			item = BG_FindItemForHoldable( itemNum );
-			CG_CenterPrint( va("Use %s", item->pickup_name), SCREEN_HEIGHT * 0.30, BIGCHAR_WIDTH );
+			CG_CenterPrint( va("Use %s", item->pickup_name), SCREEN_HEIGHT * 0.42f, BIGCHAR_WIDTH );
 		}
 	}
 
@@ -1111,6 +1111,14 @@ void CG_EntityEvent( centity_t *cent, vec3_t position ) {
 	case EV_USE_ITEM15:
 		DEBUGNAME("EV_USE_ITEM15");
 		CG_UseItem( cent );
+		break;
+
+	case EV_FUEL_EMPTY:
+		DEBUGNAME("EV_FUEL_EMPTY");
+		if ( es->number == cg.snap->ps.clientNum ) {
+			CG_CenterPrint( "Out of fuel! Coast to a stop.", SCREEN_HEIGHT * 0.36f, BIGCHAR_WIDTH );
+			trap_S_StartLocalSound( cgs.media.talkSound, CHAN_LOCAL_SOUND );
+		}
 		break;
 
 	//=================================================================

--- a/engine/code/cgame/cg_scoreboard.c
+++ b/engine/code/cgame/cg_scoreboard.c
@@ -2016,7 +2016,9 @@ static void CG_DrawColumnData(sbColumn_t colType, int x, int y, int width,
             break;
             
         case SBCOL_TOTALTIME:
-            if (ci->team == TEAM_SPECTATOR) {
+            if (score->scoreFlags & SCORE_FLAG_DNF) {
+                CG_DrawModernText(x, y, "DNF", 1, width, textColor, qfalse);
+            } else if (ci->team == TEAM_SPECTATOR) {
                 CG_DrawModernText(x, y, "-", 1, width, textColor, qfalse);
             } else {
                 totalTime = CG_CalculateScoreTotalTime(score, isRacingMode);

--- a/engine/code/game/bg_physics.c
+++ b/engine/code/game/bg_physics.c
@@ -565,6 +565,7 @@ void PM_InitializeVehicle( car_t *car, vec3_t origin, vec3_t angles, vec3_t velo
 	car->rpm = CP_RPM_MIN;
 	car->fuel = keep ? fuel : CP_MAX_FUEL;
 	car->fuelLeak = keep ? leak : qfalse;
+	car->outOfFuel = (car->fuel <= 0.0f);
 	if ( pm->ps ) pm->ps->stats[STAT_FUEL] = (int)car->fuel;
 	car->preserveFuel = qfalse;
 
@@ -2357,9 +2358,15 @@ void PM_DriveMove( car_t *car, float time, qboolean includeBodies )
 		if ( car->fuelLeak ) {
 			car->fuel -= CP_FUEL_LEAK_RATE * time;
 		}
-		if (car->fuel < 0.0f) {
-			car->fuel = 0.0f;
+	}
+	if ( car->fuel <= 0.0f ) {
+		if ( !car->outOfFuel ) {
+			car->outOfFuel = qtrue;
+			PM_AddEvent( EV_FUEL_EMPTY );
 		}
+		car->fuel = 0.0f;
+	} else {
+		car->outOfFuel = qfalse;
 	}
 	pm->ps->stats[STAT_FUEL] = (int)car->fuel;
 

--- a/engine/code/game/bg_physics.h
+++ b/engine/code/game/bg_physics.h
@@ -309,6 +309,8 @@ typedef struct {
 
 	qboolean	preserveFuel;
 
+	qboolean	outOfFuel;
+
 	qboolean	initializeOnNextMove;
 
 //	float	aCOF;

--- a/engine/code/game/bg_public.h
+++ b/engine/code/game/bg_public.h
@@ -527,6 +527,7 @@ typedef enum {
         EV_USE_ITEM13,
         EV_USE_ITEM14, // 40
         EV_USE_ITEM15,
+        EV_FUEL_EMPTY,
 
         EV_ITEM_RESPAWN,
         EV_ITEM_POP,

--- a/engine/code/game/bg_wheel_forces.c
+++ b/engine/code/game/bg_wheel_forces.c
@@ -499,27 +499,54 @@ void PM_AddRoadForces(car_t *car, carBody_t *body, carPoint_t *points, float sec
 
 	v = DotProduct(body->v, body->forward);
 
-	if (pm->ps->stats[STAT_HEALTH] > 0){
-		car->throttle = pm->cmd.forwardmove / 127.0F;
+        if (pm->ps->stats[STAT_HEALTH] > 0){
+                float   rawThrottle;
+                int             originalGear;
+                qboolean        outOfFuel;
 
-		if (!pm->manualShift){
-			if (car->gear < 0)
-				car->throttle *= -1.0f;
+                rawThrottle = pm->cmd.forwardmove / 127.0F;
+                originalGear = car->gear;
+                outOfFuel = (car->fuel <= 0.0f);
+                car->throttle = rawThrottle;
 
-			if (car->throttle < 0){
-				if (car->gear > 0 && v < 40.0f){
-					car->gear = -1;
-					car->throttle *= -1.0f;
-				}
-				else if (car->gear < 0 && v > -40.0f){
-					car->gear = 1;
-					car->throttle *= -1.0f;
-				}
-			}
-		}
+                if (!pm->manualShift && !outOfFuel){
+                        if (car->gear < 0)
+                                car->throttle *= -1.0f;
 
-		if (pm->controlMode == CT_MOUSE){
-			car->wheelAngle = WheelAngle(pm->ps->viewangles[YAW], pm->ps->damageAngles[YAW]);
+                        if (car->throttle < 0){
+                                if (car->gear > 0 && v < 40.0f){
+                                        car->gear = -1;
+                                        car->throttle *= -1.0f;
+                                }
+                                else if (car->gear < 0 && v > -40.0f){
+                                        car->gear = 1;
+                                        car->throttle *= -1.0f;
+                                }
+                        }
+                }
+
+                if ( outOfFuel ) {
+                        car->gear = originalGear;
+
+                        if ( rawThrottle > 0.0f ) {
+                                if ( v < -1.0f ) {
+                                        car->throttle = -fabs( rawThrottle );
+                                } else {
+                                        car->throttle = 0.0f;
+                                }
+                        } else if ( rawThrottle < 0.0f ) {
+                                if ( v > 1.0f ) {
+                                        car->throttle = rawThrottle;
+                                } else {
+                                        car->throttle = 0.0f;
+                                }
+                        } else {
+                                car->throttle = 0.0f;
+                        }
+                }
+
+                if (pm->controlMode == CT_MOUSE){
+                        car->wheelAngle = WheelAngle(pm->ps->viewangles[YAW], pm->ps->damageAngles[YAW]);
 
 			if (v < 0.5f && v > -0.5f)
 				car->wheelAngle = 0.0;

--- a/engine/code/game/g_active.c
+++ b/engine/code/game/g_active.c
@@ -24,6 +24,10 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 
 #include "g_local.h"
 
+#define FUEL_DNF_STOP_SPEED_KPH 5.0f
+
+static void G_CompleteFuelDNF( gentity_t *ent );
+static qboolean G_VehicleBelowFuelDNFThreshold( const gentity_t *ent );
 
 // STONELANCE
 /*
@@ -441,6 +445,87 @@ void	G_TouchTriggers( gentity_t *ent ) {
 	}
 }
 
+static qboolean G_HasFollowableRacer( int skipClient ) {
+        int i;
+
+        for ( i = 0; i < level.maxclients; i++ ) {
+                gclient_t *client;
+
+                if ( i == skipClient ) {
+                        continue;
+                }
+
+                client = &level.clients[i];
+                if ( client->pers.connected != CON_CONNECTED ) {
+                        continue;
+                }
+                if ( client->sess.sessionTeam == TEAM_SPECTATOR ) {
+                        continue;
+                }
+                if ( isRaceObserver( i ) ) {
+                        continue;
+                }
+
+                return qtrue;
+        }
+
+        return qfalse;
+}
+
+static qboolean G_VehicleBelowFuelDNFThreshold( const gentity_t *ent ) {
+        float speedQu;
+        float stopSpeedQu;
+
+        if ( !ent || !ent->client ) {
+                return qtrue;
+        }
+
+        speedQu = VectorLength( ent->client->ps.velocity );
+        stopSpeedQu = (FUEL_DNF_STOP_SPEED_KPH / 3.6f) * CP_M_2_QU;
+
+        return speedQu <= stopSpeedQu;
+}
+
+static void G_CompleteFuelDNF( gentity_t *ent ) {
+        gclient_t *client;
+
+        if ( !ent || !ent->client ) {
+                return;
+        }
+
+        client = ent->client;
+        client->pendingFuelDNF = qfalse;
+        client->fuelEmptyTime = 0;
+
+        if ( client->didNotFinish ) {
+                return;
+        }
+
+        if ( !client->car.outOfFuel ) {
+                return;
+        }
+
+        if ( !isRallyRace() || !level.startRaceTime || level.finishRaceTime ) {
+                return;
+        }
+
+        if ( client->sess.sessionTeam == TEAM_SPECTATOR || isRaceObserver( ent->s.number ) ) {
+                return;
+        }
+
+        if ( client->finishRaceTime ) {
+                return;
+        }
+
+        trap_SendServerCommand( ent->s.number, "cp \"Out of fuel! Did not finish.\n\"" );
+        trap_SendServerCommand( -1, va( "print \"%s" S_COLOR_WHITE " ran out of fuel and is out of the race!\n\"",
+                        client->pers.netname ) );
+        SetTeam( ent, "racerSpectator" );
+        StopFollowing( ent );
+        client->didNotFinish = qtrue;
+        SendScoreboardMessageToAllClients();
+}
+
 /*
 =================
 SpectatorThink
@@ -501,8 +586,11 @@ void SpectatorThink( gentity_t *ent, usercmd_t *ucmd ) {
 	if ( ( client->buttons & BUTTON_ATTACK ) && ! ( client->oldbuttons & BUTTON_ATTACK ) 
 		&& !(ent->r.svFlags & SVF_BOT) ) {
 // END
-		Cmd_FollowCycle_f( ent, 1 );
+		if ( G_HasFollowableRacer( ent->s.number ) ) {
+			Cmd_FollowCycle_f( ent, 1 );
+		}
 	}
+
 
 // STONELANCE
 	if ( ( client->buttons & BUTTON_REARATTACK ) && ! ( client->oldbuttons & BUTTON_REARATTACK ) ) {
@@ -871,9 +959,17 @@ void ClientEvents( gentity_t *ent, int oldEventSequence ) {
 			break;
 #endif
 
-		case EV_USE_ITEM7:		      // fuel can
+		case EV_USE_ITEM7:			// fuel can
 			ent->client->car.fuel = ent->client->car.maxFuel;
+			ent->client->car.outOfFuel = qfalse;
+			ent->client->pendingFuelDNF = qfalse;
+			ent->client->fuelEmptyTime = 0;
 			ent->client->ps.stats[STAT_FUEL] = (int)ent->client->car.fuel;
+			break;
+
+		case EV_FUEL_EMPTY:
+			ent->client->pendingFuelDNF = qtrue;
+			ent->client->fuelEmptyTime = level.time;
 			break;
 
 		default:
@@ -1623,6 +1719,15 @@ void ClientThink_real( gentity_t *ent ) {
 	client->oldbuttons = client->buttons;
 	client->buttons = ucmd->buttons;
 	client->latched_buttons |= client->buttons & ~client->oldbuttons;
+
+	if ( client->pendingFuelDNF ) {
+		if ( !client->car.outOfFuel ) {
+			client->pendingFuelDNF = qfalse;
+			client->fuelEmptyTime = 0;
+		} else if ( G_VehicleBelowFuelDNFThreshold( ent ) ) {
+			G_CompleteFuelDNF( ent );
+		}
+	}
 
 	// check for respawning
 	if ( client->ps.stats[STAT_HEALTH] <= 0 ) {

--- a/engine/code/game/g_client.c
+++ b/engine/code/game/g_client.c
@@ -1262,6 +1262,8 @@ void ClientBegin( int clientNum ) {
 	client->ladderEliminationRound = 0;
 	client->ladderEliminationPlayersRemaining = 0;
 	client->ladderEliminationMetric = 0.0f;
+	client->pendingFuelDNF = qfalse;
+	client->fuelEmptyTime = 0;
 	client->didNotFinish = qfalse;
 
 	// save eflags around this, because changing teams will
@@ -1631,6 +1633,9 @@ client->ps.stats[STAT_WEAPONS] = ( 1u << WP_DERBY_RAM );
 	client->car.maxFuel = CP_MAX_FUEL;
 	client->car.fuel = client->car.maxFuel;
 	client->car.fuelLeak = qfalse;
+	client->car.outOfFuel = qfalse;
+	client->pendingFuelDNF = qfalse;
+	client->fuelEmptyTime = 0;
 	client->ps.stats[STAT_FUEL] = client->car.maxFuel;
 
 	if ( !ent->frontBounds )

--- a/engine/code/game/g_combat.c
+++ b/engine/code/game/g_combat.c
@@ -636,6 +636,11 @@ void player_die( gentity_t *self, gentity_t *inflictor, gentity_t *attacker, int
                         if ( attacker->client->car.fuel > attacker->client->car.maxFuel ) {
                                 attacker->client->car.fuel = attacker->client->car.maxFuel;
                         }
+                        if ( attacker->client->car.fuel > 0.0f ) {
+                                attacker->client->car.outOfFuel = qfalse;
+                                attacker->client->pendingFuelDNF = qfalse;
+                                attacker->client->fuelEmptyTime = 0;
+                        }
                         attacker->client->ps.stats[STAT_FUEL] = (int)attacker->client->car.fuel;
 
                 }

--- a/engine/code/game/g_local.h
+++ b/engine/code/game/g_local.h
@@ -408,6 +408,8 @@ struct gclient_s {
 	float		pmoveTime;
 
 	// race variables
+	qboolean		pendingFuelDNF;
+	int			fuelEmptyTime;
 	int			finishRaceTime;
 	qboolean		didNotFinish;
 	int			ladderBestLapMs;

--- a/engine/code/game/g_main.c
+++ b/engine/code/game/g_main.c
@@ -1671,7 +1671,9 @@ void LogExit( const char *string ) {
 			}
 
 			if ( client->sess.sessionTeam == TEAM_SPECTATOR || isRaceObserver( i ) ) {
-				client->didNotFinish = qfalse;
+				if ( !client->didNotFinish ) {
+					client->didNotFinish = qfalse;
+				}
 				continue;
 			}
 

--- a/engine/code/game/g_trigger.c
+++ b/engine/code/game/g_trigger.c
@@ -441,6 +441,12 @@ void Touch_Fuel( gentity_t *self, gentity_t *other, trace_t *trace ) {
 		other->client->car.fuel = max;
 	}
 
+	if ( other->client->car.fuel > 0.0f ) {
+		other->client->car.outOfFuel = qfalse;
+		other->client->pendingFuelDNF = qfalse;
+		other->client->fuelEmptyTime = 0;
+	}
+
 	other->client->ps.stats[STAT_FUEL] = (int)other->client->car.fuel;
 }
 


### PR DESCRIPTION
## Summary
- defer fuel-empty disqualifications to a per-frame check that waits for the car to slow below 5 km/h before moving drivers to spectator mode
- reset pending fuel DNFs whenever vehicles are refueled or awarded fuel so drivers can recover without being forced out
- update the client fuel warning copy to prompt players to coast after running out of gas

## Testing
- not run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68dd917b670883249137042b32376712