### PR TITLE
Disable throttle inputs when fuel is empty

### DIFF
--- a/engine/code/game/g_active.c
+++ b/engine/code/game/g_active.c
@@ -1291,6 +1291,10 @@ void ClientThink_real( gentity_t *ent ) {
 		client->horn_sound_time = level.time + 100;
 	}
 
+	if ( client->car.outOfFuel || client->pendingFuelDNF ) {
+		ucmd->buttons &= ~BUTTON_TURBO;
+	}
+
 	// use turbo
 	if ((ucmd->buttons & BUTTON_TURBO) && !(client->oldbuttons & BUTTON_TURBO)
 		&& client->ps.powerups[ PW_TURBO ] < 0){
@@ -1357,6 +1361,14 @@ void ClientThink_real( gentity_t *ent ) {
 
 	pm.ps = &client->ps;
 	pm.cmd = *ucmd;
+
+	if ( client->car.outOfFuel || client->pendingFuelDNF ) {
+		if ( pm.cmd.forwardmove > 0 ) {
+			pm.cmd.forwardmove = 0;
+		}
+
+		pm.cmd.buttons &= ~BUTTON_TURBO;
+	}
 // STONELANCE - dead cars can still hit things
 /*
 	if ( pm.ps->pm_type == PM_DEAD ) {


### PR DESCRIPTION
## Summary
- clear turbo button presses when a client has run out of fuel or is pending a fuel DNF
- zero out forward throttle commands during pmove while preserving braking so empty cars can only coast

## Testing
- not run (not supported in this environment)

------
https://chatgpt.com/codex/tasks/task_e_68de7a3706d48324b99cd48ce917daf9