### PR TITLE
Fix scripted object model registration

### DIFF
--- a/engine/code/cgame/cg_rally_scripted_objects.c
+++ b/engine/code/cgame/cg_rally_scripted_objects.c
@@ -120,10 +120,14 @@ qboolean CG_ParseScriptedObject( centity_t *cent, const char *scriptName ){
 		return qfalse;
 	}
 
-       model[0] = 0;
-       deadmodel[0] = 0;
+	model[0] = 0;
+	deadmodel[0] = 0;
 
-       cent->numGibModels = 0;
+	// Models can be referenced directly by path or via a section that contains a "model" token.
+	cent->modelHandle = 0;
+	cent->deadModelHandle = 0;
+
+	cent->numGibModels = 0;
        cent->gibsSpawned = qfalse;
        memset( cent->gibModels, 0, sizeof( cent->gibModels ) );
        memset( cent->gibSounds, 0, sizeof( cent->gibSounds ) );
@@ -325,21 +329,51 @@ qboolean CG_ParseScriptedObject( centity_t *cent, const char *scriptName ){
 	}
 
 	if ( model[0] ){
+		qboolean foundModelPath = qfalse;
+
 		// reset the pointer
 		text_p = text;
 
 		if ( !SeekToSection( &text_p, model ) ){
 //			Com_Printf( "'%s' section not found in script file, assuming it was an actual filename\n", model );
 
-			cent->modelHandle = trap_R_RegisterModel( deadmodel );
+			cent->modelHandle = trap_R_RegisterModel( model );
 		}
 		else {
-			Com_Printf( "Loading model info for '%s'\n", model );
-			// load model info
+			while ( 1 ) {
+				token = COM_Parse( &text_p );
+
+				if ( !token || token[0] == 0 ) {
+					break;
+				}
+
+				if ( !Q_stricmp( token, "{" ) ) {
+					continue;
+				}
+
+				if ( !Q_stricmp( token, "}" ) ) {
+					break;
+				}
+
+				if ( !Q_stricmp( token, "model" ) ) {
+					token = COM_Parse( &text_p );
+					if ( token && token[0] ) {
+						cent->modelHandle = trap_R_RegisterModel( token );
+						foundModelPath = qtrue;
+					}
+					break;
+				}
+			}
+
+			if ( !foundModelPath ) {
+				cent->modelHandle = trap_R_RegisterModel( model );
+			}
 		}
 	}
 
 	if ( deadmodel[0] ){
+		qboolean foundDeadModelPath = qfalse;
+
 		// reset the pointer
 		text_p = text;
 
@@ -349,8 +383,34 @@ qboolean CG_ParseScriptedObject( centity_t *cent, const char *scriptName ){
 			cent->deadModelHandle = trap_R_RegisterModel( deadmodel );
 		}
 		else {
-			Com_Printf( "Loading deadmodel info for '%s'\n", deadmodel );
-			// load deadmodel info
+			while ( 1 ) {
+				token = COM_Parse( &text_p );
+
+				if ( !token || token[0] == 0 ) {
+					break;
+				}
+
+				if ( !Q_stricmp( token, "{" ) ) {
+					continue;
+				}
+
+				if ( !Q_stricmp( token, "}" ) ) {
+					break;
+				}
+
+				if ( !Q_stricmp( token, "model" ) ) {
+					token = COM_Parse( &text_p );
+					if ( token && token[0] ) {
+						cent->deadModelHandle = trap_R_RegisterModel( token );
+						foundDeadModelPath = qtrue;
+					}
+					break;
+				}
+			}
+
+			if ( !foundDeadModelPath ) {
+				cent->deadModelHandle = trap_R_RegisterModel( deadmodel );
+			}
 		}
 	}
 

--- a/readme/rally_scripted_objects_manual.txt
+++ b/readme/rally_scripted_objects_manual.txt
@@ -27,6 +27,8 @@ rally_scripted_object {
     }
 }
 
+Hinweis: Die Werte von model und deadmodel können entweder direkt einen Modellpfad (z. B. "models/mapobjects/hydrant/hydrant") angeben oder auf einen benannten Abschnitt im selben Script verweisen, der wiederum ein model-Token mit dem tatsächlichen Pfad enthält. Im zweiten Fall wird der Pfad automatisch aus diesem Abschnitt geladen.
+
 2.Entity im Editor platzieren
 
 - In Radiant (oder einem kompatiblen Editor) wählst du die Entity rally_scripted_object
@@ -75,6 +77,8 @@ rally_scripted_object {
         "models/mapobjects/hydrant/piece4" 4
     }
 }
+
+Note: The values of model and deadmodel can either point directly to a model path (for example "models/mapobjects/hydrant/hydrant") or reference a named section in the same script that contains a model token with the actual path. In the latter case the path is automatically loaded from that section.
 
 2.Place entity in editor
 


### PR DESCRIPTION
## Summary
- ensure scripted objects fall back to registering the configured model path when a named section is missing
- parse optional model sections to extract actual paths for the live and dead models before registering
- initialize model handles defensively and document the accepted model/deadmodel formats in the manual

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e43c337ddc83249a0d13d4b2878b16