### PR TITLE
Add shared JSON implementation module

### DIFF
--- a/engine/Makefile
+++ b/engine/Makefile
@@ -2011,7 +2011,8 @@ Q3OBJ = \
 \
   $(B)/client/q_math.o \
   $(B)/client/q_shared.o \
-  \
+  $(B)/client/json_shared.o \
+\
   $(B)/client/unzip.o \
   $(B)/client/ioapi.o \
   $(B)/client/puff.o \
@@ -2105,7 +2106,8 @@ Q3R2OBJ = \
   $(B)/renderergl2/tr_surface.o \
   $(B)/renderergl2/tr_vbo.o \
   $(B)/renderergl2/tr_world.o \
-  \
+  $(B)/renderergl2/json_shared.o \
+\
   $(B)/renderergl1/sdl_gamma.o \
   $(B)/renderergl1/sdl_glimp.o
 
@@ -2589,7 +2591,8 @@ Q3DOBJ = \
   \
   $(B)/ded/q_math.o \
   $(B)/ded/q_shared.o \
-  \
+  $(B)/ded/json_shared.o \
+\
   $(B)/ded/unzip.o \
   $(B)/ded/ioapi.o \
   $(B)/ded/vm.o \
@@ -3107,6 +3110,9 @@ $(B)/renderergl2/glsl/%.c: $(RGL2DIR)/glsl/%.glsl $(STRINGIFY)
 	$(DO_REF_STR)
 
 $(B)/renderergl2/glsl/%.o: $(B)/renderergl2/glsl/%.c
+	$(DO_REF_CC)
+
+$(B)/renderergl2/%.o: $(CMDIR)/%.c
 	$(DO_REF_CC)
 
 $(B)/renderergl2/%.o: $(RCOMMONDIR)/%.c

--- a/engine/code/qcommon/json.h
+++ b/engine/code/qcommon/json.h
@@ -87,6 +87,7 @@ int JSON_ValueGetInt(const char *json, const char *jsonEnd);
 
 #ifdef JSON_IMPLEMENTATION
 #include <stdio.h>
+#include <string.h>
 
 // --------------------------------------------------------------------------
 //   Internal Functions

--- a/engine/code/qcommon/json_shared.c
+++ b/engine/code/qcommon/json_shared.c
@@ -1,0 +1,6 @@
+/*
+ * Shared JSON implementation wrapper to ensure a single translation unit
+ * provides the json.h helpers for all modules that require them.
+ */
+#define JSON_IMPLEMENTATION
+#include "json.h"

--- a/engine/code/renderergl2/tr_bsp.c
+++ b/engine/code/renderergl2/tr_bsp.c
@@ -23,9 +23,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 
 #include "tr_local.h"
 
-#define JSON_IMPLEMENTATION
 #include "../qcommon/json.h"
-#undef JSON_IMPLEMENTATION
 
 /*
 


### PR DESCRIPTION
## Summary
- add a shared json_shared.c translation unit that defines JSON_IMPLEMENTATION once
- remove the local definition from tr_bsp.c and include the new object in every relevant build list
- ensure json.h pulls in <string.h> for required C library prototypes

## Testing
- `make -C engine release` *(fails: missing dependency SDL_version.h in build environment)*

------
https://chatgpt.com/codex/tasks/task_e_68df8ba55da48324879f1b804b98d395