### PR TITLE
Include q_shared in license plate header

### DIFF
--- a/engine/code/qcommon/q_shared_plates.h
+++ b/engine/code/qcommon/q_shared_plates.h
@@ -1,6 +1,8 @@
 #ifndef Q_SHARED_PLATES_H
 #define Q_SHARED_PLATES_H
 
+#include "q_shared.h"
+
 qboolean Q3R_CreateLicensePlateImage( const char *templateImage,
                                       const char *outputImage,
                                       const char *name,


### PR DESCRIPTION
## Summary
- include q_shared.h from q_shared_plates.h so qboolean is always defined

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e2b53508788324839f69e3dc32d392