### PR TITLE
Delay race observer transition until countdown completion

### DIFF
--- a/engine/code/game/g_active.c
+++ b/engine/code/game/g_active.c
@@ -1144,7 +1144,10 @@ void ClientThink_real( gentity_t *ent ) {
 		ucmd->upmove = 0;
 	}
 
-	if ( ent->client->finishRaceTime && ent->client->finishRaceTime + RACE_OBSERVER_DELAY < level.time ){
+	if ( ent->client->finishRaceTime
+		&& ent->client->finishRaceTime + RACE_OBSERVER_DELAY < level.time
+		&& level.finishRaceTime
+		&& level.time >= level.finishRaceTime + ( g_finishRaceDelay.integer * 1000 ) ){
 		gentity_t	*tent;
 		tent = G_TempEntity( ent->client->ps.origin, EV_PLAYER_TELEPORT_OUT );
 		tent->s.clientNum = ent->s.clientNum;


### PR DESCRIPTION
## Summary
- gate the race observer transition on the global finish countdown completing before teleporting drivers
- keep the post-finish immobilization while deferring the teleport/scoreboard trigger until the countdown elapses

## Testing
- not run (not supported in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68df086fa0808324a492a30cdd51f917