### PR TITLE
Align race observer timing with finish countdown

### DIFF
--- a/engine/code/cgame/cg_rally_tools.c
+++ b/engine/code/cgame/cg_rally_tools.c
@@ -819,7 +819,19 @@ isRaceObserver
 =================
 */
 qboolean isRaceObserver( int clientNum ){
-	return (cg_entities[clientNum].finishRaceTime && cg_entities[clientNum].finishRaceTime + RACE_OBSERVER_DELAY < cg.time);
+	int cutoffTime;
+
+	if ( clientNum == cg.clientNum && cg.raceFinishCountdownEnd ) {
+		return ( cg.time >= cg.raceFinishCountdownEnd );
+	}
+
+	if ( !cg_entities[clientNum].finishRaceTime ) {
+		return qfalse;
+	}
+
+	cutoffTime = cg_entities[clientNum].finishRaceTime + ( cgs.finishRaceDelay * 1000 );
+
+	return ( cg.time >= cutoffTime );
 }
 
 qboolean CG_InsideBox( vec3_t mins, vec3_t maxs, vec3_t pos ){

--- a/engine/code/game/g_active.c
+++ b/engine/code/game/g_active.c
@@ -1145,7 +1145,6 @@ void ClientThink_real( gentity_t *ent ) {
 	}
 
 	if ( ent->client->finishRaceTime
-		&& ent->client->finishRaceTime + RACE_OBSERVER_DELAY < level.time
 		&& level.finishRaceTime
 		&& level.time >= level.finishRaceTime + ( g_finishRaceDelay.integer * 1000 ) ){
 		gentity_t	*tent;


### PR DESCRIPTION
## Summary
- wait to promote finished drivers to observer until the global finish countdown expires server-side
- base the client-side race observer flag on the configured finish countdown instead of a hard-coded delay

## Testing
- not run (not available in this environment)

------
https://chatgpt.com/codex/tasks/task_e_68df108dfd8483249fae3ab501de19d9