### PR TITLE
Unify RIVALS plate shaders with in-game player plate scheme

### DIFF
--- a/engine/code/q3_ui/ui_players.c
+++ b/engine/code/q3_ui/ui_players.c
@@ -1938,10 +1938,15 @@ qboolean UI_RegisterClientModelname( playerInfo_t *pi,  const char *modelSkinNam
 
 	// figure out plate model
 //	Com_sprintf( filename, sizeof( filename ), "models/players/plates/player%d.tga", ci->clientNum );
-	if ( !Q_stricmpn( plateName, "usa_", 4 ) || !Q_stricmpn( plateName, "uibot", 5 ) ){
+	if ( !Q_stricmpn( plateName, "usa_", 4 )
+		|| !Q_stricmpn( plateName, "uibot", 5 )
+		|| !Q_stricmpn( plateName, "player", 6 ) ){
 		Q_strncpyz( pi->plateName, "plate_usa", sizeof( pi->plateName ) );
 		if ( !Q_stricmpn( plateName, "uibot", 5 ) ) {
 			Com_Printf( "RIVALS: Detected generated bot plate '%s' -> pi->plateName '%s'\n", plateName, pi->plateName );
+		}
+		if ( !Q_stricmpn( plateName, "player", 6 ) ) {
+			Com_Printf( "RIVALS: Detected generated player-style plate '%s' -> pi->plateName '%s'\n", plateName, pi->plateName );
 		}
 //		CreateLicensePlateImage(va("models/players/plates/%s.tga", ci->plateSkinName), filename, ci->name, 10);
 	}

--- a/engine/code/q3_ui/ui_rally_bots.c
+++ b/engine/code/q3_ui/ui_rally_bots.c
@@ -22,18 +22,20 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 */
 
 #include "ui_local.h"
-static qhandle_t UI_GenerateBotPlateShader( const char *botName, int botIndex ) {
+static qhandle_t UI_GenerateBotPlateShader( const char *botName, int botIndex, char *plateShaderName, int plateShaderNameSize ) {
     char          output[MAX_QPATH];
+    char          shaderName[MAX_QPATH];
     qhandle_t     h;
 
-    Com_sprintf( output, sizeof(output), "models/players/plates/uibot%d.tga", botIndex );
+    Com_sprintf( output, sizeof(output), "models/players/plates/player%d.tga", botIndex );
+    Com_sprintf( shaderName, sizeof(shaderName), "models/players/plates/player%d", botIndex );
     CreateLicensePlateImage( "models/players/plates/usa_california.tga", output, botName, 10 );
 
-    /* Register directly with full TGA path using the same shader registration
-       path as in-game. Avoid remapping here so we don't preload the image
-       with different flags. */
-    h = trap_R_RegisterShader( output );
-    Com_Printf( "Q3R UI Plate: bot %d (%s) -> shader handle %d\n", botIndex, botName, h );
+    h = trap_R_RegisterShader( shaderName );
+    if ( plateShaderName && plateShaderNameSize > 0 ) {
+        Q_strncpyz( plateShaderName, va("player%d", botIndex), plateShaderNameSize );
+    }
+    Com_Printf( "Q3R UI Plate: bot %d (%s) -> %s (handle %d)\n", botIndex, botName, shaderName, h );
     return h;
 }
 
@@ -280,6 +282,7 @@ static char botAIFiles[MAX_BOTS][NAME_BUFSIZE];
 static char botDescriptions[MAX_BOTS][DESC_BUFSIZE];
 static char botPersonalities[MAX_BOTS][DESC_BUFSIZE];
 static char botFavWeapon[MAX_BOTS][DESC_BUFSIZE];
+static char botPlateNames[MAX_BOTS][NAME_BUFSIZE];
 static qhandle_t botIcons[MAX_BOTS];
 static qhandle_t botPlateShaders[MAX_BOTS];
 static weapon_t  botWeapons[MAX_BOTS];
@@ -314,9 +317,16 @@ static void UI_BotsMenu_SetRival( int index ) {
 
     wp = botWeapons[index];
 
-    /* plate: use USA marker for model selection when using generated bot plate shaders */
-    if ( botPlateShaders[index] ) {
-        Q_strncpyz( plate, "usa_california", sizeof(plate) );
+    /*
+     * Reload/invalidate point for RIVALS:
+     * regenerate and re-register plate shader whenever a rival is (re)selected
+     * so the latest generated file is always bound.
+     */
+    botPlateShaders[index] = 0;
+    botPlateShaders[index] = UI_GenerateBotPlateShader( botNames[index], index, botPlateNames[index], sizeof(botPlateNames[index]) );
+
+    if ( botPlateNames[index][0] ) {
+        Q_strncpyz( plate, botPlateNames[index], sizeof(plate) );
     } else {
         trap_Cvar_VariableStringBuffer( "plate", plate, sizeof(plate) );
         if ( !plate[0] ) Q_strncpyz( plate, "usa_california", sizeof(plate) );
@@ -324,9 +334,10 @@ static void UI_BotsMenu_SetRival( int index ) {
 
     UI_PlayerInfo_SetModel( &s_garagePlayerInfo, botModels[index], NULL, NULL, plate );
 
-    /* Override the plateShader directly with our pre-generated one */
+    /* Ensure plateShader points to the exact freshly-generated shader handle. */
     if ( botPlateShaders[index] ) {
-        Com_Printf( "RIVALS: Bot %d uses generated plate shader uibot%d.tga with plate marker '%s'\n", index, index, plate );
+        Com_Printf( "RIVALS: Bot %d uses generated plate '%s' with marker '%s' (handle %d)\n",
+                    index, botPlateNames[index], plate, botPlateShaders[index] );
         s_garagePlayerInfo.plateShader = botPlateShaders[index];
     }
 
@@ -500,9 +511,10 @@ static void UI_BotsMenu_ParseBots(void) {
             Q_strncpyz(botDescriptions[botCount], description, DESC_BUFSIZE);
             Q_strncpyz(botPersonalities[botCount], personality, DESC_BUFSIZE);
             Q_strncpyz(botFavWeapon[botCount], favoriteweapon, DESC_BUFSIZE);
+            botPlateNames[botCount][0] = '\0';
             botIcons[botCount]        = UI_LoadModelIconFor(model);
             botWeapons[botCount]      = UI_WeaponEnumFromText(favoriteweapon);
-            botPlateShaders[botCount] = UI_GenerateBotPlateShader(name, botCount);
+            botPlateShaders[botCount] = 0;
             
             botCount++;
         }


### PR DESCRIPTION
### Motivation
- RIVALS used a different plate texture naming (`uibot%d.tga`) than the in-game player scheme (`player%d.tga`), which could produce different caching/shader paths and reuse stale handles.
- The change aligns the UI rivals plate generation and binding with the in-game player plate shader handling so shader names, geometry selection and texture sources are consistent.

### Description
- Reworked `UI_GenerateBotPlateShader()` signature to `UI_GenerateBotPlateShader(const char *botName, int botIndex, char *plateShaderName, int plateShaderNameSize)` and switched output to generate `models/players/plates/player%d.tga` while registering the shader as `models/players/plates/player%d` so it matches the in-game registration path.
- Added `botPlateNames` to store the generated plate token (`player%d`) for each bot and updated `UI_BotsMenu_ParseBots()` to avoid pre-registering plate shaders at parse time (reset `botPlateShaders` to `0` and clear `botPlateNames`).
- Introduced an explicit reload/invalidation point in `UI_BotsMenu_SetRival()` that clears any previous handle, regenerates and re-registers the plate shader on (re)selection, and then assigns the freshly generated handle to `s_garagePlayerInfo.plateShader` to avoid reusing stale handles.
- Extended `UI_RegisterClientModelname()` to treat a new `player` prefix like `usa_`/`uibot` for geometry selection (keeps selecting `plate_usa` model) without changing how the texture source is determined.

### Testing
- Ran repository static check `git diff --check` and inspected the changed code paths; no issues were reported.
- Verified repository status (`git status --short`) to confirm only the intended files were modified; check passed.
- Manually reviewed code paths in `ui_rally_bots.c` and `ui_players.c` to ensure generated shader name, plate token and `s_garagePlayerInfo.plateShader` binding are consistent; review succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69db719f270883238902957217dc8320)