### PR TITLE
Validate client customization userinfo values

### DIFF
--- a/engine/code/cgame/cg_local.h
+++ b/engine/code/cgame/cg_local.h
@@ -90,8 +90,10 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 
 // Q3Rally Code Start - update to sidepipe
 // #define	DEFAULT_MODEL			"sarge"
-#define	DEFAULT_MODEL			"sidepipe"
-#define	DEFAULT_SKIN			"red"
+#ifndef DEFAULT_MODEL
+#define DEFAULT_MODEL                   "sidepipe"
+#endif
+#define DEFAULT_SKIN                    "red"
 // Q3Rally Code END
 #ifdef MISSIONPACK
 #define	DEFAULT_TEAM_MODEL		"doom"
@@ -103,9 +105,15 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #define	DEFAULT_TEAM_MODEL		"sidepipe"
 #define	DEFAULT_TEAM_HEAD		"doom"
 #endif
-#define	DEFAULT_HEAD			"doom"
-#define	DEFAULT_RIM				"svt_cobra"
-#define	DEFAULT_PLATE			"plate_usa"
+#ifndef DEFAULT_HEAD
+#define DEFAULT_HEAD                    "doom"
+#endif
+#ifndef DEFAULT_RIM
+#define DEFAULT_RIM                             "svt_cobra"
+#endif
+#ifndef DEFAULT_PLATE
+#define DEFAULT_PLATE                   "plate_usa"
+#endif
 #define	DEFAULT_PLATE_SKIN		"player0"
 
 extern	vec4_t				bgColor; // Q3Rally Code - UPDATE change variable name?

--- a/engine/code/game/bg_public.h
+++ b/engine/code/game/bg_public.h
@@ -29,6 +29,20 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #include "bg_physics.h"
 // END
 
+// shared defaults for cosmetic configuration
+#ifndef DEFAULT_MODEL
+#define DEFAULT_MODEL                   "sidepipe"
+#endif
+#ifndef DEFAULT_HEAD
+#define DEFAULT_HEAD                    "doom"
+#endif
+#ifndef DEFAULT_RIM
+#define DEFAULT_RIM                             "svt_cobra"
+#endif
+#ifndef DEFAULT_PLATE
+#define DEFAULT_PLATE                   "plate_usa"
+#endif
+
 // because games can change separately from the main system version, we need a
 // second version that must match between game and cgame
 

--- a/engine/code/game/g_client.c
+++ b/engine/code/game/g_client.c
@@ -36,6 +36,88 @@ static vec3_t	playerMaxs = {15, 15, 32};
 static vec3_t	playerMins = {-CAR_WIDTH/2, -CAR_WIDTH/2, -CAR_WIDTH/2};
 static vec3_t	playerMaxs = {CAR_WIDTH/2, CAR_WIDTH/2, CAR_WIDTH/2};
 
+typedef qboolean (*customValidator_t)( const char *value );
+
+static qboolean G_FileExists( const char *path ) {
+    fileHandle_t    f;
+    int             len;
+
+    len = trap_FS_FOpenFile( path, &f, FS_READ );
+    if ( len < 0 ) {
+        return qfalse;
+    }
+
+    trap_FS_FCloseFile( f );
+    return qtrue;
+}
+
+static qboolean G_CustomizationAssetExists( const char *format, const char *name ) {
+    char            path[MAX_QPATH];
+
+    if ( !name[0] || !Q_stricmp( name, "0" ) ) {
+        return qfalse;
+    }
+
+    Com_sprintf( path, sizeof( path ), format, name );
+    return G_FileExists( path );
+}
+
+static qboolean G_IsKnownCarModel( const char *model ) {
+    char            baseModel[MAX_QPATH];
+    const char      *slash;
+    int             len;
+
+    if ( !model[0] || !Q_stricmp( model, "0" ) ) {
+        return qfalse;
+    }
+
+    slash = strchr( model, '/' );
+    if ( slash ) {
+        len = slash - model;
+        if ( len <= 0 || len >= sizeof( baseModel ) ) {
+            return qfalse;
+        }
+        Q_strncpyz( baseModel, model, len + 1 );
+    } else {
+        Q_strncpyz( baseModel, model, sizeof( baseModel ) );
+    }
+
+    return G_CustomizationAssetExists( "models/players/%s/body.md3", baseModel );
+}
+
+static qboolean G_HeadAssetExists( const char *head ) {
+    return G_CustomizationAssetExists( "models/players/heads/%s.md3", head );
+}
+
+static qboolean G_RimAssetExists( const char *rim ) {
+    return G_CustomizationAssetExists( "models/players/wheels/%s.skin", rim );
+}
+
+static qboolean G_PlateAssetExists( const char *plate ) {
+    if ( !plate[0] || !Q_stricmp( plate, "0" ) ) {
+        return qfalse;
+    }
+
+    if ( G_CustomizationAssetExists( "models/players/plates/%s.md3", plate ) ) {
+        return qtrue;
+    }
+    if ( G_CustomizationAssetExists( "models/players/plates/%s.tga", plate ) ) {
+        return qtrue;
+    }
+    if ( G_CustomizationAssetExists( "models/players/plates/%s.jpg", plate ) ) {
+        return qtrue;
+    }
+
+    return qfalse;
+}
+
+static void G_SanitizeCustomizationValue( char *value, int valueSize, const char *defaultValue, customValidator_t validator ) {
+    if ( !validator( value ) ) {
+        Q_strncpyz( value, defaultValue, valueSize );
+    }
+}
+
+
 //static vec3_t	playerMins = {-CAR_LENGTH/2, -CAR_WIDTH/2, -CAR_HEIGHT/2};
 //static vec3_t	playerMaxs = {CAR_LENGTH/2, CAR_WIDTH/2, CAR_HEIGHT/2};
 // END
@@ -960,6 +1042,13 @@ void ClientUserinfoChanged( int clientNum ) {
 	// plate
 	Q_strncpyz( plate, Info_ValueForKey (userinfo, "plate"), sizeof( plate ) );
 // END
+
+	if ( !G_IsKnownCarModel( model ) ) {
+		Q_strncpyz( model, DEFAULT_MODEL, sizeof( model ) );
+	}
+	G_SanitizeCustomizationValue( headModel, sizeof( headModel ), DEFAULT_HEAD, G_HeadAssetExists );
+	G_SanitizeCustomizationValue( rim, sizeof( rim ), DEFAULT_RIM, G_RimAssetExists );
+	G_SanitizeCustomizationValue( plate, sizeof( plate ), DEFAULT_PLATE, G_PlateAssetExists );
 
 #ifdef MISSIONPACK
 	if (g_gametype.integer >= GT_TEAM && !(ent->r.svFlags & SVF_BOT)) {

--- a/engine/code/q3_ui/ui_local.h
+++ b/engine/code/q3_ui/ui_local.h
@@ -40,14 +40,22 @@ typedef void (*voidfunc_f)(void);
 // STONELANCE
 #define MENU_TRANSITION_TIME	665
 
-#define	DEFAULT_MODEL			"sidepipe"
-#define	DEFAULT_SKIN			"red"
-#define	DEFAULT_TEAM_MODEL		"sidepipe"
-#define	DEFAULT_TEAM_HEAD		"doom"
-#define	DEFAULT_HEAD			"doom"
-#define	DEFAULT_RIM				"svt_cobra"
-#define	DEFAULT_PLATE			"plate_usa"
-#define	DEFAULT_PLATE_SKIN		"default"
+#ifndef DEFAULT_MODEL
+#define DEFAULT_MODEL                   "sidepipe"
+#endif
+#define DEFAULT_SKIN                    "red"
+#define DEFAULT_TEAM_MODEL              "sidepipe"
+#define DEFAULT_TEAM_HEAD               "doom"
+#ifndef DEFAULT_HEAD
+#define DEFAULT_HEAD                    "doom"
+#endif
+#ifndef DEFAULT_RIM
+#define DEFAULT_RIM                             "svt_cobra"
+#endif
+#ifndef DEFAULT_PLATE
+#define DEFAULT_PLATE                   "plate_usa"
+#endif
+#define DEFAULT_PLATE_SKIN              "default"
 // END
 
 // STONELANCE


### PR DESCRIPTION
## Summary
- expose shared default cosmetic constants to both the game module and UI
- validate client model, head, rim, and plate selections on the server and fall back to defaults before updating the configstring

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e259b16ebc8324904fd8ce3971c2ad