### PR TITLE
Support generated bot license plates: shader registration and plate selection

### DIFF
--- a/engine/code/q3_ui/ui_players.c
+++ b/engine/code/q3_ui/ui_players.c
@@ -1938,8 +1938,11 @@ qboolean UI_RegisterClientModelname( playerInfo_t *pi,  const char *modelSkinNam
 
 	// figure out plate model
 //	Com_sprintf( filename, sizeof( filename ), "models/players/plates/player%d.tga", ci->clientNum );
-	if ( !Q_stricmpn( plateName, "usa_", 4 ) ){
+	if ( !Q_stricmpn( plateName, "usa_", 4 ) || !Q_stricmpn( plateName, "uibot", 5 ) ){
 		Q_strncpyz( pi->plateName, "plate_usa", sizeof( pi->plateName ) );
+		if ( !Q_stricmpn( plateName, "uibot", 5 ) ) {
+			Com_Printf( "RIVALS: Detected generated bot plate '%s' -> pi->plateName '%s'\n", plateName, pi->plateName );
+		}
 //		CreateLicensePlateImage(va("models/players/plates/%s.tga", ci->plateSkinName), filename, ci->name, 10);
 	}
 	else{
@@ -2159,4 +2162,3 @@ void UI_PlayerInfo_SetInfo( playerInfo_t *pi, int legsAnim, int torsoAnim, vec3_
 */
 // END
 }
-

--- a/engine/code/q3_ui/ui_rally_bots.c
+++ b/engine/code/q3_ui/ui_rally_bots.c
@@ -282,10 +282,9 @@ static qhandle_t UI_GenerateBotPlateShader( const char *botName, int botIndex ) 
         return 0;
     }
 
-    /* Register directly with full TGA path — file is on disk now.
-       Also remap in case the renderer has a stale empty cache entry. */
-    trap_R_RemapShader( output, output, "0" );
-    h = trap_R_RegisterShaderNoMip( output );
+    /* Register directly with full TGA path.
+       Use trap_R_RegisterShader to avoid mixed image flag reuse with model stages. */
+    h = trap_R_RegisterShader( output );
     Com_Printf( "Q3R UI Plate: bot %d (%s) -> shader handle %d\n", botIndex, botName, h );
     return h;
 }
@@ -567,9 +566,9 @@ static void UI_BotsMenu_SetRival( int index ) {
 
     wp = botWeapons[index];
 
-    /* plate: use pre-generated shader if available, else fall back to cvar */
+    /* plate: use USA marker for model selection when using generated bot plate shaders */
     if ( botPlateShaders[index] ) {
-        Com_sprintf( plate, sizeof(plate), "uibot%d.tga", index );
+        Q_strncpyz( plate, "usa_california", sizeof(plate) );
     } else {
         trap_Cvar_VariableStringBuffer( "plate", plate, sizeof(plate) );
         if ( !plate[0] ) Q_strncpyz( plate, "usa_california", sizeof(plate) );
@@ -579,6 +578,7 @@ static void UI_BotsMenu_SetRival( int index ) {
 
     /* Override the plateShader directly with our pre-generated one */
     if ( botPlateShaders[index] ) {
+        Com_Printf( "RIVALS: Bot %d uses generated plate shader uibot%d.tga with plate marker '%s'\n", index, index, plate );
         s_garagePlayerInfo.plateShader = botPlateShaders[index];
     }
 


### PR DESCRIPTION
### Motivation
- Ensure generated bot plate TGAs are registered with the correct shader API to avoid image flag/mip-stage conflicts and to reliably get a shader handle. 
- Make model plate selection treat generated bot plates (names starting with `uibot`) the same as US plates so the correct plate model is used. 
- Add lightweight logging to help diagnose when generated bot plates are detected and used.

### Description
- In `UI_GenerateBotPlateShader` replace the `trap_R_RemapShader` + `trap_R_RegisterShaderNoMip` sequence with a single `trap_R_RegisterShader` call to avoid mixed image flag reuse between image and model stages. 
- In `UI_BotsMenu_SetRival` choose the `usa_california` plate marker when a pre-generated `botPlateShaders[index]` exists instead of using a `uibot%d.tga` string, and add a `Com_Printf` message when a bot uses a generated plate shader. 
- In `UI_RegisterClientModelname` treat plate names beginning with `uibot` like `usa_` by mapping them to the `plate_usa` model and add a detection `Com_Printf` for `uibot` plates.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dad36c4a3c832397d7443afa89ad81)