### PR TITLE
Ensure Fuel DNF triggers follow or scoreboard

### DIFF
--- a/engine/code/game/g_active.c
+++ b/engine/code/game/g_active.c
@@ -522,6 +522,13 @@ static void G_CompleteFuelDNF( gentity_t *ent ) {
                         client->pers.netname ) );
         SetTeam( ent, "racerSpectator" );
         StopFollowing( ent );
+
+        if ( G_HasFollowableRacer( ent - g_entities ) ) {
+                Cmd_FollowCycle_f( ent, 1 );
+        } else if ( client->sess.sessionTeam == TEAM_SPECTATOR ) {
+                client->sess.spectatorState = SPECTATOR_SCOREBOARD;
+                client->sess.spectatorClient = -1;
+        }
         client->didNotFinish = qtrue;
         SendScoreboardMessageToAllClients();
 }


### PR DESCRIPTION
## Summary
- ensure racers who run out of fuel are immediately moved to follow another active racer when available
- fall back to scoreboard spectator mode when no followable racers remain

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68de7ce57cb4832488122ab4e1e07b2a