### PR TITLE
Make ladder downloads asynchronous

### DIFF
--- a/engine/code/client/cl_ui.c
+++ b/engine/code/client/cl_ui.c
@@ -44,6 +44,7 @@ typedef struct {
 static CURLM                  *cl_ladderCurlMulti = NULL;
 static CURL                   *cl_ladderCurlEasy = NULL;
 static ladderDownloadBuffer_t cl_ladderBuffer;
+static qboolean               cl_ladderRequestQueued = qfalse;
 
 static void CL_LadderCleanupRequest( qboolean releaseResources );
 static void CL_LadderCancelRequest( void );
@@ -207,12 +208,28 @@ static void CL_LadderParseResponse( const char *json, size_t length ) {
 }
 
 static void CL_LadderCleanupRequest( qboolean releaseResources ) {
+        if ( cl_ladderCurlMulti && cl_ladderCurlEasy && cl_ladderRequestQueued ) {
+                qcurl_multi_remove_handle( cl_ladderCurlMulti, cl_ladderCurlEasy );
+        }
+
+        cl_ladderRequestQueued = qfalse;
+
         if ( cl_ladderCurlEasy ) {
-                if ( cl_ladderCurlMulti ) {
-                        qcurl_multi_remove_handle( cl_ladderCurlMulti, cl_ladderCurlEasy );
+                if ( releaseResources ) {
+                        qcurl_easy_cleanup( cl_ladderCurlEasy );
+                        cl_ladderCurlEasy = NULL;
+                } else {
+#ifdef USE_CURL_DLOPEN
+                        if ( qcurl_easy_reset ) {
+                                qcurl_easy_reset( cl_ladderCurlEasy );
+                        } else {
+                                qcurl_easy_cleanup( cl_ladderCurlEasy );
+                                cl_ladderCurlEasy = NULL;
+                        }
+#else
+                        qcurl_easy_reset( cl_ladderCurlEasy );
+#endif
                 }
-                qcurl_easy_cleanup( cl_ladderCurlEasy );
-                cl_ladderCurlEasy = NULL;
         }
 
         cl_ladderBuffer.length = 0;
@@ -251,7 +268,7 @@ void CL_LadderPumpRequest( void ) {
         int             queued;
         int             running;
 
-        if ( !cl_ladderCurlMulti || !cl_ladderCurlEasy ) {
+        if ( !cl_ladderCurlMulti || !cl_ladderCurlEasy || !cl_ladderRequestQueued ) {
                 return;
         }
 
@@ -373,7 +390,10 @@ static void CL_LadderRequestData( const char *mode, const char *timeframe, const
                 "timeframe", timeframe && timeframe[0] ? timeframe : "all_time",
                 "region", region && region[0] ? region : "global" );
 
-        cl_ladderCurlEasy = qcurl_easy_init();
+        if ( !cl_ladderCurlEasy ) {
+                cl_ladderCurlEasy = qcurl_easy_init();
+        }
+
         if ( !cl_ladderCurlEasy ) {
                 CL_LadderSetError( "Failed to initialize HTTP client." );
                 return;
@@ -407,6 +427,8 @@ static void CL_LadderRequestData( const char *mode, const char *timeframe, const
                 CL_LadderCleanupRequest( qfalse );
                 return;
         }
+
+        cl_ladderRequestQueued = qtrue;
 #else
         (void)mode;
         (void)timeframe;

--- a/engine/code/q3_ui/ui_ladder.c
+++ b/engine/code/q3_ui/ui_ladder.c
@@ -219,6 +219,8 @@ static void LadderMenu_BuildResults( const uiLadderStatus_t *status ) {
 
 static void LadderMenu_RequestData( void ) {
         trap_CancelLadderRequest();
+        LadderMenu_ClearResults();
+        LadderMenu_SetStatusText( "Loading ladder data...", text_color_normal );
         trap_RequestLadderData( LadderMenu_CurrentModeKey(),
                 LadderMenu_CurrentTimeframeKey(),
                 LadderMenu_CurrentRegionKey() );


### PR DESCRIPTION
## Summary
- reuse a persistent cURL easy handle, multi handle, and buffer so ladder downloads queue without blocking the UI thread
- drive the queued transfer each frame and reuse the existing completion/error handling logic
- clear ladder results when issuing a new request so the menu immediately shows a loading state while data downloads

## Testing
- not run (not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68dfcd7e784c8324898855545afc605f