### PR TITLE
Add dynamic main-menu license plate shader generation with debug cvar

### DIFF
--- a/engine/code/q3_ui/ui_local.h
+++ b/engine/code/q3_ui/ui_local.h
@@ -866,6 +866,7 @@ extern uiStatic_t	uis;
 extern vmCvar_t	ui_profileActive;
 extern vmCvar_t	ui_profileOverlaySeen;
 extern vmCvar_t	ui_clUuid;
+extern vmCvar_t	ui_debugMainMenuPlate;
 
 // Q3RALLY DOWNLOADS START
 extern vmCvar_t	ui_dl_state;
@@ -885,6 +886,7 @@ const profile_info_t *UI_Profile_GetActiveInfo( void );
 qboolean UI_Profile_GetRank( const profile_stats_t *stats, profile_rank_t *outRank );
 qboolean UI_Profile_SaveActiveInfo( const profile_info_t *info );
 qboolean UI_Profile_HasActiveProfile( void );
+qhandle_t UI_GenerateMainMenuPlateShader( const char *profileName, char *plateShaderName, int plateShaderNameSize );
 
 //
 // ui_spLevel.c

--- a/engine/code/q3_ui/ui_main.c
+++ b/engine/code/q3_ui/ui_main.c
@@ -222,6 +222,7 @@ vmCvar_t	ui_head;
 vmCvar_t	ui_rim;
 vmCvar_t	ui_plate;
 vmCvar_t	ui_clUuid;
+vmCvar_t	ui_debugMainMenuPlate;
 // END
 
 vmCvar_t	ui_profileActive;
@@ -345,6 +346,7 @@ static cvarTable_t		cvarTable[] = {
 	 * nicht vom Spieler editierbar. CVAR_USERINFO sorgt dafür dass
 	 * die Engine den Wert automatisch in den Userinfo-String einträgt. */
 	{ &ui_clUuid, "cl_uuid", "", CVAR_USERINFO|CVAR_ARCHIVE },
+	{ &ui_debugMainMenuPlate, "ui_debugMainMenuPlate", "0", CVAR_ARCHIVE },
 // END
 
 	{ &ui_profileActive, "profile_active", "", CVAR_ARCHIVE },

--- a/engine/code/q3_ui/ui_menu.c
+++ b/engine/code/q3_ui/ui_menu.c
@@ -86,6 +86,37 @@ typedef struct {
 
 static mainmenu_t s_main;
 static vec4_t s_profileActionColor;
+static char s_mainMenuPlateProfile[MAX_QPATH];
+static qhandle_t s_mainMenuPlateShader;
+
+static void MainMenu_UpdateProfilePlate( qboolean forceRegenerate ) {
+        const char *activeProfileName;
+        char profileForPlate[64];
+        char shaderMarker[MAX_QPATH];
+
+        activeProfileName = UI_Profile_GetActiveName();
+        if ( activeProfileName && activeProfileName[0] ) {
+                Q_strncpyz( profileForPlate, activeProfileName, sizeof( profileForPlate ) );
+        } else {
+                Q_strncpyz( profileForPlate, "PLAYER", sizeof( profileForPlate ) );
+        }
+
+        if ( forceRegenerate || !s_mainMenuPlateShader || Q_stricmp( profileForPlate, s_mainMenuPlateProfile ) ) {
+                Q_strncpyz( s_mainMenuPlateProfile, profileForPlate, sizeof( s_mainMenuPlateProfile ) );
+                s_mainMenuPlateShader = UI_GenerateMainMenuPlateShader( profileForPlate, shaderMarker, sizeof( shaderMarker ) );
+                if ( ui_debugMainMenuPlate.integer ) {
+                        Com_Printf( "Q3R UI Plate: main menu regenerate profile='%s' output='models/players/plates/uimain_profile.tga' shader='%s' handle=%d\n",
+                                    profileForPlate, shaderMarker, s_mainMenuPlateShader );
+                }
+        } else if ( ui_debugMainMenuPlate.integer ) {
+                Com_Printf( "Q3R UI Plate: main menu keep cached profile='%s' output='models/players/plates/uimain_profile.tga' handle=%d\n",
+                            profileForPlate, s_mainMenuPlateShader );
+        }
+
+        if ( s_mainMenuPlateShader ) {
+                s_main.playerinfo.plateShader = s_mainMenuPlateShader;
+        }
+}
 
 static void MainMenu_UpdateProfileTexts( void ) {
         const profile_stats_t *activeProfileStats;
@@ -119,14 +150,13 @@ static void MainMenu_UpdateModel( void )
 {
         vec3_t  viewangles;
         vec3_t  moveangles;
-        char    plate[MAX_QPATH];
 
         VectorClear( viewangles );
         VectorClear( moveangles );
 
-        trap_Cvar_VariableStringBuffer( "plate", plate, sizeof( plate ) );
-        UI_PlayerInfo_SetModel( &s_main.playerinfo, s_main.modelskin, s_main.rimskin, s_main.headskin, plate);
+        UI_PlayerInfo_SetModel( &s_main.playerinfo, s_main.modelskin, s_main.rimskin, s_main.headskin, "usa_california" );
         UI_PlayerInfo_SetInfo( &s_main.playerinfo, LEGS_IDLE, TORSO_STAND, viewangles, moveangles, WP_NONE, qfalse );
+        MainMenu_UpdateProfilePlate( qfalse );
 }
 
 
@@ -349,6 +379,7 @@ void MainMenu_Prepare( void ) {
         UI_Profile_MarkStatsDirty();
         MainMenu_UpdateProfileTexts();
         MainMenu_Update();
+        MainMenu_UpdateProfilePlate( qtrue );
 
 }
 
@@ -361,6 +392,7 @@ Main_MenuDraw
 static void Main_MenuDraw( void ) {
 
         MainMenu_UpdateProfileTexts();
+        MainMenu_UpdateProfilePlate( qfalse );
 
         // standard menu drawing
 

--- a/engine/code/q3_ui/ui_players.c
+++ b/engine/code/q3_ui/ui_players.c
@@ -51,6 +51,34 @@ static float		yaw;
 static float		deltaYaw	= 60;
 static float		deltaRoll;
 
+qhandle_t UI_GenerateMainMenuPlateShader( const char *profileName, char *plateShaderName, int plateShaderNameSize ) {
+	char		output[MAX_QPATH];
+	char		shaderPath[MAX_QPATH];
+	char		cleanName[64];
+	qhandle_t	h;
+
+	if ( !profileName || !profileName[0] ) {
+		profileName = "PLAYER";
+	}
+
+	Q_strncpyz( cleanName, profileName, sizeof( cleanName ) );
+	Q_CleanStr( cleanName );
+	if ( !cleanName[0] ) {
+		Q_strncpyz( cleanName, "PLAYER", sizeof( cleanName ) );
+	}
+
+	Com_sprintf( output, sizeof( output ), "models/players/plates/uimain_profile.tga" );
+	Com_sprintf( shaderPath, sizeof( shaderPath ), "models/players/plates/uimain_profile" );
+	CreateLicensePlateImage( "models/players/plates/usa_california.tga", output, cleanName, 10 );
+
+	h = trap_R_RegisterShader( shaderPath );
+	if ( plateShaderName && plateShaderNameSize > 0 ) {
+		Q_strncpyz( plateShaderName, "uimain_profile", plateShaderNameSize );
+	}
+
+	return h;
+}
+
 /*
 ===============
 UI_PlayerInfo_SetWeapon
@@ -1323,6 +1351,9 @@ void UI_DrawPlayer( float x, float y, float w, float h, playerInfo_t *pi, int ti
 		UI_PositionEntityOnTag( &plate, &body, pi->bodyModel, "tag_plate");
 		plate.shadowPlane = body.shadowPlane;
 		plate.renderfx = renderfx;
+		if ( uis.mainMenu ) {
+			plate.renderfx |= RF_MINLIGHT;
+		}
 
 		trap_R_AddRefEntityToScene( &plate );
 	}


### PR DESCRIPTION
### Motivation

- Provide per-profile license plate rendering on the main menu by generating a plate texture and shader from the active profile name and allow debugging of regeneration behavior via a cvar.

### Description

- Add a new cvar `ui_debugMainMenuPlate` and register it in the UI cvar table for toggling debug logging.  
- Expose `UI_GenerateMainMenuPlateShader` in the UI header and implement it to create a profile-specific plate image, register a shader, and return its handle.  
- Add caching and update logic in the main menu to generate or reuse the profile plate shader via `MainMenu_UpdateProfilePlate`, and wire it into menu preparation and drawing.  
- Force the player preview to use a fixed plate model and set `RF_MINLIGHT` on the plate entity while the main menu is active to ensure visibility.

### Testing

- Built the project with the normal build (`make`) and the compile/link completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69db8ac1e2248323acfec5faf99f5fa9)