### PR TITLE
Add Domination & KOTH LTG logic and DMNet objective debug export

### DIFF
--- a/engine/code/game/ai_dmnet.c
+++ b/engine/code/game/ai_dmnet.c
@@ -133,6 +133,69 @@ static const char *Bot_DebugRecoveryStateName( bot_recovery_state_t state ) {
 	}
 }
 
+static const char *Bot_DebugObjectiveStateName( int state ) {
+	switch ( state ) {
+		case 1: return "dom_neutralize";
+		case 2: return "dom_capture";
+		case 3: return "dom_defend";
+		case 4: return "koth_contest";
+		case 5: return "koth_defend";
+		case 6: return "health_retreat";
+		default: return "none";
+	}
+}
+
+static void Bot_DebugGetObjectiveSnapshot( bot_state_t *bs, int *objectiveState, int *kothOwner, int *kothContested ) {
+	int state = 0;
+	int owner = TEAM_FREE;
+	int contested = 0;
+
+	if ( bs ) {
+		if ( bs->inventory[INVENTORY_HEALTH] > 0 && bs->inventory[INVENTORY_HEALTH] < 40 ) {
+			state = 6;
+		}
+		if ( gametype == GT_DOMINATION ) {
+			bot_goal_t sigilGoal;
+			int sigilStatus = SIGIL_NONE;
+			int team = BotTeam( bs );
+
+			if ( BotGetDominationSigilGoal( bs, &sigilGoal, &sigilStatus ) ) {
+				if ( sigilStatus == SIGIL_ISWHITE ) {
+					state = 2;
+				} else if ( (team == TEAM_RED && sigilStatus == SIGIL_ISBLUE) ||
+					(team == TEAM_BLUE && sigilStatus == SIGIL_ISRED) ) {
+					state = 1;
+				} else {
+					state = 3;
+				}
+			}
+		}
+		else if ( gametype == GT_KOTH ) {
+			int capturePct;
+			float hillRadius;
+			vec3_t hillOrigin;
+
+			if ( BotGetKOTHStatus( &owner, &contested, &capturePct, hillOrigin, &hillRadius ) ) {
+				if ( owner == BotTeam( bs ) && !contested && capturePct >= 100 ) {
+					state = 5;
+				} else {
+					state = 4;
+				}
+			}
+		}
+	}
+
+	if ( objectiveState ) {
+		*objectiveState = state;
+	}
+	if ( kothOwner ) {
+		*kothOwner = owner;
+	}
+	if ( kothContested ) {
+		*kothContested = contested;
+	}
+}
+
 static void Bot_DebugFormatRecoveryTransition( char *buffer, int bufferSize, bot_recovery_state_t fromState, bot_recovery_state_t toState ) {
 	if ( !buffer || bufferSize <= 0 ) {
 		return;
@@ -150,7 +213,8 @@ static void Bot_DebugExportDmnetTick( bot_state_t *bs, int routeIndex, float tar
 	ghostDecisionState_t decisionState, qboolean collisionRisk, bot_recovery_state_t recoveryState,
 	bot_recovery_state_t previousRecoveryState, const char *recoveryEvent,
 	const char *recoveryTrigger, float routeDeviation, int pathId, int nodeIndex, int lookAheadIndex,
-	int widthClampEvent, int autoSpeedActive, int targetSpeedOverrideActive, int launchGateActive ) {
+	int widthClampEvent, int autoSpeedActive, int targetSpeedOverrideActive, int launchGateActive,
+	int objectiveState, int kothOwner, int kothContested ) {
 	fileHandle_t f;
 	char line[1024];
 	char recoveryTransition[96];
@@ -189,7 +253,7 @@ static void Bot_DebugExportDmnetTick( bot_state_t *bs, int routeIndex, float tar
 	}
 
 	if ( len == 0 && !isJson ) {
-		char header[] = "time,client,routeIndex,targetSpeed,actualSpeed,decisionState,collisionRisk,recoveryState,recoveryTransition,recoveryEvent,recoveryTrigger,routeDeviation,pathId,nodeIndex,lookaheadIndex,widthClampEvent,autoSpeedActive,targetSpeedOverrideActive,launchGate\n";
+		char header[] = "time,client,routeIndex,targetSpeed,actualSpeed,decisionState,collisionRisk,recoveryState,recoveryTransition,recoveryEvent,recoveryTrigger,routeDeviation,pathId,nodeIndex,lookaheadIndex,widthClampEvent,autoSpeedActive,targetSpeedOverrideActive,launchGate,objectiveState,kothOwner,kothContested\n";
 		trap_FS_Write( header, strlen( header ), f );
 	}
 	Bot_DebugFormatRecoveryTransition( recoveryTransition, sizeof( recoveryTransition ), previousRecoveryState, recoveryState );
@@ -200,23 +264,27 @@ static void Bot_DebugExportDmnetTick( bot_state_t *bs, int routeIndex, float tar
 			"\"decisionState\":\"%s\",\"collisionRisk\":%d,\"recoveryState\":\"%s\","
 			"\"recoveryTransition\":\"%s\",\"recoveryEvent\":\"%s\",\"recoveryTrigger\":\"%s\",\"routeDeviation\":%.2f,"
 			"\"pathId\":%d,\"nodeIndex\":%d,\"lookaheadIndex\":%d,\"widthClampEvent\":%d,"
-			"\"autoSpeedActive\":%d,\"targetSpeedOverrideActive\":%d,\"launchGate\":%d,"			"\"ox\":%.2f,\"oy\":%.2f,\"oz\":%.2f}\n",
+			"\"autoSpeedActive\":%d,\"targetSpeedOverrideActive\":%d,\"launchGate\":%d,"
+			"\"objectiveState\":\"%s\",\"kothOwner\":%d,\"kothContested\":%d,"
+			"\"ox\":%.2f,\"oy\":%.2f,\"oz\":%.2f}\n",
 			level.time * 0.001f, bs->client, routeIndex, targetSpeed, actualSpeed,
 			Bot_DebugDecisionStateName( decisionState ), collisionRisk ? 1 : 0,
 			Bot_DebugRecoveryStateName( recoveryState ), recoveryTransition,
 			recoveryEvent ? recoveryEvent : "", recoveryTrigger ? recoveryTrigger : "",
 			routeDeviation, pathId, nodeIndex, lookAheadIndex, widthClampEvent,
 			autoSpeedActive, targetSpeedOverrideActive, launchGateActive,
+			Bot_DebugObjectiveStateName( objectiveState ), kothOwner, kothContested,
 			origin[0], origin[1], origin[2] );
 	} else {
 		Com_sprintf( line, sizeof( line ),
-			"%.3f,%d,%d,%.2f,%.2f,%s,%d,%s,%s,%s,%s,%.2f,%d,%d,%d,%d,%d,%d,%d\n",
+			"%.3f,%d,%d,%.2f,%.2f,%s,%d,%s,%s,%s,%s,%.2f,%d,%d,%d,%d,%d,%d,%d,%s,%d,%d\n",
 			level.time * 0.001f, bs->client, routeIndex, targetSpeed, actualSpeed,
 			Bot_DebugDecisionStateName( decisionState ), collisionRisk ? 1 : 0,
 			Bot_DebugRecoveryStateName( recoveryState ), recoveryTransition,
 			recoveryEvent ? recoveryEvent : "", recoveryTrigger ? recoveryTrigger : "",
 			routeDeviation, pathId, nodeIndex, lookAheadIndex, widthClampEvent,
-			autoSpeedActive, targetSpeedOverrideActive, launchGateActive );
+			autoSpeedActive, targetSpeedOverrideActive, launchGateActive,
+			Bot_DebugObjectiveStateName( objectiveState ), kothOwner, kothContested );
 	}
 	trap_FS_Write( line, strlen( line ), f );
 	trap_FS_FCloseFile( f );
@@ -1650,6 +1718,64 @@ int BotGetLongTermGoal(bot_state_t *bs, int tfl, int retreat, bot_goal_t *goal) 
 		}
 	}
 #endif
+	if (gametype == GT_DOMINATION) {
+		int sigilStatus = SIGIL_NONE;
+		int team = BotTeam(bs);
+		qboolean lowHealth = (bs->inventory[INVENTORY_HEALTH] > 0 && bs->inventory[INVENTORY_HEALTH] < 40) ? qtrue : qfalse;
+
+		if ((bs->ltgtype == LTG_GETFLAG || bs->ltgtype == LTG_ATTACKENEMYBASE || bs->ltgtype == LTG_DEFENDKEYAREA) &&
+			BotGetDominationSigilGoal(bs, goal, &sigilStatus)) {
+			if (lowHealth && BotFindEnemy(bs, -1)) {
+				return BotGetItemLongTermGoal(bs, tfl, goal);
+			}
+
+			if (sigilStatus == SIGIL_ISWHITE) {
+				bs->ltgtype = LTG_GETFLAG;
+			}
+			else if ((team == TEAM_RED && sigilStatus == SIGIL_ISBLUE) ||
+				(team == TEAM_BLUE && sigilStatus == SIGIL_ISRED)) {
+				bs->ltgtype = LTG_ATTACKENEMYBASE;
+			}
+			else {
+				bs->ltgtype = LTG_DEFENDKEYAREA;
+			}
+
+			BotAlternateRoute(bs, goal);
+			return qtrue;
+		}
+	}
+	else if (gametype == GT_KOTH) {
+		int owner, contested, capturePct;
+		float hillRadius;
+		float radiusExtent;
+		vec3_t hillOrigin;
+		qboolean lowHealth = (bs->inventory[INVENTORY_HEALTH] > 0 && bs->inventory[INVENTORY_HEALTH] < 40) ? qtrue : qfalse;
+
+		if ((bs->ltgtype == LTG_ATTACKENEMYBASE || bs->ltgtype == LTG_DEFENDKEYAREA || bs->ltgtype == LTG_GETFLAG)
+			&& BotGetKOTHStatus(&owner, &contested, &capturePct, hillOrigin, &hillRadius)) {
+			if (lowHealth && owner != BotTeam(bs)) {
+				return BotGetItemLongTermGoal(bs, tfl, goal);
+			}
+
+			radiusExtent = (hillRadius > 32.0f) ? hillRadius : 128.0f;
+			goal->entitynum = ENTITYNUM_NONE;
+			goal->areanum = BotPointAreaNum(hillOrigin);
+			VectorSet(goal->mins, -radiusExtent, -radiusExtent, -24);
+			VectorSet(goal->maxs, radiusExtent, radiusExtent, 48);
+			VectorCopy(hillOrigin, goal->origin);
+			goal->flags = 0;
+			goal->number = 0;
+			goal->iteminfo = 0;
+
+			if (owner == BotTeam(bs) && !contested && capturePct >= 100) {
+				bs->ltgtype = LTG_DEFENDKEYAREA;
+			}
+			else {
+				bs->ltgtype = LTG_ATTACKENEMYBASE;
+			}
+			return qtrue;
+		}
+	}
 	//normal goal stuff
 	return BotGetItemLongTermGoal(bs, tfl, goal);
 }
@@ -3851,11 +3977,17 @@ int AINode_MoveToNextCheckpoint( bot_state_t *bs )
 
 			throttleChange = Bot_CheckForObstacles( bs, angles, throttleChange );
 			VectorCopy( angles, bs->ideal_viewangles );
+			{
+				int objectiveState;
+				int kothOwner;
+				int kothContested;
+				Bot_DebugGetObjectiveSnapshot( bs, &objectiveState, &kothOwner, &kothContested );
 			Bot_DebugExportDmnetTick( bs, selectedLookAheadIndex, speedFromRoute, actualSpeed, decisionState,
 				pathCollisionRisk.hasPredictedConflict, pathRecoveryState, pathRecoveryState, "", "",
 				Distance( bs->cur_ps.origin, baseTargetPoint ), selectedPathId, selectedNodeIndex,
 				selectedLookAheadIndex, widthClampEvent, autoSpeedActive, targetSpeedOverrideActive,
-				forwardLaunchPhase ? 1 : 0 );
+				forwardLaunchPhase ? 1 : 0, objectiveState, kothOwner, kothContested );
+			}
 
 			if ( throttleChange > 0 ) {
 				trap_EA_MoveForward( bs->client );
@@ -4372,9 +4504,16 @@ int AINode_MoveToNextCheckpoint( bot_state_t *bs )
 
 			throttleChange = Bot_CheckForObstacles( bs, angles, throttleChange );
 			VectorCopy( angles, bs->ideal_viewangles );
+			{
+				int objectiveState;
+				int kothOwner;
+				int kothContested;
+				Bot_DebugGetObjectiveSnapshot( bs, &objectiveState, &kothOwner, &kothContested );
 			Bot_DebugExportDmnetTick( bs, bestIndex, speed, actualSpeed, decisionState, collisionRiskActive,
 				recoveryState, previousRecoveryState, recoveryEvent, recoveryTrigger, routeDistanceFromCenter,
-				-1, bestIndex, lookAheadIndex, 0, 1, 0, forwardLaunchPhase ? 1 : 0 );
+				-1, bestIndex, lookAheadIndex, 0, 1, 0, forwardLaunchPhase ? 1 : 0,
+				objectiveState, kothOwner, kothContested );
+			}
 
 			if( throttleChange > 0 )
 				trap_EA_MoveForward( bs->client );

--- a/engine/code/game/ai_dmq3.c
+++ b/engine/code/game/ai_dmq3.c
@@ -199,6 +199,120 @@ bot_goal_t *BotTeamFlag(bot_state_t *bs) {
 	}
 }
 
+static qboolean Bot_IsLowHealthForObjectivePush(bot_state_t *bs) {
+	if ( !bs ) {
+		return qfalse;
+	}
+	return ( bs->inventory[INVENTORY_HEALTH] > 0 && bs->inventory[INVENTORY_HEALTH] < 40 );
+}
+
+qboolean BotGetKOTHStatus(int *owner, int *contested, int *capturePct, vec3_t hillOrigin, float *hillRadius) {
+	char status[MAX_INFO_STRING];
+	int parsed;
+	int parsedOwner, parsedContested, parsedCapturePct;
+	int x, y, z, radius;
+
+	trap_GetConfigstring(CS_KOTHSTATUS, status, sizeof(status));
+	if (!status[0]) {
+		return qfalse;
+	}
+
+	parsed = sscanf(status, "%d %d %d %d %d %d %d",
+		&parsedOwner, &parsedContested, &parsedCapturePct, &x, &y, &z, &radius);
+	if (parsed < 7) {
+		return qfalse;
+	}
+
+	if (owner) {
+		*owner = parsedOwner;
+	}
+	if (contested) {
+		*contested = parsedContested;
+	}
+	if (capturePct) {
+		*capturePct = parsedCapturePct;
+	}
+	if (hillOrigin) {
+		hillOrigin[0] = x;
+		hillOrigin[1] = y;
+		hillOrigin[2] = z;
+	}
+	if (hillRadius) {
+		*hillRadius = radius;
+	}
+	return qtrue;
+}
+
+int BotGetDominationSigilGoal(bot_state_t *bs, bot_goal_t *goal, int *sigilStatus) {
+	char statusBuf[MAX_INFO_STRING];
+	bot_goal_t candidate;
+	int index;
+	int itemIndex;
+	int team;
+	int score;
+	int bestScore;
+	int bestItemIndex;
+	int bestStatus;
+	vec3_t delta;
+
+	if (!bs || !goal) {
+		return qfalse;
+	}
+
+	trap_GetConfigstring(CS_SIGILSTATUS, statusBuf, sizeof(statusBuf));
+	if (!statusBuf[0]) {
+		return qfalse;
+	}
+
+	team = BotTeam(bs);
+	itemIndex = -1;
+	index = 0;
+	bestScore = 999999;
+	bestItemIndex = -1;
+	bestStatus = SIGIL_NONE;
+
+	while (statusBuf[index]) {
+		itemIndex = trap_BotGetLevelItemGoal(itemIndex, "team_domination_sigil", &candidate);
+		if (itemIndex < 0) {
+			break;
+		}
+		switch (statusBuf[index] - '0') {
+			case SIGIL_ISWHITE:
+				score = 0;
+				break;
+			case SIGIL_ISRED:
+				score = (team == TEAM_RED) ? 3 : 1;
+				break;
+			case SIGIL_ISBLUE:
+				score = (team == TEAM_BLUE) ? 3 : 1;
+				break;
+			default:
+				score = 2;
+				break;
+		}
+
+		VectorSubtract(bs->origin, candidate.origin, delta);
+		score = score * 100000 + (int)VectorLengthSquared(delta);
+		if (score < bestScore) {
+			bestScore = score;
+			bestItemIndex = itemIndex;
+			bestStatus = statusBuf[index] - '0';
+		}
+		index++;
+	}
+
+	if (bestItemIndex < 0) {
+		return qfalse;
+	}
+	if (trap_BotGetLevelItemGoal(bestItemIndex, "team_domination_sigil", goal) < 0) {
+		return qfalse;
+	}
+	if (sigilStatus) {
+		*sigilStatus = bestStatus;
+	}
+	return qtrue;
+}
+
 
 /*
 ==================
@@ -1162,6 +1276,110 @@ void BotObeliskRetreatGoals(bot_state_t *bs) {
 	//nothing special
 }
 
+void BotDominationSeekGoals(bot_state_t *bs) {
+	int sigilStatus;
+	int team;
+
+	if (!BotGetDominationSigilGoal(bs, &bs->teamgoal, &sigilStatus)) {
+		return;
+	}
+
+	team = BotTeam(bs);
+	bs->decisionmaker = bs->client;
+	bs->ordered = qfalse;
+	bs->teammessage_time = FloatTime() + random();
+
+	if (Bot_IsLowHealthForObjectivePush(bs) && BotFindEnemy(bs, -1)) {
+		bs->ltgtype = LTG_GETITEM;
+		bs->teamgoal_time = FloatTime() + 5;
+		BotSetTeamStatus(bs);
+		return;
+	}
+
+	if (sigilStatus == SIGIL_ISWHITE) {
+		bs->ltgtype = LTG_GETFLAG;
+		bs->teamgoal_time = FloatTime() + TEAM_ATTACKENEMYBASE_TIME;
+		BotGetAlternateRouteGoal(bs, BotOppositeTeam(bs));
+	}
+	else if ((team == TEAM_RED && sigilStatus == SIGIL_ISBLUE)
+		|| (team == TEAM_BLUE && sigilStatus == SIGIL_ISRED)) {
+		bs->ltgtype = LTG_ATTACKENEMYBASE;
+		bs->teamgoal_time = FloatTime() + TEAM_ATTACKENEMYBASE_TIME;
+		bs->attackaway_time = 0;
+		BotGetAlternateRouteGoal(bs, BotOppositeTeam(bs));
+	}
+	else {
+		bs->ltgtype = LTG_DEFENDKEYAREA;
+		bs->teamgoal_time = FloatTime() + TEAM_DEFENDKEYAREA_TIME;
+		bs->defendaway_time = 0;
+	}
+	BotSetTeamStatus(bs);
+}
+
+void BotDominationRetreatGoals(bot_state_t *bs) {
+	if (Bot_IsLowHealthForObjectivePush(bs)) {
+		bs->ltgtype = LTG_GETITEM;
+		bs->teamgoal_time = FloatTime() + 4;
+		BotSetTeamStatus(bs);
+		return;
+	}
+	BotDominationSeekGoals(bs);
+}
+
+void BotKOTHSeekGoals(bot_state_t *bs) {
+	int owner, contested, capturePct;
+	float hillRadius;
+	vec3_t hillOrigin;
+	float radiusExtent;
+
+	if (!BotGetKOTHStatus(&owner, &contested, &capturePct, hillOrigin, &hillRadius)) {
+		return;
+	}
+
+	bs->decisionmaker = bs->client;
+	bs->ordered = qfalse;
+	bs->teammessage_time = FloatTime() + random();
+
+	if (Bot_IsLowHealthForObjectivePush(bs) && owner != BotTeam(bs)) {
+		bs->ltgtype = LTG_GETITEM;
+		bs->teamgoal_time = FloatTime() + 5;
+		BotSetTeamStatus(bs);
+		return;
+	}
+
+	radiusExtent = (hillRadius > 32.0f) ? hillRadius : 128.0f;
+	bs->teamgoal.entitynum = ENTITYNUM_NONE;
+	bs->teamgoal.areanum = BotPointAreaNum(hillOrigin);
+	VectorSet(bs->teamgoal.mins, -radiusExtent, -radiusExtent, -24);
+	VectorSet(bs->teamgoal.maxs, radiusExtent, radiusExtent, 48);
+	VectorCopy(hillOrigin, bs->teamgoal.origin);
+	bs->teamgoal.flags = 0;
+	bs->teamgoal.number = 0;
+	bs->teamgoal.iteminfo = 0;
+
+	if (owner == BotTeam(bs) && !contested && capturePct >= 100) {
+		bs->ltgtype = LTG_DEFENDKEYAREA;
+		bs->teamgoal_time = FloatTime() + TEAM_DEFENDKEYAREA_TIME;
+		bs->defendaway_time = 0;
+	}
+	else {
+		bs->ltgtype = LTG_ATTACKENEMYBASE;
+		bs->teamgoal_time = FloatTime() + TEAM_ATTACKENEMYBASE_TIME;
+		bs->attackaway_time = 0;
+	}
+	BotSetTeamStatus(bs);
+}
+
+void BotKOTHRetreatGoals(bot_state_t *bs) {
+	if (Bot_IsLowHealthForObjectivePush(bs)) {
+		bs->ltgtype = LTG_GETITEM;
+		bs->teamgoal_time = FloatTime() + 4;
+		BotSetTeamStatus(bs);
+		return;
+	}
+	BotKOTHSeekGoals(bs);
+}
+
 /*
 ==================
 BotHarvesterSeekGoals
@@ -1344,6 +1562,12 @@ void BotTeamGoals(bot_state_t *bs, int retreat) {
 		if (gametype == GT_CTF) {
 			BotCTFRetreatGoals(bs);
 		}
+		else if (gametype == GT_DOMINATION) {
+			BotDominationRetreatGoals(bs);
+		}
+		else if (gametype == GT_KOTH) {
+			BotKOTHRetreatGoals(bs);
+		}
 #ifdef MISSIONPACK
 		else if (gametype == GT_1FCTF) {
 			Bot1FCTFRetreatGoals(bs);
@@ -1360,6 +1584,12 @@ void BotTeamGoals(bot_state_t *bs, int retreat) {
 		if (gametype == GT_CTF) {
 			//decide what to do in CTF mode
 			BotCTFSeekGoals(bs);
+		}
+		else if (gametype == GT_DOMINATION) {
+			BotDominationSeekGoals(bs);
+		}
+		else if (gametype == GT_KOTH) {
+			BotKOTHSeekGoals(bs);
 		}
 #ifdef MISSIONPACK
 		else if (gametype == GT_1FCTF) {

--- a/engine/code/game/ai_dmq3.h
+++ b/engine/code/game/ai_dmq3.h
@@ -147,6 +147,16 @@ void BotRememberLastOrderedTask(bot_state_t *bs);
 void BotCTFSeekGoals(bot_state_t *bs);
 //set ctf goals (defend base, get enemy flag) during retreat
 void BotCTFRetreatGoals(bot_state_t *bs);
+//returns the highest-priority domination sigil goal for this bot
+int BotGetDominationSigilGoal(bot_state_t *bs, bot_goal_t *goal, int *sigilStatus);
+//reads KOTH hill state from CS_KOTHSTATUS configstring
+qboolean BotGetKOTHStatus(int *owner, int *contested, int *capturePct, vec3_t hillOrigin, float *hillRadius);
+//set domination goals during seek/retreat
+void BotDominationSeekGoals(bot_state_t *bs);
+void BotDominationRetreatGoals(bot_state_t *bs);
+//set KOTH goals during seek/retreat
+void BotKOTHSeekGoals(bot_state_t *bs);
+void BotKOTHRetreatGoals(bot_state_t *bs);
 //
 #ifdef MISSIONPACK
 int Bot1FCTFCarryingFlag(bot_state_t *bs);


### PR DESCRIPTION
### Motivation
- Bots need explicit long-term-goal handling for GT_DOMINATION and GT_KOTH so team-objective behaviour (neutralize/capture/defend / contest/hold) is handled like CTF/Obelisk/Harvester.
- Make bot decision telemetry observable through the existing DMNet debug export so objective decision state (and KOTH ownership/contest) can be traced for tuning and debugging.

### Description
- Added DOM/KOTH LTG branches to team goal selection (`BotTeamGoals`) and implemented Seek/Retreat handlers: `BotDominationSeekGoals`/`BotDominationRetreatGoals` and `BotKOTHSeekGoals`/`BotKOTHRetreatGoals` (files: `ai_dmq3.c`, declarations in `ai_dmq3.h`).
- Implemented Domination sigil scoring and selection via `BotGetDominationSigilGoal` using `CS_SIGILSTATUS` and map `team_domination_sigil` items; decisions map to LTG types (neutralize/capture/defend) and use `BotAlternateRoute` when appropriate (file: `ai_dmq3.c`, header: `ai_dmq3.h`).
- Implemented KOTH status parsing from `CS_KOTHSTATUS` in `BotGetKOTHStatus` and integrated hill position/ownership/contest into goal scoring so bots contest enemy hill and defend owned hill (file: `ai_dmq3.c`, header: `ai_dmq3.h`).
- Added simple risk/health-aware fallback: low-health bots temporarily switch to short heal/item goals instead of aggressively forcing objective pushes (helpers + checks added across `ai_dmq3.c` and `ai_dmnet.c`).
- Extended DMNet debug export: new objective decision names and snapshot helper (`Bot_DebugObjectiveStateName`, `Bot_DebugGetObjectiveSnapshot`) and appended `objectiveState`, `kothOwner`, `kothContested` to CSV/JSONL export; updated all DMNet export call sites to include the new telemetry (file: `ai_dmnet.c`).
- Misc: corrected/robustified uses of `trap_BotGetLevelItemGoal` return handling when iterating item goals.

### Testing
- Attempted an in-repo build with `make -C /workspace/q3rally_tryout -j2 game` which failed because no `game` target exists in this environment (automated build: failed).
- Attempted a generic `make -C /workspace/q3rally_tryout -j2` which failed due to missing Makefile/targets in the environment (automated build: failed).
- No automated unit tests were present or executed in this environment; changes were committed locally (`git commit`) after code edits.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dbcf439b788323936a8ffd346939db)