### PR TITLE
Add scripted object sound handling

### DIFF
--- a/engine/code/cgame/cg_local.h
+++ b/engine/code/cgame/cg_local.h
@@ -262,6 +262,15 @@ typedef struct centity_s {
 	qhandle_t		postSoundLoop;
 	qhandle_t		destroySound;
 
+	char		hitSoundName[MAX_QPATH];
+	char		preSoundLoopName[MAX_QPATH];
+	char		postSoundLoopName[MAX_QPATH];
+	char		destroySoundName[MAX_QPATH];
+
+	qhandle_t		activeScriptLoop;
+	int		scriptLastEvent;
+	qboolean		scriptDestroyPending;
+
 	qhandle_t		modelHandle;
 	qhandle_t		deadModelHandle;
 

--- a/engine/code/cgame/cg_rally_scripted_objects.c
+++ b/engine/code/cgame/cg_rally_scripted_objects.c
@@ -94,6 +94,18 @@ qboolean CG_ParseScriptedObject( centity_t *cent, const char *scriptName ){
 
 //	Com_Printf("Attempting to load script %s\n", filename);
 
+	cent->hitSound = 0;
+	cent->preSoundLoop = 0;
+	cent->postSoundLoop = 0;
+	cent->destroySound = 0;
+	cent->activeScriptLoop = 0;
+	cent->scriptDestroyPending = qfalse;
+	cent->scriptLastEvent = cent->currentState.event;
+	cent->hitSoundName[0] = '\0';
+	cent->preSoundLoopName[0] = '\0';
+	cent->postSoundLoopName[0] = '\0';
+	cent->destroySoundName[0] = '\0';
+
 	// load the file
 	len = trap_FS_FOpenFile( filename, &f, FS_READ );
 
@@ -458,10 +470,54 @@ void CG_Scripted_Object( centity_t *cent ){
                         return;
                 }
 
-		if ( CG_ParseScriptedObject( cent, scriptName ) )
-			cent->scriptLoadTime = cg.time;
-		else
-			return;
+                if ( CG_ParseScriptedObject( cent, scriptName ) )
+                        cent->scriptLoadTime = cg.time;
+                else
+                        return;
+        }
+
+        if ( cent->scriptLastEvent != s1->event ) {
+                int eventType = s1->event & ~EV_EVENT_BITS;
+
+                if ( eventType == EV_GENERAL_SOUND ) {
+                        const char *eventSound = CG_ConfigString( CS_SOUNDS + s1->eventParm );
+
+                        if ( eventSound && eventSound[0] ) {
+                                if ( cent->destroySoundName[0] && !Q_stricmp( eventSound, cent->destroySoundName ) ) {
+                                        cent->scriptDestroyPending = qtrue;
+                                } else if ( cent->hitSoundName[0] && !Q_stricmp( eventSound, cent->hitSoundName ) ) {
+                                        cent->scriptDestroyPending = qfalse;
+                                }
+                        }
+                }
+
+                cent->scriptLastEvent = s1->event;
+        }
+
+        if ( s1->eFlags & EF_DEAD ) {
+                cent->scriptDestroyPending = qfalse;
+        }
+
+        {
+                qhandle_t desiredLoop = 0;
+
+                if ( ( s1->eFlags & EF_DEAD ) || cent->scriptDestroyPending ) {
+                        if ( cent->postSoundLoop ) {
+                                desiredLoop = cent->postSoundLoop;
+                        }
+                } else if ( cent->preSoundLoop ) {
+                        desiredLoop = cent->preSoundLoop;
+                }
+
+                if ( desiredLoop != cent->activeScriptLoop ) {
+                        if ( desiredLoop ) {
+                                trap_S_AddLoopingSound( s1->number, cent->lerpOrigin, vec3_origin, desiredLoop );
+                        } else if ( cent->activeScriptLoop ) {
+                                trap_S_StopLoopingSound( s1->number );
+                        }
+
+                        cent->activeScriptLoop = desiredLoop;
+                }
         }
 
        if ( (cent->currentState.eFlags & EF_DEAD) && !cent->gibsSpawned ) {

--- a/engine/code/game/g_rally_scripted_objects.c
+++ b/engine/code/game/g_rally_scripted_objects.c
@@ -233,18 +233,46 @@ qboolean G_ParseScriptedObject( gentity_t *ent ){
 
 			continue;
 		}
-		else if ( !Q_stricmp( token, "hitsound" ) ){
-			COM_Parse( &text_p );
-		}
-		else if ( !Q_stricmp( token, "presound" ) ){
-			COM_Parse( &text_p );
-		}
-		else if ( !Q_stricmp( token, "postsound" ) ){
-			COM_Parse( &text_p );
-		}
-		else if ( !Q_stricmp( token, "destroysound" ) ){
-			COM_Parse( &text_p );
-		}
+               else if ( !Q_stricmp( token, "hitsound" ) ){
+                       token = COM_Parse( &text_p );
+                       if ( !token || !token[0] ) {
+                               break;
+                       }
+
+                       ent->hitSound = G_SoundIndex( token );
+
+                       continue;
+               }
+               else if ( !Q_stricmp( token, "presound" ) ){
+                       token = COM_Parse( &text_p );
+                       if ( !token || !token[0] ) {
+                               break;
+                       }
+
+                       ent->preSoundLoop = G_SoundIndex( token );
+
+                       continue;
+               }
+               else if ( !Q_stricmp( token, "postsound" ) ){
+                       token = COM_Parse( &text_p );
+                       if ( !token || !token[0] ) {
+                               break;
+                       }
+
+                       ent->postSoundLoop = G_SoundIndex( token );
+
+                       continue;
+               }
+               else if ( !Q_stricmp( token, "destroysound" ) ){
+                       token = COM_Parse( &text_p );
+                       if ( !token || !token[0] ) {
+                               break;
+                       }
+
+                       ent->destroySound = G_SoundIndex( token );
+
+                       continue;
+               }
 		else if ( !Q_stricmp( token, "gibs" ) ) {
 			/* skip gibs part of script (it is only used client side) */
 			token = COM_Parse( &text_p );
@@ -280,9 +308,19 @@ qboolean G_ParseScriptedObject( gentity_t *ent ){
 }
 
 void G_ScriptedObject_Destroy( gentity_t *self, gentity_t *inflictor, gentity_t *attacker, int damage, int mod ){
-	Com_Printf("Destroying scripted map object %s\n", self->classname);
+       Com_Printf("Destroying scripted map object %s\n", self->classname);
 
-	self->s.eFlags |= EF_DEAD;
+       if ( self->destroySound ) {
+               G_AddEvent( self, EV_GENERAL_SOUND, self->destroySound );
+       }
+
+       if ( self->postSoundLoop ) {
+               self->s.loopSound = self->postSoundLoop;
+       } else {
+               self->s.loopSound = 0;
+       }
+
+       self->s.eFlags |= EF_DEAD;
 }
 
 void G_ScriptedObject_Touch ( gentity_t *self, gentity_t *other, trace_t *trace ){
@@ -354,15 +392,13 @@ void G_ScriptedObject_Think ( gentity_t *self ){
 }
 
 void G_ScriptedObject_Pain ( gentity_t *self, gentity_t *attacker, int damage ){
-	/* Optional: Hit sound and frame animation based on health */
-	/*
-	if (self->number > 0){
-		self->s.frame = self->number - ((self->maxHealth / (float)self->number) * self->health);
-	}
-	*/
+       if ( self->hitSound ) {
+               G_AddEvent( self, EV_GENERAL_SOUND, self->hitSound );
+       }
 
-	/* Debug output for pain events */
-	/* Com_Printf("Scripted map object %s was hit\n", self->classname); */
+       if ( self->preSoundLoop ) {
+               self->s.loopSound = self->preSoundLoop;
+       }
 }
 
 void SP_rally_scripted_object( gentity_t *ent ){
@@ -402,11 +438,9 @@ void SP_rally_scripted_object( gentity_t *ent ){
 	/* Initialize velocity tracking */
 	VectorSet( ent->lastNonZeroVelocity, 0, 0, 0 );
 
-	/* Optional: Set looping sound if defined in script */
-	/*
-	if (ent->preSoundLoop)
-		ent->s.loopSound = ent->preSoundLoop;
-	*/
+       if ( ent->preSoundLoop ) {
+               ent->s.loopSound = ent->preSoundLoop;
+       }
 
 	/* Drop object to ground level */
 	DropToFloor(ent);


### PR DESCRIPTION
## Summary
- index scripted object sound cues on the server and trigger hit/destroy audio along with loop transitions
- mirror scripted object sound configuration on the client, track loop state, and react to sound events to manage pre/post loops
- extend client entity data to cache scripted sound names and loop state

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e441acb2b48324a7639313e20e9ab6