### PR TITLE
Update match filtering to use where and add GT_RACING test

### DIFF
--- a/ladder_service/ladder_service/main.py
+++ b/ladder_service/ladder_service/main.py
@@ -86,7 +86,7 @@ def list_matches(
 
     query = select(Match).order_by(Match.start_time.desc()).offset(offset).limit(limit)
     if mode:
-        query = query.filter(Match.mode == mode)
+        query = query.where(Match.mode == mode)
 
     rows = session.execute(query).scalars().all()
     matches = [json.loads(row.payload) for row in rows]

--- a/ladder_service/tests/test_api.py
+++ b/ladder_service/tests/test_api.py
@@ -74,6 +74,27 @@ def test_list_matches() -> None:
     assert len(data["matches"]) >= 1
 
 
+def test_list_matches_filter_mode() -> None:
+    alt_match = {
+        **MATCH_TEMPLATE,
+        "matchId": "srv-20240405-183011-43",
+        "mode": "ARCADE_RACING",
+    }
+    created = client.post("/api/v1/matches", json=alt_match)
+    assert created.status_code == 201, created.text
+
+    response = client.get("/api/v1/matches?mode=GT_RACING")
+    assert response.status_code == 200, response.text
+    data = response.json()
+    assert data["matches"], "Expected at least one GT_RACING match in response"
+    for match in data["matches"]:
+        assert match["mode"] == "GT_RACING"
+        assert match["matchId"] != alt_match["matchId"]
+
+    cleanup = client.delete(f"/api/v1/matches/{alt_match['matchId']}")
+    assert cleanup.status_code == 204
+
+
 def test_delete_match() -> None:
     response = client.delete(f"/api/v1/matches/{MATCH_TEMPLATE['matchId']}")
     assert response.status_code == 204


### PR DESCRIPTION
## Summary
- switch the match listing endpoint to use SQLAlchemy's where() for optional mode filtering
- add a regression test that exercises GET /api/v1/matches?mode=GT_RACING and ensures the response only includes GT_RACING matches

## Testing
- pytest ladder_service/tests/test_api.py *(fails: missing httpx dependency in test environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e0c6366bd48324a616b31f0c3b07b4