### PR TITLE
Add empty fuel warning to HUD

### DIFF
--- a/engine/code/cgame/cg_rally_hud.c
+++ b/engine/code/cgame/cg_rally_hud.c
@@ -230,14 +230,16 @@ void CG_DrawFuelGauge( float x, float y, float w, float h ) {
 
                // draw centered critical fuel warning text
                {
+                       const char *warning;
                        int textWidth;
                        float textX;
 
-                       textWidth = BIGCHAR_WIDTH * CG_DrawStrlen( "Fuel Critical - Refuel Now!" );
+                       warning = ( fuel <= 0 ) ? "Fuel Empty" : "Fuel Critical - Refuel Now!";
+                       textWidth = BIGCHAR_WIDTH * CG_DrawStrlen( warning );
                        textX = ( SCREEN_WIDTH - textWidth ) / 2;
 
                        CG_SetScreenPlacement( PLACE_CENTER, PLACE_CENTER );
-                       CG_DrawStringExt( textX, SCREEN_HEIGHT * 0.30f, "Fuel Critical - Refuel Now!", warnColor, qfalse, qtrue, BIGCHAR_WIDTH, (int)(BIGCHAR_WIDTH * 1.5f), 0 );
+                       CG_DrawStringExt( textX, SCREEN_HEIGHT * 0.30f, warning, warnColor, qfalse, qtrue, BIGCHAR_WIDTH, (int)(BIGCHAR_WIDTH * 1.5f), 0 );
                        CG_PopScreenPlacement();
                }
        } else {


### PR DESCRIPTION
## Summary
- update the low fuel warning logic to display a distinct "Fuel Empty" message when tanks are depleted
- reuse the chosen warning text for width calculations and rendering to keep the HUD aligned

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68def7e303888324beefd8f0ad7a2bd2