### PR TITLE
Prevent fuel-depletion finishes from triggering personal record

### DIFF
--- a/engine/code/cgame/cg_local.h
+++ b/engine/code/cgame/cg_local.h
@@ -2000,7 +2000,7 @@ qboolean CG_InsideBox( vec3_t mins, vec3_t maxs, vec3_t pos );
 // cg_rally_race_tools.c
 //
 void CG_NewLapTime( int client, int lap, int time );
-void CG_FinishedRace( int client, int time );
+void CG_FinishedRace( int client, int time, qboolean fuelDepleted );
 void CG_StartRace( int time );
 void CG_DrawRaceCountDown( void );
 void CG_DrawRaceFinishCountdown( void );

--- a/engine/code/cgame/cg_rally_racetools.c
+++ b/engine/code/cgame/cg_rally_racetools.c
@@ -53,7 +53,7 @@ void CG_NewLapTime( int client, int lap, int time ) {
 	cent->startLapTime = time;
 }
 
-void CG_FinishedRace( int client, int time ) {
+void CG_FinishedRace( int client, int time, qboolean fuelDepleted ) {
 	centity_t	*cent;
 	char		*t;
 
@@ -65,7 +65,7 @@ void CG_FinishedRace( int client, int time ) {
 		cg.raceFinishCountdownEnd = time + ( cgs.finishRaceDelay * 1000 );
 	}
 
-	if ( client == cg.snap->ps.clientNum
+	if ( !fuelDepleted && client == cg.snap->ps.clientNum
 		&& ((time - cent->startLapTime) < cent->bestLapTime || cent->bestLapTime == 0) ){
 		// New bestlap
 		cent->bestLapTime = (time - cent->startLapTime);

--- a/engine/code/cgame/cg_servercmds.c
+++ b/engine/code/cgame/cg_servercmds.c
@@ -1491,12 +1491,19 @@ static void CG_ServerCommand( void ) {
 		return;
 	}
 
-	if ( !strcmp( cmd, "raceFinishTime" ) ) {
-		i1 = atoi(CG_Argv(1));
-		i2 = atoi(CG_Argv(2));
-		CG_FinishedRace( i1, i2 );
-		return;
-	}
+        if ( !strcmp( cmd, "raceFinishTime" ) ) {
+                int fuelDepleted = 0;
+
+                i1 = atoi(CG_Argv(1));
+                i2 = atoi(CG_Argv(2));
+
+                if ( trap_Argc() >= 4 ) {
+                        fuelDepleted = atoi( CG_Argv(3) );
+                }
+
+                CG_FinishedRace( i1, i2, fuelDepleted ? qtrue : qfalse );
+                return;
+        }
 // END
 
 	CG_Printf( "Unknown client game command: %s\n", cmd );

--- a/engine/code/game/g_main.c
+++ b/engine/code/game/g_main.c
@@ -2172,7 +2172,7 @@ void CheckExitRules( void ) {
                 soleActiveClient->ps.stats[STAT_POSITION] = 1;
                 level.winnerNumber = soleActiveClient->ps.clientNum;
                 level.finishRaceTime = finishTime;
-                trap_SendServerCommand( -1, va( "raceFinishTime %i %i", soleActiveClient->ps.clientNum, finishTime ) );
+                trap_SendServerCommand( -1, va( "raceFinishTime %i %i %i", soleActiveClient->ps.clientNum, finishTime, 1 ) );
                 return;
         }
 
@@ -2188,7 +2188,7 @@ void CheckExitRules( void ) {
 	if ( level.finishRaceTime && g_gametype.integer == GT_DERBY
 		&& level.finishRaceTime + 10000 < level.time ){
 		g_entities[ level.winnerNumber ].client->finishRaceTime = level.time;
-		trap_SendServerCommand( -1, va("raceFinishTime %i %i", level.winnerNumber, level.time) );
+                trap_SendServerCommand( -1, va("raceFinishTime %i %i %i", level.winnerNumber, level.time, 0) );
 		LogExit( "Derby finished." );
 		return;
 	}
@@ -2196,7 +2196,7 @@ void CheckExitRules( void ) {
 	if ( level.finishRaceTime && (g_gametype.integer == GT_LCS || g_gametype.integer == GT_ELIMINATION)
 		&& level.finishRaceTime + 10000 < level.time ){
 		g_entities[ level.winnerNumber ].client->finishRaceTime = level.time;
-		trap_SendServerCommand( -1, va("raceFinishTime %i %i", level.winnerNumber, level.time) );
+                trap_SendServerCommand( -1, va("raceFinishTime %i %i %i", level.winnerNumber, level.time, 0) );
 		if ( g_gametype.integer == GT_LCS ) {
 			LogExit( "Last car standing finished." );
 		}


### PR DESCRIPTION
## Summary
- add a fuel depletion marker to `raceFinishTime` server commands
- teach the cgame race-finish handler to ignore best-lap bookkeeping when fuel runs out mid-lap

## Testing
- not run (in-game verification not available in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68df096b2bac832487ce8e873ee3d18a