### PR TITLE
Bot license plate: treat uibot plates as USA, register generated TGAs without remap, and ensure plate lighting

### DIFF
--- a/engine/code/q3_ui/ui_players.c
+++ b/engine/code/q3_ui/ui_players.c
@@ -1320,7 +1320,7 @@ void UI_DrawPlayer( float x, float y, float w, float h, playerInfo_t *pi, int ti
 
 		VectorCopy( origin, plate.lightingOrigin );
 		UI_PositionEntityOnTag( &plate, &body, pi->bodyModel, "tag_plate");
-		plate.renderfx = renderfx;
+		plate.renderfx = renderfx | RF_MINLIGHT;
 
 		trap_R_AddRefEntityToScene( &plate );
 	}
@@ -1938,7 +1938,7 @@ qboolean UI_RegisterClientModelname( playerInfo_t *pi,  const char *modelSkinNam
 
 	// figure out plate model
 //	Com_sprintf( filename, sizeof( filename ), "models/players/plates/player%d.tga", ci->clientNum );
-	if ( !Q_stricmpn( plateName, "usa_", 4 ) ){
+	if ( !Q_stricmpn( plateName, "usa_", 4 ) || !Q_stricmpn( plateName, "uibot", 5 ) ){
 		Q_strncpyz( pi->plateName, "plate_usa", sizeof( pi->plateName ) );
 //		CreateLicensePlateImage(va("models/players/plates/%s.tga", ci->plateSkinName), filename, ci->name, 10);
 	}
@@ -2159,4 +2159,3 @@ void UI_PlayerInfo_SetInfo( playerInfo_t *pi, int legsAnim, int torsoAnim, vec3_
 */
 // END
 }
-

--- a/engine/code/q3_ui/ui_rally_bots.c
+++ b/engine/code/q3_ui/ui_rally_bots.c
@@ -282,9 +282,8 @@ static qhandle_t UI_GenerateBotPlateShader( const char *botName, int botIndex ) 
         return 0;
     }
 
-    /* Register directly with full TGA path — file is on disk now.
-       Also remap in case the renderer has a stale empty cache entry. */
-    trap_R_RemapShader( output, output, "0" );
+    /* Register directly with full TGA path.
+       Avoid remapping here so we don't preload the image with different flags. */
     h = trap_R_RegisterShaderNoMip( output );
     Com_Printf( "Q3R UI Plate: bot %d (%s) -> shader handle %d\n", botIndex, botName, h );
     return h;
@@ -567,9 +566,9 @@ static void UI_BotsMenu_SetRival( int index ) {
 
     wp = botWeapons[index];
 
-    /* plate: use pre-generated shader if available, else fall back to cvar */
+    /* plate: use USA marker for model selection when using generated bot plate shaders */
     if ( botPlateShaders[index] ) {
-        Com_sprintf( plate, sizeof(plate), "uibot%d.tga", index );
+        Q_strncpyz( plate, "usa_california", sizeof(plate) );
     } else {
         trap_Cvar_VariableStringBuffer( "plate", plate, sizeof(plate) );
         if ( !plate[0] ) Q_strncpyz( plate, "usa_california", sizeof(plate) );


### PR DESCRIPTION
### Motivation
- Ensure generated bot license plates are treated as USA-style plates for model selection, register their TGA shaders without unintended remapping/preloading flags, and make plates receive minimum lighting so they are visible in UI previews.

### Description
- Add `RF_MINLIGHT` to `plate.renderfx` in `UI_DrawPlayer` so license plates are rendered with minimum lighting.
- Treat plate names starting with `"uibot"` as USA plates in `UI_RegisterClientModelname` by mapping them to `"plate_usa"`.
- Replace `trap_R_RemapShader` with `trap_R_RegisterShaderNoMip` in `UI_GenerateBotPlateShader` to register generated TGA files directly without remapping and avoid preloading with different flags.
- When a pre-generated bot plate shader exists, use the `"usa_california"` marker for model selection in `UI_BotsMenu_SetRival` so the correct plate model is chosen.

### Testing
- Performed a full project build with `make` which completed successfully.
- Executed the UI automated test/smoke suite and verified that generated bot plate shaders register and render in the UI, with the tests completing successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dad36c4a3c832397d7443afa89ad81)