### PR TITLE
Remove ladder menu entry from main menu

### DIFF
--- a/engine/code/q3_ui/ui_menu.c
+++ b/engine/code/q3_ui/ui_menu.c
@@ -41,7 +41,6 @@ MAIN MENU
 
 #define ID_MODS                         16
 #define ID_GARAGE                       17
-#define ID_LADDER                       19
 #define ID_EXIT                         18
 
 #define MAIN_BANNER_MODEL               "models/mapobjects/q3rtitle/q3rtitle.md3"
@@ -60,7 +59,6 @@ typedef struct {
         menutext_s              cinematics;
         menutext_s              mods;
         menutext_s              garage;
-        menutext_s              ladder;
         menutext_s              exit;
 
         menutext_s              banner;
@@ -202,7 +200,6 @@ void Main_MenuEvent (void* ptr, int event) {
         case ID_MULTIPLAYER:
         case ID_SETUP:
         case ID_GARAGE:
-        case ID_LADDER:
         case ID_DEMOS:
         case ID_CINEMATICS:
         case ID_MODS:
@@ -241,10 +238,6 @@ void MainMenu_ChangeMenu( int menuId ){
                 UI_BotsMenu();
                 break;
 
-        case ID_LADDER:
-                UI_LadderMenu();
-                break;
-
         case ID_DEMOS:
                 UI_DemosMenu();
                 break;
@@ -276,7 +269,6 @@ void MainMenu_RunTransition( float frac ) {
         s_main.singleplayer.color = uis.text_color;
         s_main.multiplayer.color = uis.text_color;
         s_main.setup.color = uis.text_color;
-        s_main.ladder.color = uis.text_color;
         s_main.garage.color = uis.text_color;
         s_main.cinematics.color = uis.text_color;
         s_main.demos.color = uis.text_color;
@@ -442,16 +434,12 @@ void UI_MainMenu( void ) {
 	InitMenuText(&s_main.setup, ID_SETUP, "CONFIG", x - 10, y + 12);
 
 
-        y += MAIN_MENU_VERTICAL_SPACING;
-        InitMenuText(&s_main.ladder, ID_LADDER, "LADDER", x - 10, y + 12);
+	y += MAIN_MENU_VERTICAL_SPACING;
+	InitMenuText(&s_main.garage, ID_GARAGE, "THE GARAGE", x - 10, y + 12);
 
 
-        y += MAIN_MENU_VERTICAL_SPACING;
-        InitMenuText(&s_main.garage, ID_GARAGE, "THE GARAGE", x - 10, y + 12);
-
-
-        y += MAIN_MENU_VERTICAL_SPACING;
-        InitMenuText(&s_main.demos, ID_DEMOS, "DEMOS", x - 10, y + 12);
+	y += MAIN_MENU_VERTICAL_SPACING;
+	InitMenuText(&s_main.demos, ID_DEMOS, "DEMOS", x - 10, y + 12);
 
 
         s_main.carlogo.generic.type                     = MTYPE_BITMAP;
@@ -471,7 +459,6 @@ void UI_MainMenu( void ) {
         Menu_AddItem( &s_main.menu,     &s_main.singleplayer );
         Menu_AddItem( &s_main.menu,     &s_main.multiplayer );
         Menu_AddItem( &s_main.menu,     &s_main.setup );
-        Menu_AddItem( &s_main.menu,     &s_main.ladder );
         Menu_AddItem( &s_main.menu,     &s_main.garage );
         Menu_AddItem( &s_main.menu,     &s_main.demos );
         Menu_AddItem( &s_main.menu,     &s_main.exit );            


### PR DESCRIPTION
## Summary
- remove the ladder menu option and related code from the main menu implementation
- keep the menu layout aligned by moving THE GARAGE directly after CONFIG

## Testing
- make -C engine *(fails: missing SDL_version.h in build environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dfe1741010832486ee745e7e55f5cb