### PR TITLE
Refactor scripted object parsing into shared helper

### DIFF
--- a/engine/Makefile
+++ b/engine/Makefile
@@ -285,6 +285,7 @@ ASMDIR=$(MOUNT_DIR)/asm
 SYSDIR=$(MOUNT_DIR)/sys
 GDIR=$(MOUNT_DIR)/game
 CGDIR=$(MOUNT_DIR)/cgame
+SHAREDDIR=$(MOUNT_DIR)/shared
 BLIBDIR=$(MOUNT_DIR)/botlib
 NDIR=$(MOUNT_DIR)/null
 UIDIR=$(MOUNT_DIR)/ui
@@ -2729,6 +2730,7 @@ Q3CGOBJ_ = \
   $(B)/$(BASEGAME)/cgame/cg_rally_racetools.o \
   $(B)/$(BASEGAME)/cgame/cg_rally_rearweapons.o \
   $(B)/$(BASEGAME)/cgame/cg_rally_scripted_objects.o \
+  $(B)/$(BASEGAME)/cgame/rally_script_parser.o \
   $(B)/$(BASEGAME)/cgame/cg_rally_tools.o \
   $(B)/$(BASEGAME)/cgame/cg_scoreboard.o \
   $(B)/$(BASEGAME)/cgame/cg_ladder.o \
@@ -2838,6 +2840,7 @@ Q3GOBJ_ = \
   $(B)/$(BASEGAME)/game/g_rally_racetools.o \
   $(B)/$(BASEGAME)/game/g_rally_rearweapon.o \
   $(B)/$(BASEGAME)/game/g_rally_scripted_objects.o \
+  $(B)/$(BASEGAME)/game/rally_script_parser.o \
   $(B)/$(BASEGAME)/game/g_rally_tools.o \
   $(B)/$(BASEGAME)/game/g_session.o \
   $(B)/$(BASEGAME)/game/g_spawn.o \
@@ -3178,6 +3181,12 @@ $(B)/$(BASEGAME)/cgame/%.o: $(CGDIR)/%.c
 $(B)/$(BASEGAME)/cgame/q_shared_plates.o: $(CMDIR)/q_shared_plates.c
 	$(DO_CGAME_CC)
 
+$(B)/$(BASEGAME)/cgame/rally_script_parser.o: $(SHAREDDIR)/rally_script_parser.c
+	$(DO_CGAME_CC)
+
+$(B)/$(BASEGAME)/cgame/rally_script_parser.asm: $(SHAREDDIR)/rally_script_parser.c $(Q3LCC)
+	$(DO_CGAME_Q3LCC)
+
 $(B)/$(BASEGAME)/cgame/bg_%.asm: $(GDIR)/bg_%.c $(Q3LCC)
 	$(DO_CGAME_Q3LCC)
 
@@ -3208,6 +3217,12 @@ $(B)/$(MISSIONPACK)/cgame/q_shared_plates.asm: $(CMDIR)/q_shared_plates.c $(Q3LC
 
 $(B)/$(BASEGAME)/game/%.o: $(GDIR)/%.c
 	$(DO_GAME_CC)
+
+$(B)/$(BASEGAME)/game/rally_script_parser.o: $(SHAREDDIR)/rally_script_parser.c
+	$(DO_GAME_CC)
+
+$(B)/$(BASEGAME)/game/rally_script_parser.asm: $(SHAREDDIR)/rally_script_parser.c $(Q3LCC)
+	$(DO_GAME_Q3LCC)
 
 $(B)/$(BASEGAME)/game/%.asm: $(GDIR)/%.c $(Q3LCC)
 	$(DO_GAME_Q3LCC)

--- a/engine/code/cgame/cg_rally_scripted_objects.c
+++ b/engine/code/cgame/cg_rally_scripted_objects.c
@@ -22,343 +22,98 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 */
 
 #include "cg_local.h"
-
-#define		MAX_SCRIPT_TEXT		8192
+#include "../shared/rally_script_parser.h"
 #define GIB_VELOCITY 250
 #define GIB_JUMP 100
 
-qboolean SeekToSection( char **pointer, char *str ){
-	char		*token;
-
-	// UPDATE: using strstr instead?
-	// UPDATE: check if end of file is inside of a bracket (ie bad brackets in script file)
-
-	// seek to 'str {'
-	while ( 1 ) {
-		token = COM_Parse( pointer );
-
-		if( !token || token[0] == 0 )
-			return qfalse;
-
-		if ( !Q_stricmp( token, "{" ) ){
-			// loop through this
-			while ( 1 ) {
-				token = COM_Parse( pointer );
-
-				if( !token || token[0] == 0 )
-					return qfalse;
-
-				if ( !Q_stricmp( token, "}" ) )
-					break;
-			}
-		}
-
-		if ( !Q_stricmp( token, str ) )
-			break;
-	}
-
-	if( !token || token[0] == 0 ) // not found 
-		return qfalse;
-
-	return qtrue;
-}
-
 qboolean CG_ParseScriptedObject( centity_t *cent, const char *scriptName ){
-	char		*text_p;
-	int			len, i;
-	char		*token;
-	char		text[MAX_SCRIPT_TEXT];
-	char		filename[MAX_QPATH];
-	char		model[MAX_QPATH];
-	char		deadmodel[MAX_QPATH];
-	fileHandle_t	f;
-
-	// setup defaults
-//	ent->takedamage = qfalse;
-//	VectorLength(ent->r.mins);
-//	VectorLength(ent->r.maxs);
-//	ent->elasticity = 0.1f;
-//	ent->mass = 100;
-//	ent->moveable = qfalse;
-//	ent->number = 0;
+	rallyScriptObjectDef_t config;
+	char			text[RSP_MAX_SCRIPT_TEXT];
+	char			filename[MAX_QPATH];
+	char			model[MAX_QPATH];
+	char			deadmodel[MAX_QPATH];
+	char			*text_p;
+	int			i;
 
 	if (!scriptName || scriptName[0] == 0){
 		Com_Printf("No Script file specified\n");
 		return qfalse;
 	}
 
-	Q_strncpyz(filename, scriptName, sizeof(filename));
-	token = strchr(filename, '.');
-	if (!token)
-		Q_strcat(filename, sizeof(filename), ".script");
+	cent->numGibModels = 0;
+	cent->gibsSpawned = qfalse;
+	memset( cent->gibModels, 0, sizeof( cent->gibModels ) );
+	memset( cent->gibSounds, 0, sizeof( cent->gibSounds ) );
+	cent->hitSound = 0;
+	cent->preSoundLoop = 0;
+	cent->postSoundLoop = 0;
+	cent->destroySound = 0;
+	cent->modelHandle = 0;
+	cent->deadModelHandle = 0;
 
-//	Com_Printf("Attempting to load script %s\n", filename);
-
-	// load the file
-	len = trap_FS_FOpenFile( filename, &f, FS_READ );
-
-	if ( !f ){
-		Com_Printf("Could not find script %s\n", filename);
+	if ( !RSP_LoadScriptText( scriptName, text, sizeof( text ), filename, sizeof( filename ),
+			trap_FS_FOpenFile, trap_FS_Read, trap_FS_FCloseFile, Com_Printf, cg_developer.integer ) ) {
 		return qfalse;
 	}
 
-	if ( len >= MAX_SCRIPT_TEXT ) {
-		len = MAX_SCRIPT_TEXT - 1;
-	}
-
-	trap_FS_Read( text, len, f );
-	text[len] = 0;
-
-	trap_FS_FCloseFile( f );
-
-	// parse the text
-	text_p = text;
-
-	// seek to "rally_scripted_object {"
-	if ( !SeekToSection( &text_p, "rally_scripted_object" ) ){
-		Com_Printf( "Script file '%s' did not contain rally_scripted_object\n", filename );
+	if ( !RSP_ParseScriptedObject( text, filename, &config, Com_Printf ) ) {
 		return qfalse;
 	}
 
-       model[0] = 0;
-       deadmodel[0] = 0;
+	model[0] = 0;
+	deadmodel[0] = 0;
+	if ( config.hasModel ) {
+		Q_strncpyz( model, config.model, sizeof( model ) );
+	}
+	if ( config.hasDeadModel ) {
+		Q_strncpyz( deadmodel, config.deadmodel, sizeof( deadmodel ) );
+	}
 
-       cent->numGibModels = 0;
-       cent->gibsSpawned = qfalse;
-       memset( cent->gibModels, 0, sizeof( cent->gibModels ) );
-       memset( cent->gibSounds, 0, sizeof( cent->gibSounds ) );
+	if ( config.hasHitSound ) {
+		cent->hitSound = trap_S_RegisterSound( config.hitSound, qfalse );
+	}
+	if ( config.hasPreSound ) {
+		cent->preSoundLoop = trap_S_RegisterSound( config.preSound, qfalse );
+	}
+	if ( config.hasPostSound ) {
+		cent->postSoundLoop = trap_S_RegisterSound( config.postSound, qfalse );
+	}
+	if ( config.hasDestroySound ) {
+		cent->destroySound = trap_S_RegisterSound( config.destroySound, qfalse );
+	}
 
-	// read optional parameters
-	while ( 1 ) {
-		token = COM_Parse( &text_p );
-
-		if( !token || token[0] == 0 || !Q_stricmp( token, "}" ) ) {
-			break;
-		}
-
-		if ( !Q_stricmp( token, "{" ) )
-			continue;
-
-//		Com_Printf("Found token: %s\n", token);
-
-		if ( !Q_stricmp( token, "type" ) ){
-			token = COM_Parse( &text_p );
-			if ( !token ) {
-				break;
+	for ( i = 0; i < config.numGibs && cent->numGibModels < MAX_SCRIPT_GIBS; i++ ) {
+		if ( config.gibs[i].model[0] ) {
+			int current = cent->numGibModels++;
+			cent->gibModels[current] = trap_R_RegisterModel( config.gibs[i].model );
+			if ( config.gibs[i].sound[0] ) {
+				cent->gibSounds[current] = trap_S_RegisterSound( config.gibs[i].sound, qfalse );
 			}
-
-			continue;
-		}
-		if ( !Q_stricmp( token, "model" ) ){
-			token = COM_Parse( &text_p );
-			if ( !token ) {
-				break;
-			}
-
-			Q_strncpyz( model, token, sizeof(model) );
-
-			continue;
-		}
-		else if ( !Q_stricmp( token, "deadmodel" ) ){
-			token = COM_Parse( &text_p );
-			if ( !token ) {
-				break;
-			}
-
-			Q_strncpyz( deadmodel, token, sizeof(deadmodel) );
-
-			continue;
-		}
-		else if ( !Q_stricmp( token, "moveable" ) ){
-			token = COM_Parse( &text_p );
-			if ( !token ) {
-				break;
-			}
-
-			continue;
-		}
-		else if ( !Q_stricmp( token, "elasticity" ) ){
-			token = COM_Parse( &text_p );
-			if ( !token ) {
-				break;
-			}
-
-			continue;
-		}
-		else if ( !Q_stricmp( token, "mass" ) ){
-			token = COM_Parse( &text_p );
-			if ( !token ) {
-				break;
-			}
-
-			continue;
-		}
-
-		else if ( !Q_stricmp( token, "frames" ) ){
-			token = COM_Parse( &text_p );
-			if ( !token ) {
-				break;
-			}
-
-//			ent->number = atoi(token);
-
-			continue;
-		}
-
-		else if ( !Q_stricmp( token, "health" ) ){
-			token = COM_Parse( &text_p );
-			if ( !token ) {
-				break;
-			}
-
-			continue;
-		}
-		else if ( !Q_stricmp( token, "mins" ) ){
-			for (i = 0; i < 3; i++){
-				token = COM_Parse( &text_p );
-				if ( !token ) break;
-			}
-
-			continue;
-		}
-		else if ( !Q_stricmp( token, "maxs" ) ){
-			for (i = 0; i < 3; i++){
-				token = COM_Parse( &text_p );
-				if ( !token ) break;
-			}
-
-			continue;
-		}
-		else if ( !Q_stricmp( token, "hitsound" ) ){
-			token = COM_Parse( &text_p );
-			if ( !token ) {
-				break;
-			}
-
-			cent->hitSound = trap_S_RegisterSound( token, qfalse );
-
-			continue;
-		}
-		else if ( !Q_stricmp( token, "presound" ) ){
-			token = COM_Parse( &text_p );
-			if ( !token ) {
-				break;
-			}
-
-			cent->preSoundLoop = trap_S_RegisterSound( token, qfalse );
-
-			continue;
-		}
-		else if ( !Q_stricmp( token, "postsound" ) ){
-			token = COM_Parse( &text_p );
-			if ( !token ) {
-				break;
-			}
-
-			cent->postSoundLoop = trap_S_RegisterSound( token, qfalse );
-
-			continue;
-		}
-		else if ( !Q_stricmp( token, "destroysound" ) ){
-			token = COM_Parse( &text_p );
-			if ( !token ) {
-				break;
-			}
-
-			cent->destroySound = trap_S_RegisterSound( token, qfalse );
-
-			continue;
-		}
-               else if ( !Q_stricmp( token, "gibs" ) ) {
-                       token = COM_Parse( &text_p );
-                       if ( !token ) {
-                               break;
-                       }
-
-                       if ( !Q_stricmp( token, "{" ) ){
-                               int current = -1;
-
-                               while ( 1 ) {
-                                       token = COM_Parse( &text_p );
-
-                                       if( !token || token[0] == 0 )
-                                               return qfalse;
-
-                                       if ( !Q_stricmp( token, "}" ) )
-                                               break;
-
-                                       if ( !Q_stricmp( token, "model" ) ) {
-                                               token = COM_Parse( &text_p );
-                                               if ( !token ) {
-                                                       break;
-                                               }
-
-                                               if ( cent->numGibModels < MAX_SCRIPT_GIBS ) {
-                                                       current = cent->numGibModels++;
-                                                       cent->gibModels[current] = trap_R_RegisterModel( token );
-                                               }
-                                               continue;
-                                       }
-
-                                       if ( !Q_stricmp( token, "sound" ) ) {
-                                               token = COM_Parse( &text_p );
-                                               if ( !token ) {
-                                                       break;
-                                               }
-
-                                               if ( current >= 0 && current < MAX_SCRIPT_GIBS ) {
-                                                       cent->gibSounds[current] = trap_S_RegisterSound( token, qfalse );
-                                               }
-                                               continue;
-                                       }
-
-                                       // skip any unknown token (like counts)
-                               }
-                       }
-
-                       continue;
-               }
-		else {
-			Com_Printf("Warning: Skipping unknown token %s in %s\n", token, filename);
-			continue;
 		}
 	}
 
-	if ( model[0] ){
-		// reset the pointer
+	if ( model[0] ) {
 		text_p = text;
-
-		if ( !SeekToSection( &text_p, model ) ){
-//			Com_Printf( "'%s' section not found in script file, assuming it was an actual filename\n", model );
-
+		if ( !RSP_SeekToSection( &text_p, model ) ) {
 			cent->modelHandle = trap_R_RegisterModel( deadmodel );
-		}
-		else {
+		} else {
 			Com_Printf( "Loading model info for '%s'\n", model );
-			// load model info
+			/* load model info */
 		}
 	}
 
-	if ( deadmodel[0] ){
-		// reset the pointer
+	if ( deadmodel[0] ) {
 		text_p = text;
-
-		if ( !SeekToSection( &text_p, deadmodel ) ){
-//			Com_Printf( "'%s' section not found in script file, assuming it was an actual filename\n", model );
-
+		if ( !RSP_SeekToSection( &text_p, deadmodel ) ) {
 			cent->deadModelHandle = trap_R_RegisterModel( deadmodel );
-		}
-		else {
+		} else {
 			Com_Printf( "Loading deadmodel info for '%s'\n", deadmodel );
-			// load deadmodel info
+			/* load deadmodel info */
 		}
 	}
-
-//	Com_Printf("Successfully parsed script file\n");
 
 	return qtrue;
 }
-
 /*
 void CG_ScriptedObject_Destroy( gentity_t *self, gentity_t *inflictor, gentity_t *attacker, int damage, int mod ){
 }

--- a/engine/code/game/g_rally_scripted_objects.c
+++ b/engine/code/game/g_rally_scripted_objects.c
@@ -22,8 +22,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 */
 
 #include "g_local.h"
-
-#define		MAX_SCRIPT_TEXT		8192
+#include "../shared/rally_script_parser.h"
 
 /* collision types */
 #define		CT_BOX			0
@@ -33,49 +32,10 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 /* Global temporary force vector for testing */
 vec3_t		tempForce;
 
-qboolean SeekToSection( char **pointer, char *str ){
-	char		*token;
-
-	/* UPDATE: using strstr instead? */
-	/* UPDATE: check if end of file is inside of a bracket (ie bad brackets in script file) */
-
-	/* seek to 'str {' */
-	while ( 1 ) {
-		token = COM_Parse( pointer );
-
-		if( !token || token[0] == 0 )
-			return qfalse;
-
-		if ( !Q_stricmp( token, "{" ) ){
-			/* loop through this */
-			while ( 1 ) {
-				token = COM_Parse( pointer );
-
-				if( !token || token[0] == 0 )
-					return qfalse;
-
-				if ( !Q_stricmp( token, "}" ) )
-					break;
-			}
-		}
-
-		if ( !Q_stricmp( token, str ) )
-			break;
-	}
-
-	if( !token || token[0] == 0 ) /* model not found */
-		return qfalse;
-
-	return qtrue;
-}
-
 qboolean G_ParseScriptedObject( gentity_t *ent ){
-	char		*text_p;
-	int			len, i;
-	char		*token;
-	char		text[MAX_SCRIPT_TEXT];
-	char		filename[MAX_QPATH];
-	fileHandle_t	f;
+	rallyScriptObjectDef_t config;
+	char			text[RSP_MAX_SCRIPT_TEXT];
+	char			filename[MAX_QPATH];
 
 	/* setup defaults */
 	ent->takedamage = qfalse;
@@ -95,37 +55,12 @@ qboolean G_ParseScriptedObject( gentity_t *ent ){
 	/* if( Q_stricmp( ent->script, "models/mapobjects/barrels/barrel01" ) ) */
 	/*	return qfalse; */
 
-	Q_strncpyz(filename, ent->script, sizeof(filename));
-	token = strchr(filename, '.');
-	if (!token)
-		Q_strcat(filename, sizeof(filename), ".script");
-
-	if (g_developer.integer)
-		Com_Printf("Attempting to load script %s\n", filename);
-
-	/* load the file */
-	len = trap_FS_FOpenFile( filename, &f, FS_READ );
-
-	if ( !f ){
-		Com_Printf("Could not find script %s\n", filename);
+	if ( !RSP_LoadScriptText( ent->script, text, sizeof( text ), filename, sizeof( filename ),
+			trap_FS_FOpenFile, trap_FS_Read, trap_FS_FCloseFile, Com_Printf, g_developer.integer ) ) {
 		return qfalse;
 	}
 
-	if ( len >= MAX_SCRIPT_TEXT ) {
-		len = MAX_SCRIPT_TEXT - 1;
-	}
-
-	trap_FS_Read( text, len, f );
-	text[len] = 0;
-
-	trap_FS_FCloseFile( f );
-
-	/* parse the text */
-	text_p = text;
-
-	/* seek to "rally_scripted_object {" */
-	if ( !SeekToSection( &text_p, "rally_scripted_object" ) ){
-		Com_Printf( "Script file '%s' did not contain rally_scripted_object\n", filename );
+	if ( !RSP_ParseScriptedObject( text, filename, &config, Com_Printf ) ) {
 		return qfalse;
 	}
 
@@ -133,152 +68,43 @@ qboolean G_ParseScriptedObject( gentity_t *ent ){
 	/* to do all of the drawing and stuff server side. */
 	ent->s.modelindex = G_ScriptIndex( ent->script );
 
-	/* read optional parameters */
-	while ( 1 ) {
-		token = COM_Parse( &text_p );
-
-		if( !token || token[0] == 0 || !Q_stricmp( token, "}" ) ) {
-			break;
-		}
-
-		if ( !Q_stricmp( token, "{" ) )
-			continue;
-
-		if (g_developer.integer)
-			Com_Printf("Found token: %s\n", token);
-
-		if ( !Q_stricmp( token, "type" ) ){
-			token = COM_Parse( &text_p );
-			if ( !token ) {
-				break;
-			}
-
-			ent->s.weapon = atoi(token);
-
-			continue;
-		}
-		else if ( !Q_stricmp( token, "model" ) ){
-			COM_Parse( &text_p );
-		}
-		else if ( !Q_stricmp( token, "deadmodel" ) ){
-			COM_Parse( &text_p );
-		}
-		else if ( !Q_stricmp( token, "moveable" ) ){
-			token = COM_Parse( &text_p );
-			if ( !token ) {
-				break;
-			}
-
-			ent->moveable = atoi(token);
-
-			continue;
-		}
-		else if ( !Q_stricmp( token, "elasticity" ) ){
-			token = COM_Parse( &text_p );
-			if ( !token ) {
-				break;
-			}
-
-			ent->elasticity = atof(token);
-
-			continue;
-		}
-		else if ( !Q_stricmp( token, "mass" ) ){
-			token = COM_Parse( &text_p );
-			if ( !token ) {
-				break;
-			}
-
-			ent->mass = atoi(token);
-			if (ent->mass <= 0)
-				ent->mass = 100;
-
-			continue;
-		}
-		else if ( !Q_stricmp( token, "frames" ) ){
-			COM_Parse( &text_p );
-			COM_Parse( &text_p );
-			COM_Parse( &text_p );
-			COM_Parse( &text_p );
-		}
-		else if ( !Q_stricmp( token, "health" ) ){
-			token = COM_Parse( &text_p );
-			if ( !token ) {
-				break;
-			}
-
-			ent->maxHealth = ent->health = atoi(token);
-			if (ent->health >= 0)
-				ent->takedamage = qtrue;
-
-			continue;
-		}
-		else if ( !Q_stricmp( token, "mins" ) ){
-			for (i = 0; i < 3; i++){
-				token = COM_Parse( &text_p );
-				if ( !token ) break;
-
-				ent->r.mins[i] = atof(token);
-			}
-
-			continue;
-		}
-		else if ( !Q_stricmp( token, "maxs" ) ){
-			for (i = 0; i < 3; i++){
-				token = COM_Parse( &text_p );
-				if ( !token ) break;
-
-				ent->r.maxs[i] = atof(token);
-			}
-
-			continue;
-		}
-		else if ( !Q_stricmp( token, "hitsound" ) ){
-			COM_Parse( &text_p );
-		}
-		else if ( !Q_stricmp( token, "presound" ) ){
-			COM_Parse( &text_p );
-		}
-		else if ( !Q_stricmp( token, "postsound" ) ){
-			COM_Parse( &text_p );
-		}
-		else if ( !Q_stricmp( token, "destroysound" ) ){
-			COM_Parse( &text_p );
-		}
-		else if ( !Q_stricmp( token, "gibs" ) ) {
-			/* skip gibs part of script (it is only used client side) */
-			token = COM_Parse( &text_p );
-			if ( !token ) {
-				break;
-			}
-
-			if ( !Q_stricmp( token, "{" ) ){
-				/* loop through this */
-				while ( 1 ) {
-					token = COM_Parse( &text_p );
-
-					if( !token || token[0] == 0 )
-						return qfalse;
-
-					if ( !Q_stricmp( token, "}" ) )
-						break;
-				}
-			}
-
-			continue;
-		}
-		else {
-			Com_Printf("Warning: Skipping unknown token %s in %s\n", token, filename);
-			continue;
-		}
+	if ( config.hasType ) {
+		ent->s.weapon = config.type;
 	}
 
-	if (g_developer.integer)
+	if ( config.hasMoveable ) {
+		ent->moveable = config.moveable;
+	}
+
+	if ( config.hasElasticity ) {
+		ent->elasticity = config.elasticity;
+	}
+
+	if ( config.hasMass ) {
+		ent->mass = config.mass;
+		if ( ent->mass <= 0 )
+			ent->mass = 100;
+	}
+
+	if ( config.hasHealth ) {
+		ent->maxHealth = ent->health = config.health;
+		if ( ent->health >= 0 )
+			ent->takedamage = qtrue;
+	}
+
+	if ( config.hasMins ) {
+		VectorCopy( config.mins, ent->r.mins );
+	}
+
+	if ( config.hasMaxs ) {
+		VectorCopy( config.maxs, ent->r.maxs );
+	}
+
+	if ( g_developer.integer )
 		Com_Printf("Successfully parsed script file\n");
 
 	return qtrue;
 }
-
 void G_ScriptedObject_Destroy( gentity_t *self, gentity_t *inflictor, gentity_t *attacker, int damage, int mod ){
 	Com_Printf("Destroying scripted map object %s\n", self->classname);
 

--- a/engine/code/shared/rally_script_parser.c
+++ b/engine/code/shared/rally_script_parser.c
@@ -1,0 +1,425 @@
+/*
+===========================================================================
+Shared implementation for parsing rally scripted object definitions.
+===========================================================================
+*/
+
+#include "rally_script_parser.h"
+
+#include <stdlib.h>
+#include <string.h>
+
+static void RSP_CopyToken( char *dest, size_t destSize, const char *token ) {
+    if ( !dest || !destSize ) {
+        return;
+    }
+
+    if ( token && token[0] ) {
+        Q_strncpyz( dest, token, destSize );
+    } else {
+        dest[0] = '\0';
+    }
+}
+
+void RSP_InitObjectDef( rallyScriptObjectDef_t *def ) {
+    if ( !def ) {
+        return;
+    }
+
+    memset( def, 0, sizeof( *def ) );
+    def->mass = 100;
+    def->elasticity = 0.1f;
+}
+
+qboolean RSP_LoadScriptText( const char *scriptName,
+                            char *buffer, int bufferSize,
+                            char *resolvedName, size_t resolvedSize,
+                            rsp_fs_open_t fsOpen,
+                            rsp_fs_read_t fsRead,
+                            rsp_fs_close_t fsClose,
+                            rsp_print_t printFn,
+                            qboolean developerMode ) {
+    fileHandle_t    fileHandle;
+    int             len;
+    char            filename[MAX_QPATH];
+
+    if ( !buffer || bufferSize <= 0 || !fsOpen || !fsRead || !fsClose ) {
+        return qfalse;
+    }
+
+    if ( !scriptName || !scriptName[0] ) {
+        if ( printFn ) {
+            printFn( "No Script file specified\n" );
+        }
+        return qfalse;
+    }
+
+    Q_strncpyz( filename, scriptName, sizeof( filename ) );
+    if ( !strchr( filename, '.' ) ) {
+        Q_strcat( filename, sizeof( filename ), ".script" );
+    }
+
+    if ( developerMode && printFn ) {
+        printFn( "Attempting to load script %s\n", filename );
+    }
+
+    len = fsOpen( filename, &fileHandle, FS_READ );
+    if ( !fileHandle ) {
+        if ( printFn ) {
+            printFn( "Could not find script %s\n", filename );
+        }
+        return qfalse;
+    }
+
+    if ( len >= bufferSize ) {
+        len = bufferSize - 1;
+    }
+
+    fsRead( buffer, len, fileHandle );
+    buffer[len] = '\0';
+    fsClose( fileHandle );
+
+    if ( resolvedName ) {
+        Q_strncpyz( resolvedName, filename, resolvedSize );
+    }
+
+    return qtrue;
+}
+
+static qboolean RSP_ParseGibs( char **text_p, rallyScriptObjectDef_t *outDef, rsp_print_t warningFn, const char *filename ) {
+    char    *token;
+    int     current = -1;
+
+    token = COM_Parse( text_p );
+    if ( !token || !token[0] ) {
+        return qfalse;
+    }
+
+    if ( Q_stricmp( token, "{" ) ) {
+        // nothing to parse, treat as malformed block
+        if ( warningFn ) {
+            warningFn( "Warning: Malformed gibs block in %s\n", filename );
+        }
+        return qfalse;
+    }
+
+    while ( 1 ) {
+        token = COM_Parse( text_p );
+
+        if ( !token || !token[0] ) {
+            return qfalse;
+        }
+
+        if ( !Q_stricmp( token, "}" ) ) {
+            break;
+        }
+
+        if ( !Q_stricmp( token, "{" ) ) {
+            // skip nested sections entirely
+            if ( !RSP_SkipBracedSection( text_p ) ) {
+                return qfalse;
+            }
+            continue;
+        }
+
+        if ( !Q_stricmp( token, "model" ) ) {
+            token = COM_Parse( text_p );
+            if ( !token || !token[0] ) {
+                return qfalse;
+            }
+
+            if ( outDef->numGibs < RSP_MAX_GIBS ) {
+                current = outDef->numGibs++;
+                RSP_CopyToken( outDef->gibs[current].model, sizeof( outDef->gibs[current].model ), token );
+            } else {
+                current = -1;
+            }
+            continue;
+        }
+
+        if ( !Q_stricmp( token, "sound" ) ) {
+            token = COM_Parse( text_p );
+            if ( !token || !token[0] ) {
+                return qfalse;
+            }
+
+            if ( current >= 0 && current < outDef->numGibs ) {
+                RSP_CopyToken( outDef->gibs[current].sound, sizeof( outDef->gibs[current].sound ), token );
+            }
+            continue;
+        }
+
+        // Skip unknown token (and let following tokens be processed)
+        if ( warningFn ) {
+            warningFn( "Warning: Skipping unknown token %s in %s\n", token, filename );
+        }
+    }
+
+    return qtrue;
+}
+
+qboolean RSP_ParseScriptedObject( char *text, const char *filename,
+                                  rallyScriptObjectDef_t *outDef,
+                                  rsp_print_t warningFn ) {
+    char    *text_p;
+    char    *token;
+
+    if ( !text || !outDef ) {
+        return qfalse;
+    }
+
+    RSP_InitObjectDef( outDef );
+    if ( filename ) {
+        Q_strncpyz( outDef->scriptFile, filename, sizeof( outDef->scriptFile ) );
+    }
+
+    text_p = text;
+    if ( !RSP_SeekToSection( &text_p, "rally_scripted_object" ) ) {
+        if ( warningFn ) {
+            warningFn( "Script file '%s' did not contain rally_scripted_object\n", filename ? filename : "<unknown>" );
+        }
+        return qfalse;
+    }
+
+    while ( 1 ) {
+        token = COM_Parse( &text_p );
+
+        if ( !token || !token[0] || !Q_stricmp( token, "}" ) ) {
+            break;
+        }
+
+        if ( !Q_stricmp( token, "{" ) ) {
+            continue;
+        }
+
+        if ( !Q_stricmp( token, "type" ) ) {
+            token = COM_Parse( &text_p );
+            if ( !token || !token[0] ) {
+                return qfalse;
+            }
+            outDef->type = atoi( token );
+            outDef->hasType = qtrue;
+            continue;
+        }
+
+        if ( !Q_stricmp( token, "model" ) ) {
+            token = COM_Parse( &text_p );
+            if ( !token || !token[0] ) {
+                return qfalse;
+            }
+            RSP_CopyToken( outDef->model, sizeof( outDef->model ), token );
+            outDef->hasModel = qtrue;
+            continue;
+        }
+
+        if ( !Q_stricmp( token, "deadmodel" ) ) {
+            token = COM_Parse( &text_p );
+            if ( !token || !token[0] ) {
+                return qfalse;
+            }
+            RSP_CopyToken( outDef->deadmodel, sizeof( outDef->deadmodel ), token );
+            outDef->hasDeadModel = qtrue;
+            continue;
+        }
+
+        if ( !Q_stricmp( token, "moveable" ) ) {
+            token = COM_Parse( &text_p );
+            if ( !token || !token[0] ) {
+                return qfalse;
+            }
+            outDef->moveable = ( atoi( token ) != 0 );
+            outDef->hasMoveable = qtrue;
+            continue;
+        }
+
+        if ( !Q_stricmp( token, "elasticity" ) ) {
+            token = COM_Parse( &text_p );
+            if ( !token || !token[0] ) {
+                return qfalse;
+            }
+            outDef->elasticity = (float)atof( token );
+            outDef->hasElasticity = qtrue;
+            continue;
+        }
+
+        if ( !Q_stricmp( token, "mass" ) ) {
+            token = COM_Parse( &text_p );
+            if ( !token || !token[0] ) {
+                return qfalse;
+            }
+            outDef->mass = atoi( token );
+            outDef->hasMass = qtrue;
+            continue;
+        }
+
+        if ( !Q_stricmp( token, "frames" ) ) {
+            // skip the next two tokens (start and end frames)
+            COM_Parse( &text_p );
+            COM_Parse( &text_p );
+            continue;
+        }
+
+        if ( !Q_stricmp( token, "health" ) ) {
+            token = COM_Parse( &text_p );
+            if ( !token || !token[0] ) {
+                return qfalse;
+            }
+            outDef->health = atoi( token );
+            outDef->hasHealth = qtrue;
+            continue;
+        }
+
+        if ( !Q_stricmp( token, "mins" ) ) {
+            if ( !RSP_ParseTokenVec3( &text_p, outDef->mins ) ) {
+                return qfalse;
+            }
+            outDef->hasMins = qtrue;
+            continue;
+        }
+
+        if ( !Q_stricmp( token, "maxs" ) ) {
+            if ( !RSP_ParseTokenVec3( &text_p, outDef->maxs ) ) {
+                return qfalse;
+            }
+            outDef->hasMaxs = qtrue;
+            continue;
+        }
+
+        if ( !Q_stricmp( token, "hitsound" ) ) {
+            token = COM_Parse( &text_p );
+            if ( !token || !token[0] ) {
+                return qfalse;
+            }
+            RSP_CopyToken( outDef->hitSound, sizeof( outDef->hitSound ), token );
+            outDef->hasHitSound = qtrue;
+            continue;
+        }
+
+        if ( !Q_stricmp( token, "presound" ) ) {
+            token = COM_Parse( &text_p );
+            if ( !token || !token[0] ) {
+                return qfalse;
+            }
+            RSP_CopyToken( outDef->preSound, sizeof( outDef->preSound ), token );
+            outDef->hasPreSound = qtrue;
+            continue;
+        }
+
+        if ( !Q_stricmp( token, "postsound" ) ) {
+            token = COM_Parse( &text_p );
+            if ( !token || !token[0] ) {
+                return qfalse;
+            }
+            RSP_CopyToken( outDef->postSound, sizeof( outDef->postSound ), token );
+            outDef->hasPostSound = qtrue;
+            continue;
+        }
+
+        if ( !Q_stricmp( token, "destroysound" ) ) {
+            token = COM_Parse( &text_p );
+            if ( !token || !token[0] ) {
+                return qfalse;
+            }
+            RSP_CopyToken( outDef->destroySound, sizeof( outDef->destroySound ), token );
+            outDef->hasDestroySound = qtrue;
+            continue;
+        }
+
+        if ( !Q_stricmp( token, "gibs" ) ) {
+            if ( !RSP_ParseGibs( &text_p, outDef, warningFn, filename ) ) {
+                return qfalse;
+            }
+            continue;
+        }
+
+        if ( warningFn ) {
+            warningFn( "Warning: Skipping unknown token %s in %s\n", token, filename ? filename : "<unknown>" );
+        }
+    }
+
+    return qtrue;
+}
+
+qboolean RSP_SeekToSection( char **pointer, const char *section ) {
+    char    *token;
+
+    if ( !pointer || !*pointer || !section ) {
+        return qfalse;
+    }
+
+    while ( 1 ) {
+        token = COM_Parse( pointer );
+
+        if ( !token || !token[0] ) {
+            return qfalse;
+        }
+
+        if ( !Q_stricmp( token, "{" ) ) {
+            if ( !RSP_SkipBracedSection( pointer ) ) {
+                return qfalse;
+            }
+            continue;
+        }
+
+        if ( !Q_stricmp( token, section ) ) {
+            break;
+        }
+    }
+
+    return qtrue;
+}
+
+qboolean RSP_ParseTokenVec3( char **text_p, vec3_t out ) {
+    int i;
+    char *token;
+
+    if ( !text_p || !out ) {
+        return qfalse;
+    }
+
+    for ( i = 0; i < 3; i++ ) {
+        token = COM_Parse( text_p );
+        if ( !token || !token[0] ) {
+            return qfalse;
+        }
+
+        out[i] = (float)atof( token );
+    }
+
+    return qtrue;
+}
+
+qboolean RSP_SkipBracedSection( char **text_p ) {
+    char    *token;
+    int     depth = 0;
+
+    if ( !text_p ) {
+        return qfalse;
+    }
+
+    while ( 1 ) {
+        token = COM_Parse( text_p );
+
+        if ( !token || !token[0] ) {
+            return qfalse;
+        }
+
+        if ( !Q_stricmp( token, "{" ) ) {
+            depth++;
+            continue;
+        }
+
+        if ( !Q_stricmp( token, "}" ) ) {
+            if ( depth == 0 ) {
+                break;
+            }
+
+            depth--;
+            if ( depth < 0 ) {
+                depth = 0;
+            }
+        }
+    }
+
+    return qtrue;
+}

--- a/engine/code/shared/rally_script_parser.h
+++ b/engine/code/shared/rally_script_parser.h
@@ -1,0 +1,95 @@
+/*
+===========================================================================
+Shared utilities for parsing rally scripted object definitions.
+===========================================================================
+*/
+
+#ifndef RALLY_SCRIPT_PARSER_H
+#define RALLY_SCRIPT_PARSER_H
+
+#include <stddef.h>
+
+#include "../qcommon/q_shared.h"
+
+#define RSP_MAX_SCRIPT_TEXT     8192
+
+#ifndef RSP_MAX_GIBS
+#define RSP_MAX_GIBS            5
+#endif
+
+typedef struct {
+    char    model[MAX_QPATH];
+    char    sound[MAX_QPATH];
+} rallyScriptGibDef_t;
+
+typedef struct {
+    char    scriptFile[MAX_QPATH];
+
+    int     type;
+    qboolean        hasType;
+
+    qboolean        moveable;
+    qboolean        hasMoveable;
+
+    float   elasticity;
+    qboolean        hasElasticity;
+
+    int     mass;
+    qboolean        hasMass;
+
+    int     health;
+    qboolean        hasHealth;
+
+    vec3_t  mins;
+    qboolean        hasMins;
+
+    vec3_t  maxs;
+    qboolean        hasMaxs;
+
+    char    model[MAX_QPATH];
+    qboolean        hasModel;
+
+    char    deadmodel[MAX_QPATH];
+    qboolean        hasDeadModel;
+
+    char    hitSound[MAX_QPATH];
+    qboolean        hasHitSound;
+
+    char    preSound[MAX_QPATH];
+    qboolean        hasPreSound;
+
+    char    postSound[MAX_QPATH];
+    qboolean        hasPostSound;
+
+    char    destroySound[MAX_QPATH];
+    qboolean        hasDestroySound;
+
+    int     numGibs;
+    rallyScriptGibDef_t gibs[RSP_MAX_GIBS];
+} rallyScriptObjectDef_t;
+
+typedef void (QDECL *rsp_print_t)( const char *fmt, ... );
+typedef int (*rsp_fs_open_t)( const char *qpath, fileHandle_t *f, fsMode_t mode );
+typedef void (*rsp_fs_read_t)( void *buffer, int len, fileHandle_t f );
+typedef void (*rsp_fs_close_t)( fileHandle_t f );
+
+void RSP_InitObjectDef( rallyScriptObjectDef_t *def );
+
+qboolean RSP_LoadScriptText( const char *scriptName,
+                            char *buffer, int bufferSize,
+                            char *resolvedName, size_t resolvedSize,
+                            rsp_fs_open_t fsOpen,
+                            rsp_fs_read_t fsRead,
+                            rsp_fs_close_t fsClose,
+                            rsp_print_t printFn,
+                            qboolean developerMode );
+
+qboolean RSP_ParseScriptedObject( char *text, const char *filename,
+                                  rallyScriptObjectDef_t *outDef,
+                                  rsp_print_t warningFn );
+
+qboolean RSP_SeekToSection( char **pointer, const char *section );
+qboolean RSP_ParseTokenVec3( char **text_p, vec3_t out );
+qboolean RSP_SkipBracedSection( char **text_p );
+
+#endif /* RALLY_SCRIPT_PARSER_H */


### PR DESCRIPTION
## Summary
- add a shared rally script parser module that loads, tokenises and shares configuration data for scripted map objects
- switch both the game- and client-side scripted object loaders to the new parser so they consume the shared configuration struct
- wire the new shared sources into the Makefile so cgame and game builds compile the helper

## Testing
- `make BUILD_CLIENT=0 BUILD_GAME_SO=1 BUILD_BASEGAME=1 -j1` *(fails: existing duplicate trap_R_RegisterShaderLightMap declaration in cg_local.h)*

------
https://chatgpt.com/codex/tasks/task_e_68e43152d80c83249ed8b2ea4d8e849f