### PR TITLE
Remove ladder option from in-game menu

### DIFF
--- a/engine/code/q3_ui/ui_ingame.c
+++ b/engine/code/q3_ui/ui_ingame.c
@@ -47,7 +47,6 @@ INGAME MENU
 #define ID_QUIT					17
 #define ID_RESUME				18
 #define ID_TEAMORDERS			19
-#define ID_LADDER				20
 
 
 typedef struct {
@@ -57,7 +56,6 @@ typedef struct {
 	menutext_s		team;
 	menutext_s		setup;
 	menutext_s		server;
-	menutext_s		ladder;
 	menutext_s		leave;
 	menutext_s		restart;
 	menutext_s		addbots;
@@ -137,9 +135,6 @@ void InGame_Event( void *ptr, int notification ) {
 		UI_ServerInfoMenu();
 		break;
 
-	case ID_LADDER:
-		UI_LadderMenu();
-		break;
 
 	case ID_ADDBOTS:
 		UI_AddBotsMenu();
@@ -271,17 +266,6 @@ void InGame_MenuInit( void ) {
 	s_ingame.server.style				= UI_CENTER|UI_SMALLFONT;
 
 	y += INGAME_MENU_VERTICAL_SPACING;
-	s_ingame.ladder.generic.type		= MTYPE_PTEXT;
-	s_ingame.ladder.generic.flags		= QMF_CENTER_JUSTIFY|QMF_PULSEIFFOCUS;
-	s_ingame.ladder.generic.x			= 320;
-	s_ingame.ladder.generic.y			= y;
-	s_ingame.ladder.generic.id			= ID_LADDER;
-	s_ingame.ladder.generic.callback	= InGame_Event;
-	s_ingame.ladder.string				= "LADDER";
-	s_ingame.ladder.color				= color_red;
-	s_ingame.ladder.style				= UI_CENTER|UI_SMALLFONT;
-
-	y += INGAME_MENU_VERTICAL_SPACING;
 	s_ingame.restart.generic.type		= MTYPE_PTEXT;
 	s_ingame.restart.generic.flags		= QMF_CENTER_JUSTIFY|QMF_PULSEIFFOCUS;
 	s_ingame.restart.generic.x			= 320;
@@ -335,7 +319,6 @@ void InGame_MenuInit( void ) {
 	Menu_AddItem( &s_ingame.menu, &s_ingame.teamorders );
 	Menu_AddItem( &s_ingame.menu, &s_ingame.setup );
 	Menu_AddItem( &s_ingame.menu, &s_ingame.server );
-	Menu_AddItem( &s_ingame.menu, &s_ingame.ladder );
 	Menu_AddItem( &s_ingame.menu, &s_ingame.restart );
 	Menu_AddItem( &s_ingame.menu, &s_ingame.resume );
 	Menu_AddItem( &s_ingame.menu, &s_ingame.leave );


### PR DESCRIPTION
## Summary
- remove the ladder menu entry and handler from the in-game menu

## Testing
- rg "ID_LADDER"


------
https://chatgpt.com/codex/tasks/task_e_68dfe32d2d7483249e59826cd3481f43