### PR TITLE
Add race finish countdown tied to server-configured delay

### DIFF
--- a/engine/code/cgame/cg_draw.c
+++ b/engine/code/cgame/cg_draw.c
@@ -3429,6 +3429,7 @@ static void CG_Draw2D(stereoFrame_t stereoFrame)
 		CG_DrawCenterString();
 
 		CG_DrawRaceCountDown();
+		CG_DrawRaceFinishCountdown();
 
 	}
 }

--- a/engine/code/cgame/cg_local.h
+++ b/engine/code/cgame/cg_local.h
@@ -720,6 +720,9 @@ typedef struct {
 
 	char		countDownPrint[16];
 	int			countDownEnd;
+	int			raceFinishCountdownStart;
+	int			raceFinishCountdownEnd;
+	qboolean	raceFinishCountdownActive;
 
 	// low ammo warning state
 	int			lowAmmoWarning;		// 1 = low, 2 = empty
@@ -1252,6 +1255,7 @@ typedef struct {
 // Q3Rally Code END
 	int				capturelimit;
 	int				timelimit;
+	int				finishRaceDelay;
 	int				maxclients;
 	char			mapname[MAX_QPATH];
 	char			redTeam[MAX_QPATH];
@@ -1999,6 +2003,7 @@ void CG_NewLapTime( int client, int lap, int time );
 void CG_FinishedRace( int client, int time );
 void CG_StartRace( int time );
 void CG_DrawRaceCountDown( void );
+void CG_DrawRaceFinishCountdown( void );
 void CG_RaceCountDown( const char *str, int secondsLeft );
 
 //

--- a/engine/code/cgame/cg_rally_racetools.c
+++ b/engine/code/cgame/cg_rally_racetools.c
@@ -59,6 +59,12 @@ void CG_FinishedRace( int client, int time ) {
 
 	cent = &cg_entities[client];
 
+	if ( !cg.raceFinishCountdownActive ) {
+		cg.raceFinishCountdownActive = qtrue;
+		cg.raceFinishCountdownStart = time;
+		cg.raceFinishCountdownEnd = time + ( cgs.finishRaceDelay * 1000 );
+	}
+
 	if ( client == cg.snap->ps.clientNum
 		&& ((time - cent->startLapTime) < cent->bestLapTime || cent->bestLapTime == 0) ){
 		// New bestlap
@@ -76,6 +82,10 @@ void CG_FinishedRace( int client, int time ) {
 void CG_StartRace( int time ) {
 	int			i;
 	centity_t	*player;
+
+	cg.raceFinishCountdownActive = qfalse;
+	cg.raceFinishCountdownStart = 0;
+	cg.raceFinishCountdownEnd = 0;
 
 	for (i = 0; i < MAX_CLIENTS; i++){
 		player = &cg_entities[i];
@@ -114,6 +124,40 @@ void CG_DrawRaceCountDown( void ){
 	y = 240 - h/2;
 	CG_DrawStringExt( x, y, cg.countDownPrint, color, qfalse, qtrue, w, h, 0 );
 }
+void CG_DrawRaceFinishCountdown( void ) {
+	char			text[64];
+	int			seconds;
+	vec4_t		color = { 1.0f, 1.0f, 1.0f, 1.0f };
+	int			w;
+	int			x;
+	int			y;
+
+	if ( !cg.raceFinishCountdownActive ) {
+		return;
+	}
+
+	if ( cg.time >= cg.raceFinishCountdownEnd ) {
+		cg.raceFinishCountdownActive = qfalse;
+		cg.raceFinishCountdownStart = 0;
+		cg.raceFinishCountdownEnd = 0;
+		return;
+	}
+
+	seconds = ( cg.raceFinishCountdownEnd - cg.time + 999 ) / 1000;
+	if ( seconds < 0 ) {
+		seconds = 0;
+	}
+
+	Com_sprintf( text, sizeof( text ), "Race ends in : %02d seconds", seconds );
+
+	w = CG_DrawStrlen( text ) * BIGCHAR_WIDTH;
+	x = 320 - w / 2;
+	y = 360;
+
+	CG_DrawBigStringColor( x, y, text, color );
+}
+
+
 
 void CG_RaceCountDown( const char *str, int secondsLeft ){
 	cg.centerPrintTime = 0;

--- a/engine/code/cgame/cg_servercmds.c
+++ b/engine/code/cgame/cg_servercmds.c
@@ -244,6 +244,14 @@ void CG_ParseServerinfo( void ) {
 // END
 	cgs.capturelimit = atoi( Info_ValueForKey( info, "capturelimit" ) );
 	cgs.timelimit = atoi( Info_ValueForKey( info, "timelimit" ) );
+	{
+		const char *finishDelay = Info_ValueForKey( info, "g_finishRaceDelay" );
+		if ( finishDelay && finishDelay[0] ) {
+			cgs.finishRaceDelay = atoi( finishDelay );
+		} else {
+			cgs.finishRaceDelay = 30;
+		}
+	}
 	cgs.maxclients = atoi( Info_ValueForKey( info, "sv_maxclients" ) );
 	mapname = Info_ValueForKey( info, "mapname" );
 	Com_sprintf( cgs.mapname, sizeof( cgs.mapname ), "maps/%s.bsp", mapname );
@@ -505,6 +513,11 @@ static void CG_ConfigStringModified( void ) {
 #endif
 	} else if ( num == CS_INTERMISSION ) {
 		cg.intermissionStarted = atoi( str );
+		if ( cg.intermissionStarted ) {
+			cg.raceFinishCountdownActive = qfalse;
+			cg.raceFinishCountdownStart = 0;
+			cg.raceFinishCountdownEnd = 0;
+		}
 	} else if ( num >= CS_MODELS && num < CS_MODELS+MAX_MODELS ) {
 		cgs.gameModels[ num-CS_MODELS ] = trap_R_RegisterModel( str );
 	} else if ( num >= CS_SOUNDS && num < CS_SOUNDS+MAX_SOUNDS ) {

--- a/engine/code/game/g_main.c
+++ b/engine/code/game/g_main.c
@@ -252,7 +252,7 @@ static cvarTable_t		gameCvarTable[] = {
 	{ &g_trackLength, "g_trackLength", "0", CVAR_LATCH, 0, qfalse  },
 
 	{ &g_forceEngineStart, "g_forceEngineStart", "60", CVAR_ARCHIVE, 0, qfalse },
-	{ &g_finishRaceDelay, "g_finishRaceDelay", "30", CVAR_ARCHIVE, 0, qfalse },
+	{ &g_finishRaceDelay, "g_finishRaceDelay", "30", CVAR_SERVERINFO | CVAR_ARCHIVE, 0, qfalse },
 	{ &g_eliminationStartDelay, "g_eliminationStartDelay", "30000", CVAR_ARCHIVE, 0, qfalse },
 	{ &g_eliminationInterval, "g_eliminationInterval", "15000", CVAR_ARCHIVE, 0, qfalse },
 	{ &g_eliminationWarning, "g_eliminationWarning", "5000", CVAR_ARCHIVE, 0, qfalse },


### PR DESCRIPTION
## Summary
- expose `g_finishRaceDelay` in serverinfo so clients receive the configured value
- track the race finish countdown timings on the client with automatic resets on race start and intermission
- render a center-screen race finish countdown that mirrors the server delay

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68def92cf37c83249df2efaa84c5fe68