### PR TITLE
Handle elimination finish time updates

### DIFF
--- a/engine/code/cgame/cg_local.h
+++ b/engine/code/cgame/cg_local.h
@@ -2000,7 +2000,7 @@ qboolean CG_InsideBox( vec3_t mins, vec3_t maxs, vec3_t pos );
 // cg_rally_race_tools.c
 //
 void CG_NewLapTime( int client, int lap, int time );
-void CG_FinishedRace( int client, int time, qboolean fuelDepleted );
+void CG_FinishedRace( int client, int time, int finishFlags );
 void CG_StartRace( int time );
 void CG_DrawRaceCountDown( void );
 void CG_DrawRaceFinishCountdown( void );

--- a/engine/code/cgame/cg_rally_racetools.c
+++ b/engine/code/cgame/cg_rally_racetools.c
@@ -53,19 +53,24 @@ void CG_NewLapTime( int client, int lap, int time ) {
 	cent->startLapTime = time;
 }
 
-void CG_FinishedRace( int client, int time, qboolean fuelDepleted ) {
+void CG_FinishedRace( int client, int time, int finishFlags ) {
 	centity_t	*cent;
 	char		*t;
+	qboolean	eliminationUpdate;
+	qboolean	fuelDepleted;
 
 	cent = &cg_entities[client];
 
-	if ( !cg.raceFinishCountdownActive ) {
+	eliminationUpdate = ( finishFlags & RACE_FINISH_FLAG_ELIMINATION_UPDATE ) ? qtrue : qfalse;
+	fuelDepleted = ( finishFlags & RACE_FINISH_FLAG_FUEL_DEPLETED ) ? qtrue : qfalse;
+
+	if ( !eliminationUpdate && !cg.raceFinishCountdownActive ) {
 		cg.raceFinishCountdownActive = qtrue;
 		cg.raceFinishCountdownStart = time;
 		cg.raceFinishCountdownEnd = time + ( cgs.finishRaceDelay * 1000 );
 	}
 
-	if ( !fuelDepleted && client == cg.snap->ps.clientNum
+	if ( !fuelDepleted && !eliminationUpdate && client == cg.snap->ps.clientNum
 		&& ((time - cent->startLapTime) < cent->bestLapTime || cent->bestLapTime == 0) ){
 		// New bestlap
 		cent->bestLapTime = (time - cent->startLapTime);

--- a/engine/code/cgame/cg_servercmds.c
+++ b/engine/code/cgame/cg_servercmds.c
@@ -1492,16 +1492,16 @@ static void CG_ServerCommand( void ) {
 	}
 
         if ( !strcmp( cmd, "raceFinishTime" ) ) {
-                int fuelDepleted = 0;
+                int finishFlags = 0;
 
                 i1 = atoi(CG_Argv(1));
                 i2 = atoi(CG_Argv(2));
 
                 if ( trap_Argc() >= 4 ) {
-                        fuelDepleted = atoi( CG_Argv(3) );
+                        finishFlags = atoi( CG_Argv(3) );
                 }
 
-                CG_FinishedRace( i1, i2, fuelDepleted ? qtrue : qfalse );
+                CG_FinishedRace( i1, i2, finishFlags );
                 return;
         }
 // END

--- a/engine/code/game/bg_public.h
+++ b/engine/code/game/bg_public.h
@@ -65,6 +65,9 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #define TIME_BONUS_PER_FRAG     500
 #define RACE_OBSERVER_DELAY     5000
 
+#define RACE_FINISH_FLAG_FUEL_DEPLETED         1
+#define RACE_FINISH_FLAG_ELIMINATION_UPDATE    2
+
 #define NORMAL_WEAPON_TIME_MASK 0x0000ffff
 #define REAR_WEAPON_TIME_MASK 0xffff0000
 // END

--- a/engine/code/game/g_combat.c
+++ b/engine/code/game/g_combat.c
@@ -533,7 +533,7 @@ void player_die( gentity_t *self, gentity_t *inflictor, gentity_t *attacker, int
 // STONELANCE
         if ((g_gametype.integer == GT_DERBY || g_gametype.integer == GT_LCS || g_gametype.integer == GT_ELIMINATION) && level.startRaceTime){
                 self->client->finishRaceTime = level.time;
-                trap_SendServerCommand( -1, va("raceFinishTime %i %i", self->s.number, self->client->finishRaceTime) );
+                trap_SendServerCommand( -1, va("raceFinishTime %i %i %i", self->s.number, self->client->finishRaceTime, RACE_FINISH_FLAG_ELIMINATION_UPDATE) );
         }
 // END
 


### PR DESCRIPTION
## Summary
- share race finish flag constants between the game and cgame modules
- tag derby, LCS, and elimination deaths with an elimination-only finish time update
- teach the client to parse finish flags so only genuine race completions trigger the countdown

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e256ef45f0832482a3c6187d78f52d