### PR TITLE
Handle invalid spectator follow targets

### DIFF
--- a/engine/code/game/g_active.c
+++ b/engine/code/game/g_active.c
@@ -593,6 +593,14 @@ void SpectatorThink( gentity_t *ent, usercmd_t *ucmd ) {
 	if ( ( client->buttons & BUTTON_ATTACK ) && ! ( client->oldbuttons & BUTTON_ATTACK ) 
 		&& !(ent->r.svFlags & SVF_BOT) ) {
 // END
+		if ( client->sess.spectatorClient >= 0 ) {
+			if ( client->sess.spectatorClient >= level.maxclients
+				|| level.clients[ client->sess.spectatorClient ].pers.connected != CON_CONNECTED ) {
+				Cmd_FollowCycle_f( ent, 1 );
+				return;
+			}
+		}
+
 		if ( G_HasFollowableRacer( ent->s.number ) ) {
 			Cmd_FollowCycle_f( ent, 1 );
 		}

--- a/engine/code/game/g_cmds.c
+++ b/engine/code/game/g_cmds.c
@@ -1047,6 +1047,11 @@ void Cmd_FollowCycle_f( gentity_t *ent, int dir ) {
 		return;
 	} while ( clientnum != original );
 
+	if ( ent->client->sess.spectatorClient == original ) {
+		StopFollowing( ent );
+		trap_SendServerCommand( ent - g_entities, "print \"No valid clients to follow.\n\"" );
+	}
+
 	// leave it where it was
 }
 


### PR DESCRIPTION
## Summary
- stop following when Cmd_FollowCycle_f cannot find a valid client and notify the spectator
- guard SpectatorThink so attack presses fall back when the current follow target is invalid

## Testing
- not run (not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68de7deb1fc883248a3ed14754065fca