### PR TITLE
Handle generated bot license plates as USA plates and adjust bot-plate shader registration

### DIFF
--- a/engine/code/q3_ui/ui_players.c
+++ b/engine/code/q3_ui/ui_players.c
@@ -1938,8 +1938,11 @@ qboolean UI_RegisterClientModelname( playerInfo_t *pi,  const char *modelSkinNam
 
 	// figure out plate model
 //	Com_sprintf( filename, sizeof( filename ), "models/players/plates/player%d.tga", ci->clientNum );
-	if ( !Q_stricmpn( plateName, "usa_", 4 ) ){
+	if ( !Q_stricmpn( plateName, "usa_", 4 ) || !Q_stricmpn( plateName, "uibot", 5 ) ){
 		Q_strncpyz( pi->plateName, "plate_usa", sizeof( pi->plateName ) );
+		if ( !Q_stricmpn( plateName, "uibot", 5 ) ) {
+			Com_Printf( "RIVALS: Detected generated bot plate '%s' -> pi->plateName '%s'\n", plateName, pi->plateName );
+		}
 //		CreateLicensePlateImage(va("models/players/plates/%s.tga", ci->plateSkinName), filename, ci->name, 10);
 	}
 	else{
@@ -2159,4 +2162,3 @@ void UI_PlayerInfo_SetInfo( playerInfo_t *pi, int legsAnim, int torsoAnim, vec3_
 */
 // END
 }
-

--- a/engine/code/q3_ui/ui_rally_bots.c
+++ b/engine/code/q3_ui/ui_rally_bots.c
@@ -282,9 +282,8 @@ static qhandle_t UI_GenerateBotPlateShader( const char *botName, int botIndex ) 
         return 0;
     }
 
-    /* Register directly with full TGA path — file is on disk now.
-       Also remap in case the renderer has a stale empty cache entry. */
-    trap_R_RemapShader( output, output, "0" );
+    /* Register directly with full TGA path.
+       Avoid remapping here so we don't preload the image with different flags. */
     h = trap_R_RegisterShaderNoMip( output );
     Com_Printf( "Q3R UI Plate: bot %d (%s) -> shader handle %d\n", botIndex, botName, h );
     return h;
@@ -567,9 +566,9 @@ static void UI_BotsMenu_SetRival( int index ) {
 
     wp = botWeapons[index];
 
-    /* plate: use pre-generated shader if available, else fall back to cvar */
+    /* plate: use USA marker for model selection when using generated bot plate shaders */
     if ( botPlateShaders[index] ) {
-        Com_sprintf( plate, sizeof(plate), "uibot%d.tga", index );
+        Q_strncpyz( plate, "usa_california", sizeof(plate) );
     } else {
         trap_Cvar_VariableStringBuffer( "plate", plate, sizeof(plate) );
         if ( !plate[0] ) Q_strncpyz( plate, "usa_california", sizeof(plate) );
@@ -579,6 +578,7 @@ static void UI_BotsMenu_SetRival( int index ) {
 
     /* Override the plateShader directly with our pre-generated one */
     if ( botPlateShaders[index] ) {
+        Com_Printf( "RIVALS: Bot %d uses generated plate shader uibot%d.tga with plate marker '%s'\n", index, index, plate );
         s_garagePlayerInfo.plateShader = botPlateShaders[index];
     }
 


### PR DESCRIPTION
### Motivation

- Ensure generated bot license plates (prefixed `uibot`) select the same plate model marker as USA plates so the correct plate geometry is used for rivals.
- Avoid remapping generated TGA files into the shader cache to prevent preloading with incorrect flags and register them directly instead.

### Description

- In `ui_players.c` treat plate names starting with `uibot` the same as `usa_` by setting `pi->plateName` to `plate_usa` and emit a debug print when a `uibot` plate is detected.
- In `ui_rally_bots.c` change `UI_GenerateBotPlateShader` to register generated bot TGAs with `trap_R_RegisterShaderNoMip` and remove the `trap_R_RemapShader` call to avoid remapping/preloading with different flags.
- In `UI_BotsMenu_SetRival` use the USA plate marker (`"usa_california"`) for model selection when a generated bot plate shader exists and add a debug print when overriding `plateShader` with a generated shader.
- Update comments and logging to reflect the new behavior and to help trace generated bot plate handling at runtime.

### Testing

- Built the project with `make` and the build completed successfully.
- Executed an automated shader-registration smoke test that invoked `UI_GenerateBotPlateShader` for sample bot entries and confirmed registration returned non-zero shader handles.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dad36c4a3c832397d7443afa89ad81)