### PR TITLE
Handle stalled races when the last driver runs dry

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -70,6 +70,7 @@ Added:
 - codebase synced with ioq3
 - individual car horns for all cars
 - Usable server map rotation configs
+- Races now auto-finish if the sole remaining driver has been out of fuel and stationary for 30 seconds, preventing stalled sessions.
 - New intro
 - Make unique logos for 4 teams (Like UT99)
 - finished the flag status hud for domination

--- a/engine/code/game/g_active.c
+++ b/engine/code/game/g_active.c
@@ -24,6 +24,8 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 
 #include "g_local.h"
 
+#define FUEL_EMPTY_STOPPED_VEL_SQ   25.0f
+
 
 // STONELANCE
 /*
@@ -1495,6 +1497,18 @@ void ClientThink_real( gentity_t *ent ) {
 // END
 
 	// save results of pmove
+	if ( client->car.fuel <= 0.0f ) {
+		if ( VectorLengthSquared( client->ps.velocity ) < FUEL_EMPTY_STOPPED_VEL_SQ ) {
+			if ( !client->fuelEmptySince ) {
+				client->fuelEmptySince = level.time;
+			}
+		} else {
+			client->fuelEmptySince = 0;
+		}
+	} else if ( client->fuelEmptySince ) {
+		client->fuelEmptySince = 0;
+	}
+
 	if ( ent->client->ps.eventSequence != oldEventSequence ) {
 		ent->eventTime = level.time;
 	}

--- a/engine/code/game/g_local.h
+++ b/engine/code/game/g_local.h
@@ -427,6 +427,7 @@ struct gclient_s {
 	int			horn_sound_time;
 
 	int			lastCheckpointTime;
+	int			fuelEmptySince;
 // END
 
 	char		*areabits;

--- a/engine/code/game/g_main.c
+++ b/engine/code/game/g_main.c
@@ -25,6 +25,8 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #include "g_local.h"
 #include "../qcommon/qcommon.h"
 
+#define FUEL_EMPTY_RACE_FINISH_DELAY   30000
+
 level_locals_t	level;
 
 typedef struct {
@@ -2029,6 +2031,7 @@ void CheckExitRules( void ) {
 	gclient_t	*cl;
 // STONELANCE
 	int			count;
+	gclient_t	*soleActiveClient = NULL;
 // END
 	// if at the intermission, wait for all non-bots to
 	// signal ready, then go to next level
@@ -2148,12 +2151,29 @@ void CheckExitRules( void ) {
 //		if ( cl->ps.stats[STAT_HEALTH] <= 0 ) continue;
 
 		count++;
-		break;
+		if ( count == 1 ) {
+			soleActiveClient = cl;
+		} else {
+			soleActiveClient = NULL;
+			break;
+		}
 	}
 
 	// if its a race and the race has started if no players left playing 
 	//			or everyone is a spectator then end the race.
 	if ( isRallyRace() && level.startRaceTime && !count ){
+		LogExit( "Race finished." );
+		return;
+	}
+
+	if ( isRallyRace() && level.startRaceTime && !level.finishRaceTime
+			&& count == 1 && soleActiveClient && soleActiveClient->fuelEmptySince
+			&& level.time - soleActiveClient->fuelEmptySince >= FUEL_EMPTY_RACE_FINISH_DELAY ) {
+		soleActiveClient->finishRaceTime = level.time;
+		soleActiveClient->ps.stats[STAT_POSITION] = 1;
+		level.winnerNumber = soleActiveClient->ps.clientNum;
+		level.finishRaceTime = level.time;
+		trap_SendServerCommand( -1, va( "raceFinishTime %i %i", soleActiveClient->ps.clientNum, level.time ) );
 		LogExit( "Race finished." );
 		return;
 	}

--- a/readme/q3rally_dedicated_server_guide.txt
+++ b/readme/q3rally_dedicated_server_guide.txt
@@ -13,6 +13,7 @@ English
         set rconpassword "yourpassword"
         set g_gametype "0"
         set g_finishRaceDelay "30"
+        // When only one racer remains with an empty tank, the race auto-finishes after 30 seconds of inactivity.
         map q3r_country01
 
     elimination_server.cfg (Elimination):
@@ -75,6 +76,7 @@ Deutsch
         set rconpassword "deinpasswort"
         set g_gametype "0"
         set g_finishRaceDelay "30"
+        // Wenn nur noch ein Fahrer mit leerem Tank übrig ist, beendet der Server das Rennen nach 30 Sekunden Stillstand.
         map q3r_country01
 
     elimination_server.cfg (Elimination):


### PR DESCRIPTION
## Summary
- add per-client tracking for how long a car has been out of fuel and stopped
- automatically finish races after 30 seconds when the sole remaining driver is out of fuel and idle, including raceFinishTime broadcast
- document the new behaviour in the dedicated server guide and changelog

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dee59a8760832488bd821ed598f78a