### PR TITLE
Normalize ui_menuBackPath to qpath for remote backgrounds

### DIFF
--- a/engine/code/client/cl_bgasset.c
+++ b/engine/code/client/cl_bgasset.c
@@ -5,9 +5,11 @@
 #include <stdlib.h>
 #include <string.h>
 
-#define CL_BGASSET_CACHE_DIR BASEGAME "/ui_cache"
+#define CL_BGASSET_CACHE_QDIR "ui_cache"
+#define CL_BGASSET_CACHE_DIR BASEGAME "/" CL_BGASSET_CACHE_QDIR
 #define CL_BGASSET_CACHE_INDEX CL_BGASSET_CACHE_DIR "/cache_index.txt"
 #define CL_BGASSET_CACHE_PREFIX CL_BGASSET_CACHE_DIR "/"
+#define CL_BGASSET_CACHE_QPREFIX CL_BGASSET_CACHE_QDIR "/"
 #define CL_BGASSET_MAX_URL 512
 #define CL_BGASSET_MAX_ETAG 128
 #define CL_BGASSET_MAX_LASTMOD 128
@@ -397,6 +399,24 @@ static void CL_BGAsset_GenerateLocalPath(const char *url, char *path, size_t pat
 	}
 
 	Com_sprintf(path, pathSize, "%s/bg_%08x.%s", CL_BGASSET_CACHE_DIR, hash, ext);
+}
+
+static qboolean CL_BGAsset_ToQPath(const char *localPath, char *qpath, size_t qpathSize) {
+	if (!localPath || !localPath[0] || !qpath || qpathSize == 0) {
+		return qfalse;
+	}
+
+	if (!Q_stricmpn(localPath, CL_BGASSET_CACHE_PREFIX, strlen(CL_BGASSET_CACHE_PREFIX))) {
+		Com_sprintf(qpath, qpathSize, "%s", localPath + strlen(BASEGAME "/"));
+		return qtrue;
+	}
+
+	if (!Q_stricmpn(localPath, CL_BGASSET_CACHE_QPREFIX, strlen(CL_BGASSET_CACHE_QPREFIX))) {
+		Q_strncpyz(qpath, localPath, qpathSize);
+		return qtrue;
+	}
+
+	return qfalse;
 }
 
 static unsigned CL_BGAsset_ComputeChecksum(const char *path, int maxSize) {
@@ -859,6 +879,7 @@ static void CL_BGAsset_HandleComplete(CURLcode result) {
 	const char *etag = cl_bgasset.newEtag[0] ? cl_bgasset.newEtag : cl_bgasset.etag;
 	const char *lastModified = cl_bgasset.newLastModified[0] ? cl_bgasset.newLastModified : cl_bgasset.lastModified;
 	char errorMessage[128];
+	char qpath[MAX_QPATH];
 
 	qcurl_easy_getinfo(cl_bgasset.easyHandle, CURLINFO_RESPONSE_CODE, &responseCode);
 
@@ -889,7 +910,11 @@ static void CL_BGAsset_HandleComplete(CURLcode result) {
 			CL_BGAsset_ComputeChecksum(cl_bgasset.localPath, cl_bgasset.maxSize));
 		CL_BGAsset_SetState("cached");
 		CL_BGAsset_SetError("");
-		CL_BGAsset_SetPath(cl_bgasset.localPath);
+		if (CL_BGAsset_ToQPath(cl_bgasset.localPath, qpath, sizeof(qpath))) {
+			CL_BGAsset_SetPath(qpath);
+		} else {
+			CL_BGAsset_SetPath("");
+		}
 		CL_BGAsset_CleanupHandles();
 		CL_BGAsset_ScheduleRefresh();
 		return;
@@ -912,7 +937,11 @@ static void CL_BGAsset_HandleComplete(CURLcode result) {
 	CL_BGAsset_UpdateCacheEntry(cl_bgasset.lastURL, cl_bgasset.localPath, etag, lastModified, checksum);
 	CL_BGAsset_SetState("ready");
 	CL_BGAsset_SetError("");
-	CL_BGAsset_SetPath(cl_bgasset.localPath);
+	if (CL_BGAsset_ToQPath(cl_bgasset.localPath, qpath, sizeof(qpath))) {
+		CL_BGAsset_SetPath(qpath);
+	} else {
+		CL_BGAsset_SetPath("");
+	}
 	CL_BGAsset_CleanupHandles();
 	CL_BGAsset_ScheduleRefresh();
 }

--- a/engine/code/q3_ui/ui_atoms.c
+++ b/engine/code/q3_ui/ui_atoms.c
@@ -176,18 +176,37 @@ static qboolean UI_ReadMenuBackOverride( const char *overrideValue, char *outVal
 static qboolean UI_MenuBackPathExists( const char *path ) {
 	fileHandle_t	file;
 	int				length;
+	const char		*normalizedPath;
 
 	if ( !path || !path[0] ) {
 		return qfalse;
 	}
 
-	length = trap_FS_FOpenFile( path, &file, FS_READ );
+	normalizedPath = path;
+	if ( !Q_stricmpn( normalizedPath, BASEGAME "/", strlen( BASEGAME "/" ) ) ) {
+		normalizedPath += strlen( BASEGAME "/" );
+	}
+
+	length = trap_FS_FOpenFile( normalizedPath, &file, FS_READ );
 	if ( length <= 0 ) {
 		return qfalse;
 	}
 
 	trap_FS_FCloseFile( file );
 	return qtrue;
+}
+
+static const char *UI_NormalizeMenuBackPath( const char *path, char *normalized, int normalizedSize ) {
+	if ( !path || !path[0] ) {
+		return path;
+	}
+
+	if ( !Q_stricmpn( path, BASEGAME "/", strlen( BASEGAME "/" ) ) ) {
+		Q_strncpyz( normalized, path + strlen( BASEGAME "/" ), normalizedSize );
+		return normalized;
+	}
+
+	return path;
 }
 
 static qboolean UI_MenuBackStateAllows( const char *state ) {
@@ -207,10 +226,12 @@ void UI_UpdateMenuBackShader( qboolean force ) {
 	const char	*cvarValue;
 	qboolean	fromFile;
 	const char	*remotePath;
+	const char	*normalizedRemotePath;
 	const char	*remoteState;
 	qhandle_t	remoteShader;
 	qboolean	remoteActive;
 	qboolean	overrideActive;
+	char		normalizedRemotePathBuffer[MAX_QPATH];
 
 	if ( !force && uis.realtime < ui_menuBackOverrideCheckTime ) {
 		return;
@@ -256,6 +277,7 @@ void UI_UpdateMenuBackShader( qboolean force ) {
 	remoteActive = ui_menuBackEnable.integer != 0;
 	remoteState = ui_menuBackState.string;
 	remotePath = ui_menuBackPath.string;
+	normalizedRemotePath = UI_NormalizeMenuBackPath( remotePath, normalizedRemotePathBuffer, sizeof( normalizedRemotePathBuffer ) );
 
 	if ( ui_menuBackEnable.modificationCount != ui_menuBackRemoteModCount
 		|| ui_menuBackState.modificationCount != ui_menuBackRemoteStateModCount
@@ -282,7 +304,7 @@ void UI_UpdateMenuBackShader( qboolean force ) {
 		return;
 	}
 
-	if ( !remotePath[0] || !UI_MenuBackPathExists( remotePath ) ) {
+	if ( !normalizedRemotePath[0] || !UI_MenuBackPathExists( normalizedRemotePath ) ) {
 		if ( remotePath[0] && ( force || Q_stricmp( remotePath, ui_menuBackRemoteMissingPath ) != 0 ) ) {
 			trap_Print( va( "Menu background file not found for '%s'\n", remotePath ) );
 			Q_strncpyz( ui_menuBackRemoteMissingPath, remotePath, sizeof( ui_menuBackRemoteMissingPath ) );
@@ -299,7 +321,7 @@ void UI_UpdateMenuBackShader( qboolean force ) {
 	}
 
 	if ( force || Q_stricmp( remotePath, ui_menuBackRemotePath ) != 0 ) {
-		remoteShader = trap_R_RegisterShaderNoMip( remotePath );
+		remoteShader = trap_R_RegisterShaderNoMip( normalizedRemotePath );
 		if ( remoteShader ) {
 			uis.menuBackShader = remoteShader;
 			Q_strncpyz( ui_menuBackRemotePath, remotePath, sizeof( ui_menuBackRemotePath ) );


### PR DESCRIPTION
### Motivation
- Ensure the UI receives a qpath (e.g. `ui_cache/bg_<hash>.png`) for `ui_menuBackPath` while keeping the on-disk cache and index under the internal filesystem path (`BASEGAME/ui_cache/...`).
- Keep server-side FS operations (e.g. `FS_SV_*`) working with existing `BASEGAME/...` paths and provide a clear conversion to UI qpaths for `trap_R_RegisterShaderNoMip` and other renderer/UI usage.
- No external skills were required or used for this change.

### Description
- Introduced `CL_BGASSET_CACHE_QDIR` and `CL_BGASSET_CACHE_QPREFIX` and kept `CL_BGASSET_CACHE_DIR` for internal FS usage in `engine/code/client/cl_bgasset.c`.
- Added `CL_BGAsset_ToQPath()` to convert internal cached filesystem paths to UI-facing qpaths, and used it when setting `ui_menuBackPath` on cached/download-complete flows.
- Added defensive normalization in `engine/code/q3_ui/ui_atoms.c` via `UI_NormalizeMenuBackPath()` and updated `UI_MenuBackPathExists()` and `UI_UpdateMenuBackShader()` to use the normalized qpath so legacy `BASEGAME/`-prefixed cvars still work.
- Left cache index and `FS_SV_*` reads/writes operating on the internal `BASEGAME/ui_cache/...` paths to avoid changing storage semantics.

### Testing
- Ran formatting/patch checks with `git diff --check` which passed.
- Verified repository status and committed the changes (`git status --short` / commit) successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da21a30fd883239bf2719ad74ff902)