### PR TITLE
Normalize menu background paths and expose cached bgassets as game-relative QPATHs

### DIFF
--- a/engine/code/client/cl_bgasset.c
+++ b/engine/code/client/cl_bgasset.c
@@ -5,9 +5,11 @@
 #include <stdlib.h>
 #include <string.h>
 
-#define CL_BGASSET_CACHE_DIR BASEGAME "/ui_cache"
+#define CL_BGASSET_CACHE_QDIR "ui_cache"
+#define CL_BGASSET_CACHE_DIR BASEGAME "/" CL_BGASSET_CACHE_QDIR
 #define CL_BGASSET_CACHE_INDEX CL_BGASSET_CACHE_DIR "/cache_index.txt"
 #define CL_BGASSET_CACHE_PREFIX CL_BGASSET_CACHE_DIR "/"
+#define CL_BGASSET_CACHE_QPREFIX CL_BGASSET_CACHE_QDIR "/"
 #define CL_BGASSET_MAX_URL 512
 #define CL_BGASSET_MAX_ETAG 128
 #define CL_BGASSET_MAX_LASTMOD 128
@@ -397,6 +399,31 @@ static void CL_BGAsset_GenerateLocalPath(const char *url, char *path, size_t pat
 	}
 
 	Com_sprintf(path, pathSize, "%s/bg_%08x.%s", CL_BGASSET_CACHE_DIR, hash, ext);
+}
+
+static qboolean CL_BGAsset_ToQPath(const char *localPath, char *qpath, size_t qpathSize) {
+	char *slash;
+	char *dot;
+
+	if (!localPath || !localPath[0] || !qpath || qpathSize == 0) {
+		return qfalse;
+	}
+
+	if (!Q_stricmpn(localPath, CL_BGASSET_CACHE_PREFIX, strlen(CL_BGASSET_CACHE_PREFIX))) {
+		Com_sprintf(qpath, qpathSize, "%s", localPath + strlen(BASEGAME "/"));
+	} else if (!Q_stricmpn(localPath, CL_BGASSET_CACHE_QPREFIX, strlen(CL_BGASSET_CACHE_QPREFIX))) {
+		Q_strncpyz(qpath, localPath, qpathSize);
+	} else {
+		return qfalse;
+	}
+
+	slash = strrchr(qpath, '/');
+	dot = strrchr(qpath, '.');
+	if (dot && (!slash || dot > slash)) {
+		*dot = '\0';
+	}
+
+	return qtrue;
 }
 
 static unsigned CL_BGAsset_ComputeChecksum(const char *path, int maxSize) {
@@ -859,6 +886,7 @@ static void CL_BGAsset_HandleComplete(CURLcode result) {
 	const char *etag = cl_bgasset.newEtag[0] ? cl_bgasset.newEtag : cl_bgasset.etag;
 	const char *lastModified = cl_bgasset.newLastModified[0] ? cl_bgasset.newLastModified : cl_bgasset.lastModified;
 	char errorMessage[128];
+	char qpath[MAX_QPATH];
 
 	qcurl_easy_getinfo(cl_bgasset.easyHandle, CURLINFO_RESPONSE_CODE, &responseCode);
 
@@ -889,7 +917,11 @@ static void CL_BGAsset_HandleComplete(CURLcode result) {
 			CL_BGAsset_ComputeChecksum(cl_bgasset.localPath, cl_bgasset.maxSize));
 		CL_BGAsset_SetState("cached");
 		CL_BGAsset_SetError("");
-		CL_BGAsset_SetPath(cl_bgasset.localPath);
+		if (CL_BGAsset_ToQPath(cl_bgasset.localPath, qpath, sizeof(qpath))) {
+			CL_BGAsset_SetPath(qpath);
+		} else {
+			CL_BGAsset_SetPath("");
+		}
 		CL_BGAsset_CleanupHandles();
 		CL_BGAsset_ScheduleRefresh();
 		return;
@@ -912,7 +944,11 @@ static void CL_BGAsset_HandleComplete(CURLcode result) {
 	CL_BGAsset_UpdateCacheEntry(cl_bgasset.lastURL, cl_bgasset.localPath, etag, lastModified, checksum);
 	CL_BGAsset_SetState("ready");
 	CL_BGAsset_SetError("");
-	CL_BGAsset_SetPath(cl_bgasset.localPath);
+	if (CL_BGAsset_ToQPath(cl_bgasset.localPath, qpath, sizeof(qpath))) {
+		CL_BGAsset_SetPath(qpath);
+	} else {
+		CL_BGAsset_SetPath("");
+	}
 	CL_BGAsset_CleanupHandles();
 	CL_BGAsset_ScheduleRefresh();
 }

--- a/engine/code/q3_ui/ui_atoms.c
+++ b/engine/code/q3_ui/ui_atoms.c
@@ -176,18 +176,49 @@ static qboolean UI_ReadMenuBackOverride( const char *overrideValue, char *outVal
 static qboolean UI_MenuBackPathExists( const char *path ) {
 	fileHandle_t	file;
 	int				length;
+	const char		*normalizedPath;
+	char			candidate[MAX_QPATH];
+	const char		*extensions[] = { ".png", ".jpg", ".jpeg", ".tga" };
+	int				i;
 
 	if ( !path || !path[0] ) {
 		return qfalse;
 	}
 
-	length = trap_FS_FOpenFile( path, &file, FS_READ );
-	if ( length <= 0 ) {
-		return qfalse;
+	normalizedPath = path;
+	if ( !Q_stricmpn( normalizedPath, BASEGAME "/", strlen( BASEGAME "/" ) ) ) {
+		normalizedPath += strlen( BASEGAME "/" );
 	}
 
-	trap_FS_FCloseFile( file );
-	return qtrue;
+	length = trap_FS_FOpenFile( normalizedPath, &file, FS_READ );
+	if ( length > 0 ) {
+		trap_FS_FCloseFile( file );
+		return qtrue;
+	}
+
+	for ( i = 0; i < (int)( sizeof( extensions ) / sizeof( extensions[0] ) ); i++ ) {
+		Com_sprintf( candidate, sizeof( candidate ), "%s%s", normalizedPath, extensions[i] );
+		length = trap_FS_FOpenFile( candidate, &file, FS_READ );
+		if ( length > 0 ) {
+			trap_FS_FCloseFile( file );
+			return qtrue;
+		}
+	}
+
+	return qfalse;
+}
+
+static const char *UI_NormalizeMenuBackPath( const char *path, char *normalized, int normalizedSize ) {
+	if ( !path || !path[0] ) {
+		return path;
+	}
+
+	if ( !Q_stricmpn( path, BASEGAME "/", strlen( BASEGAME "/" ) ) ) {
+		Q_strncpyz( normalized, path + strlen( BASEGAME "/" ), normalizedSize );
+		return normalized;
+	}
+
+	return path;
 }
 
 static qboolean UI_MenuBackStateAllows( const char *state ) {
@@ -207,10 +238,12 @@ void UI_UpdateMenuBackShader( qboolean force ) {
 	const char	*cvarValue;
 	qboolean	fromFile;
 	const char	*remotePath;
+	const char	*normalizedRemotePath;
 	const char	*remoteState;
 	qhandle_t	remoteShader;
 	qboolean	remoteActive;
 	qboolean	overrideActive;
+	char		normalizedRemotePathBuffer[MAX_QPATH];
 
 	if ( !force && uis.realtime < ui_menuBackOverrideCheckTime ) {
 		return;
@@ -256,6 +289,7 @@ void UI_UpdateMenuBackShader( qboolean force ) {
 	remoteActive = ui_menuBackEnable.integer != 0;
 	remoteState = ui_menuBackState.string;
 	remotePath = ui_menuBackPath.string;
+	normalizedRemotePath = UI_NormalizeMenuBackPath( remotePath, normalizedRemotePathBuffer, sizeof( normalizedRemotePathBuffer ) );
 
 	if ( ui_menuBackEnable.modificationCount != ui_menuBackRemoteModCount
 		|| ui_menuBackState.modificationCount != ui_menuBackRemoteStateModCount
@@ -282,7 +316,7 @@ void UI_UpdateMenuBackShader( qboolean force ) {
 		return;
 	}
 
-	if ( !remotePath[0] || !UI_MenuBackPathExists( remotePath ) ) {
+	if ( !normalizedRemotePath[0] || !UI_MenuBackPathExists( normalizedRemotePath ) ) {
 		if ( remotePath[0] && ( force || Q_stricmp( remotePath, ui_menuBackRemoteMissingPath ) != 0 ) ) {
 			trap_Print( va( "Menu background file not found for '%s'\n", remotePath ) );
 			Q_strncpyz( ui_menuBackRemoteMissingPath, remotePath, sizeof( ui_menuBackRemoteMissingPath ) );
@@ -299,7 +333,7 @@ void UI_UpdateMenuBackShader( qboolean force ) {
 	}
 
 	if ( force || Q_stricmp( remotePath, ui_menuBackRemotePath ) != 0 ) {
-		remoteShader = trap_R_RegisterShaderNoMip( remotePath );
+		remoteShader = trap_R_RegisterShaderNoMip( normalizedRemotePath );
 		if ( remoteShader ) {
 			uis.menuBackShader = remoteShader;
 			Q_strncpyz( ui_menuBackRemotePath, remotePath, sizeof( ui_menuBackRemotePath ) );


### PR DESCRIPTION
### Motivation

- Ensure UI background assets stored in the cache are exposed as game-relative QPATHs rather than absolute filesystem paths so the renderer/shader registration can load them consistently.
- Allow UI background path handling to accept paths prefixed with `BASEGAME/` and try common image extensions when resolving files.
- Provide a stable normalized form for menu background lookups and shader registration to avoid mismatches between cvar values and internal file locations.

### Description

- Added `CL_BGASSET_CACHE_QDIR` and `CL_BGASSET_CACHE_QPREFIX` and introduced `CL_BGAsset_ToQPath` to convert cached local paths into game-relative QPATHs (and strip file extensions for shader use). 
- Replaced direct use of filesystem `localPath` when setting the UI background cvar in `CL_BGAsset_HandleComplete` with the normalized QPATH via `CL_BGAsset_ToQPath` and fall back to an empty path on failure. 
- Updated `UI_MenuBackPathExists` to normalize `BASEGAME/` prefixes, to probe common image extensions (`.png`, `.jpg`, `.jpeg`, `.tga`), and to return success if any candidate exists.
- Added `UI_NormalizeMenuBackPath` and updated `UI_UpdateMenuBackShader` to use the normalized remote path when checking existence and registering the shader while preserving original cvar text for messaging.

### Testing

- Project build completed successfully using `make` after the changes. 
- Ran automated test suite via `make test` (including UI/asset related checks where available) and observed no failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da21a30fd883239bf2719ad74ff902)