### PR TITLE
Add forward declaration for CL_LadderSetError

### DIFF
--- a/engine/code/client/cl_ui.c
+++ b/engine/code/client/cl_ui.c
@@ -39,6 +39,8 @@ typedef struct {
         size_t  capacity;
 } ladderDownloadBuffer_t;
 
+static void CL_LadderSetError( const char *message );
+
 static qboolean CL_LadderBufferEnsureCapacity( ladderDownloadBuffer_t *buffer, size_t required ) {
         char    *newData;
         size_t  newCapacity;


### PR DESCRIPTION
## Summary
- add a static forward declaration for `CL_LadderSetError` within the USE_CURL block so that `CL_LadderParseResponse` sees the correct signature

## Testing
- make release *(fails: missing SDL_version.h header in build environment)*

------
https://chatgpt.com/codex/tasks/task_e_68df89ffed788324b7eaace679fb7d74