### PR TITLE
Fix RIVALS bot plate model selection for generated uibot shaders

### DIFF
--- a/engine/code/q3_ui/ui_players.c
+++ b/engine/code/q3_ui/ui_players.c
@@ -1938,8 +1938,11 @@ qboolean UI_RegisterClientModelname( playerInfo_t *pi,  const char *modelSkinNam
 
 	// figure out plate model
 //	Com_sprintf( filename, sizeof( filename ), "models/players/plates/player%d.tga", ci->clientNum );
-	if ( !Q_stricmpn( plateName, "usa_", 4 ) ){
+	if ( !Q_stricmpn( plateName, "usa_", 4 ) || !Q_stricmpn( plateName, "uibot", 5 ) ){
 		Q_strncpyz( pi->plateName, "plate_usa", sizeof( pi->plateName ) );
+		if ( !Q_stricmpn( plateName, "uibot", 5 ) ) {
+			Com_Printf( "RIVALS: Detected generated bot plate '%s' -> pi->plateName '%s'\n", plateName, pi->plateName );
+		}
 //		CreateLicensePlateImage(va("models/players/plates/%s.tga", ci->plateSkinName), filename, ci->name, 10);
 	}
 	else{
@@ -2159,4 +2162,3 @@ void UI_PlayerInfo_SetInfo( playerInfo_t *pi, int legsAnim, int torsoAnim, vec3_
 */
 // END
 }
-

--- a/engine/code/q3_ui/ui_rally_bots.c
+++ b/engine/code/q3_ui/ui_rally_bots.c
@@ -567,9 +567,9 @@ static void UI_BotsMenu_SetRival( int index ) {
 
     wp = botWeapons[index];
 
-    /* plate: use pre-generated shader if available, else fall back to cvar */
+    /* plate: use USA marker for model selection when using generated bot plate shaders */
     if ( botPlateShaders[index] ) {
-        Com_sprintf( plate, sizeof(plate), "uibot%d.tga", index );
+        Q_strncpyz( plate, "usa_california", sizeof(plate) );
     } else {
         trap_Cvar_VariableStringBuffer( "plate", plate, sizeof(plate) );
         if ( !plate[0] ) Q_strncpyz( plate, "usa_california", sizeof(plate) );
@@ -579,6 +579,7 @@ static void UI_BotsMenu_SetRival( int index ) {
 
     /* Override the plateShader directly with our pre-generated one */
     if ( botPlateShaders[index] ) {
+        Com_Printf( "RIVALS: Bot %d uses generated plate shader uibot%d.tga with plate marker '%s'\n", index, index, plate );
         s_garagePlayerInfo.plateShader = botPlateShaders[index];
     }
 


### PR DESCRIPTION
### Motivation
- Generated bot plates (`uibot*.tga`) were being passed through the `usa_` prefix heuristic path inconsistently, which could select the wrong plate model for RIVALS bots.

### Description
- In `UI_BotsMenu_SetRival()` pass a USA-compatible plate marker (`"usa_california"`) to `UI_PlayerInfo_SetModel()` when a generated bot plate shader exists so the model selection uses the USA plate path while the generated texture is still applied.
- Preserve the existing override by keeping `s_garagePlayerInfo.plateShader = botPlateShaders[index]` so the dynamic `uibot*.tga` shader continues to be rendered, and add a `Com_Printf` diagnostic to log this path.
- Harden `UI_RegisterClientModelname()` in `ui_players.c` to also recognize the `uibot` prefix and map it to `plate_usa`, and add a short diagnostic `Com_Printf` when a `uibot*` plate is detected.

### Testing
- Ran `git diff -- engine/code/q3_ui/ui_rally_bots.c engine/code/q3_ui/ui_players.c` to inspect changes and it showed the intended modifications (success).
- Ran `git status --short` to verify modified files are tracked and it reported the two updated files (success).
- Committed the changes with `git commit -m "Fix rival bot plate selection to use USA model path"` and the commit completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dad36c4a3c832397d7443afa89ad81)