### PR TITLE
Bot-Persönlichkeit und Lieblingswaffe in AI-Setup integrieren

### DIFF
--- a/engine/code/game/ai_dmnet.c
+++ b/engine/code/game/ai_dmnet.c
@@ -4220,57 +4220,66 @@ int AINode_MoveToNextCheckpoint( bot_state_t *bs )
 			}
 			desiredOffset = 0.0f;
 			speedBias = 0.0f;
+			{
+				float overtakeEnterDist = 170.0f + ( bs->personalityOvertakeBias * 60.0f );
+				float overtakeEnterRelSpeed = 60.0f - ( bs->personalityOvertakeBias * 25.0f );
+				float defendRelSpeed = 95.0f - ( bs->personalityRisk * 35.0f );
+				float abortDist = 25.0f + ( ( 1.0f - bs->personalityRisk ) * 18.0f );
+				float sideSafetyThreshold = 66.0f - ( bs->personalityRisk * 28.0f );
+				float abortBrakeZone = 0.88f - ( bs->personalityRisk * 0.20f );
+				float followClearDist = 240.0f + ( bs->personalityOvertakeBias * 55.0f );
 
-			switch ( decisionState ) {
-				default:
-				case GHOST_DECISION_FOLLOW:
-					if ( collisionRisk.nearestAheadDist < 190.0f && collisionRisk.nearestAheadRelSpeed > 45.0f && brakeZone < 0.5f ) {
-						decisionState = GHOST_DECISION_PREPARE_OVERTAKE;
-					} else if ( collisionRisk.nearestBehindDist < 120.0f && collisionRisk.nearestBehindRelSpeed > 70.0f && ( brakeZone > 0.5f || cornerPhase > 0.35f ) ) {
-						decisionState = GHOST_DECISION_DEFEND_LINE;
-					} else if ( collisionRisk.hasPredictedConflict ) {
-						decisionState = GHOST_DECISION_ABORT_OVERTAKE;
-					}
-					break;
-
-				case GHOST_DECISION_PREPARE_OVERTAKE:
-					if ( collisionRisk.nearestAheadDist > 260.0f || collisionRisk.nearestAheadRelSpeed < 5.0f ) {
-						decisionState = GHOST_DECISION_FOLLOW;
-					} else if ( brakeZone > 0.5f || collisionRisk.abortOvertakeRecommended ) {
-						decisionState = GHOST_DECISION_ABORT_OVERTAKE;
-					} else {
-						if ( preferredInside ) {
-							decisionState = GHOST_DECISION_OVERTAKE_INSIDE;
-						} else {
-							decisionState = GHOST_DECISION_OVERTAKE_OUTSIDE;
+				switch ( decisionState ) {
+					default:
+					case GHOST_DECISION_FOLLOW:
+						if ( collisionRisk.nearestAheadDist < overtakeEnterDist && collisionRisk.nearestAheadRelSpeed > overtakeEnterRelSpeed && brakeZone < 0.5f ) {
+							decisionState = GHOST_DECISION_PREPARE_OVERTAKE;
+						} else if ( collisionRisk.nearestBehindDist < 120.0f && collisionRisk.nearestBehindRelSpeed > defendRelSpeed && ( brakeZone > 0.5f || cornerPhase > 0.35f ) ) {
+							decisionState = GHOST_DECISION_DEFEND_LINE;
+						} else if ( collisionRisk.hasPredictedConflict ) {
+							decisionState = GHOST_DECISION_ABORT_OVERTAKE;
 						}
-					}
-					break;
+						break;
 
-				case GHOST_DECISION_OVERTAKE_INSIDE:
-				case GHOST_DECISION_OVERTAKE_OUTSIDE:
-				{
-					qboolean sideBlocked;
-					sideBlocked = ( decisionState == GHOST_DECISION_OVERTAKE_INSIDE ) ? ( collisionRisk.sideSafetyInside < 48.0f ) : ( collisionRisk.sideSafetyOutside < 48.0f );
-					if ( collisionRisk.nearestAheadDist < 35.0f || sideBlocked || brakeZone > 0.75f || collisionRisk.abortOvertakeRecommended ) {
-						decisionState = GHOST_DECISION_ABORT_OVERTAKE;
-					} else if ( collisionRisk.nearestAheadDist > 270.0f || collisionRisk.nearestAheadRelSpeed < -20.0f ) {
-						decisionState = GHOST_DECISION_FOLLOW;
+					case GHOST_DECISION_PREPARE_OVERTAKE:
+						if ( collisionRisk.nearestAheadDist > followClearDist || collisionRisk.nearestAheadRelSpeed < 5.0f ) {
+							decisionState = GHOST_DECISION_FOLLOW;
+						} else if ( brakeZone > 0.5f || collisionRisk.abortOvertakeRecommended ) {
+							decisionState = GHOST_DECISION_ABORT_OVERTAKE;
+						} else {
+							if ( preferredInside ) {
+								decisionState = GHOST_DECISION_OVERTAKE_INSIDE;
+							} else {
+								decisionState = GHOST_DECISION_OVERTAKE_OUTSIDE;
+							}
+						}
+						break;
+
+					case GHOST_DECISION_OVERTAKE_INSIDE:
+					case GHOST_DECISION_OVERTAKE_OUTSIDE:
+					{
+						qboolean sideBlocked;
+						sideBlocked = ( decisionState == GHOST_DECISION_OVERTAKE_INSIDE ) ? ( collisionRisk.sideSafetyInside < sideSafetyThreshold ) : ( collisionRisk.sideSafetyOutside < sideSafetyThreshold );
+						if ( collisionRisk.nearestAheadDist < abortDist || sideBlocked || brakeZone > abortBrakeZone || collisionRisk.abortOvertakeRecommended ) {
+							decisionState = GHOST_DECISION_ABORT_OVERTAKE;
+						} else if ( collisionRisk.nearestAheadDist > followClearDist + 15.0f || collisionRisk.nearestAheadRelSpeed < -20.0f ) {
+							decisionState = GHOST_DECISION_FOLLOW;
+						}
+						break;
 					}
-					break;
+
+					case GHOST_DECISION_DEFEND_LINE:
+						if ( collisionRisk.nearestBehindDist > 220.0f || collisionRisk.nearestBehindRelSpeed < 25.0f ) {
+							decisionState = GHOST_DECISION_FOLLOW;
+						}
+						break;
+
+					case GHOST_DECISION_ABORT_OVERTAKE:
+						if ( collisionRisk.nearestAheadDist > 140.0f || brakeZone > 0.5f ) {
+							decisionState = GHOST_DECISION_FOLLOW;
+						}
+						break;
 				}
-
-				case GHOST_DECISION_DEFEND_LINE:
-					if ( collisionRisk.nearestBehindDist > 220.0f || collisionRisk.nearestBehindRelSpeed < 25.0f ) {
-						decisionState = GHOST_DECISION_FOLLOW;
-					}
-					break;
-
-				case GHOST_DECISION_ABORT_OVERTAKE:
-					if ( collisionRisk.nearestAheadDist > 140.0f || brakeZone > 0.5f ) {
-						decisionState = GHOST_DECISION_FOLLOW;
-					}
-					break;
 			}
 
 			if ( decisionState != (ghostDecisionState_t)bs->ghostDecisionState ) {
@@ -4281,15 +4290,15 @@ int AINode_MoveToNextCheckpoint( bot_state_t *bs )
 			switch ( decisionState ) {
 				case GHOST_DECISION_PREPARE_OVERTAKE:
 					desiredOffset = ( collisionRisk.nearestAheadLateral >= 0.0f ) ? -32.0f : 32.0f;
-					speedBias = 40.0f;
+					speedBias = 25.0f + ( bs->personalityOvertakeBias * 30.0f );
 					break;
 				case GHOST_DECISION_OVERTAKE_INSIDE:
 					desiredOffset = preferredInside ? -72.0f : 72.0f;
-					speedBias = 65.0f;
+					speedBias = 35.0f + ( bs->personalityRisk * 45.0f );
 					break;
 				case GHOST_DECISION_OVERTAKE_OUTSIDE:
 					desiredOffset = preferredInside ? 72.0f : -72.0f;
-					speedBias = 20.0f;
+					speedBias = 10.0f + ( bs->personalityOvertakeBias * 25.0f );
 					break;
 				case GHOST_DECISION_DEFEND_LINE:
 					desiredOffset = ( collisionRisk.nearestBehindLateral >= 0.0f ) ? -46.0f : 46.0f;

--- a/engine/code/game/ai_dmq3.c
+++ b/engine/code/game/ai_dmq3.c
@@ -1913,13 +1913,79 @@ BotChooseWeapon
 */
 void BotChooseWeapon(bot_state_t *bs) {
 	int newweaponnum;
+	int availabilityIndex = -1;
+	int ammoIndex = -1;
+	int originalAvailability = 0;
+	int originalAmmo = 0;
+
+	switch ( bs->favoriteWeapon ) {
+		case WP_GAUNTLET:
+			availabilityIndex = INVENTORY_GAUNTLET;
+			ammoIndex = -1;
+			break;
+		case WP_MACHINEGUN:
+			availabilityIndex = INVENTORY_MACHINEGUN;
+			ammoIndex = INVENTORY_BULLETS;
+			break;
+		case WP_SHOTGUN:
+			availabilityIndex = INVENTORY_SHOTGUN;
+			ammoIndex = INVENTORY_SHELLS;
+			break;
+		case WP_GRENADE_LAUNCHER:
+			availabilityIndex = INVENTORY_GRENADELAUNCHER;
+			ammoIndex = INVENTORY_GRENADES;
+			break;
+		case WP_ROCKET_LAUNCHER:
+			availabilityIndex = INVENTORY_ROCKETLAUNCHER;
+			ammoIndex = INVENTORY_ROCKETS;
+			break;
+		case WP_LIGHTNING:
+			availabilityIndex = INVENTORY_LIGHTNING;
+			ammoIndex = INVENTORY_LIGHTNINGAMMO;
+			break;
+		case WP_RAILGUN:
+			availabilityIndex = INVENTORY_RAILGUN;
+			ammoIndex = INVENTORY_SLUGS;
+			break;
+		case WP_PLASMAGUN:
+			availabilityIndex = INVENTORY_PLASMAGUN;
+			ammoIndex = INVENTORY_CELLS;
+			break;
+		case WP_BFG:
+			availabilityIndex = INVENTORY_BFG10K;
+			ammoIndex = INVENTORY_BFGAMMO;
+			break;
+		case WP_FLAME_THROWER:
+			availabilityIndex = INVENTORY_FLAMETHROWER;
+			ammoIndex = INVENTORY_FLAMETHROWERAMMO;
+			break;
+		default:
+			break;
+	}
 
 	if (bs->cur_ps.weaponstate == WEAPON_RAISING ||
 			bs->cur_ps.weaponstate == WEAPON_DROPPING) {
 		trap_EA_SelectWeapon(bs->client, bs->weaponnum);
 	}
 	else {
+		if ( availabilityIndex >= 0 && bs->inventory[availabilityIndex] > 0 && bs->favoriteWeaponWeightBonus > 0.0f ) {
+			originalAvailability = bs->inventory[availabilityIndex];
+			bs->inventory[availabilityIndex] += (int)bs->favoriteWeaponWeightBonus;
+			if ( ammoIndex >= 0 ) {
+				originalAmmo = bs->inventory[ammoIndex];
+				bs->inventory[ammoIndex] += (int)bs->favoriteWeaponWeightBonus;
+			}
+		}
+
 		newweaponnum = trap_BotChooseBestFightWeapon(bs->ws, bs->inventory);
+
+		if ( availabilityIndex >= 0 && originalAvailability > 0 ) {
+			bs->inventory[availabilityIndex] = originalAvailability;
+			if ( ammoIndex >= 0 ) {
+				bs->inventory[ammoIndex] = originalAmmo;
+			}
+		}
+
 		if (bs->weaponnum != newweaponnum) bs->weaponchange_time = FloatTime();
 		bs->weaponnum = newweaponnum;
 		//BotAI_Print(PRT_MESSAGE, "bs->weaponnum = %d\n", bs->weaponnum);
@@ -2585,12 +2651,15 @@ BotAggression
 ==================
 */
 float BotAggression(bot_state_t *bs) {
+	float aggression;
+
 	//if the bot has quad
 	if (bs->inventory[INVENTORY_QUAD]) {
 		//if the bot is not holding the gauntlet or the enemy is really nearby
 		if (bs->weaponnum != WP_GAUNTLET ||
 			bs->inventory[ENEMY_HORIZONTAL_DIST] < 80) {
-			return 70;
+			aggression = 70;
+			goto apply_profile;
 		}
 	}
 	//if the enemy is located way higher than the bot
@@ -2604,27 +2673,57 @@ float BotAggression(bot_state_t *bs) {
 	}
 	//if the bot can use the bfg
 	if (bs->inventory[INVENTORY_BFG10K] > 0 &&
-			bs->inventory[INVENTORY_BFGAMMO] > 7) return 100;
+			bs->inventory[INVENTORY_BFGAMMO] > 7) {
+		aggression = 100;
+		goto apply_profile;
+	}
 	//if the bot can use the railgun
 	if (bs->inventory[INVENTORY_RAILGUN] > 0 &&
-			bs->inventory[INVENTORY_SLUGS] > 5) return 95;
+			bs->inventory[INVENTORY_SLUGS] > 5) {
+		aggression = 95;
+		goto apply_profile;
+	}
 	//if the bot can use the lightning gun
 	if (bs->inventory[INVENTORY_LIGHTNING] > 0 &&
-			bs->inventory[INVENTORY_LIGHTNINGAMMO] > 50) return 90;
+			bs->inventory[INVENTORY_LIGHTNINGAMMO] > 50) {
+		aggression = 90;
+		goto apply_profile;
+	}
 	//if the bot can use the rocketlauncher
 	if (bs->inventory[INVENTORY_ROCKETLAUNCHER] > 0 &&
-			bs->inventory[INVENTORY_ROCKETS] > 5) return 90;
+			bs->inventory[INVENTORY_ROCKETS] > 5) {
+		aggression = 90;
+		goto apply_profile;
+	}
 	//if the bot can use the plasmagun
 	if (bs->inventory[INVENTORY_PLASMAGUN] > 0 &&
-			bs->inventory[INVENTORY_CELLS] > 40) return 85;
+			bs->inventory[INVENTORY_CELLS] > 40) {
+		aggression = 85;
+		goto apply_profile;
+	}
 	//if the bot can use the grenade launcher
 	if (bs->inventory[INVENTORY_GRENADELAUNCHER] > 0 &&
-			bs->inventory[INVENTORY_GRENADES] > 10) return 80;
+			bs->inventory[INVENTORY_GRENADES] > 10) {
+		aggression = 80;
+		goto apply_profile;
+	}
 	//if the bot can use the shotgun
 	if (bs->inventory[INVENTORY_SHOTGUN] > 0 &&
-			bs->inventory[INVENTORY_SHELLS] > 10) return 50;
+			bs->inventory[INVENTORY_SHELLS] > 10) {
+		aggression = 50;
+		goto apply_profile;
+	}
 	//otherwise the bot is not feeling too good
-	return 0;
+	aggression = 0;
+
+apply_profile:
+	aggression += bs->personalityAggressionBias;
+	if ( aggression < 0 ) {
+		aggression = 0;
+	} else if ( aggression > 100 ) {
+		aggression = 100;
+	}
+	return aggression;
 }
 
 /*
@@ -5141,6 +5240,10 @@ void BotCheckConsoleMessages(bot_state_t *bs) {
 				//if at a valid chat position and not chatting already and not in teamplay
 				else if (bs->ainode != AINode_Stand && BotValidChatPosition(bs) && !TeamPlayIsOn()) {
 					chat_reply = trap_Characteristic_BFloat(bs->character, CHARACTERISTIC_CHAT_REPLY, 0, 1);
+					chat_reply *= 0.60f + ( bs->personalityChatTone * 0.80f );
+					if ( chat_reply > 1.0f ) {
+						chat_reply = 1.0f;
+					}
 					if (random() < 1.5 / (NumBots()+1) && random() < chat_reply) {
 						//if bot replies with a chat message
 						if (trap_BotReplyChat(bs->cs, message, context, CONTEXT_REPLY,

--- a/engine/code/game/ai_main.c
+++ b/engine/code/game/ai_main.c
@@ -82,6 +82,74 @@ vmCvar_t bot_interbreedbots;
 vmCvar_t bot_interbreedcycle;
 vmCvar_t bot_interbreedwrite;
 
+typedef struct bot_personality_entry_s {
+	const char *name;
+	bot_personality_profile_t profile;
+} bot_personality_entry_t;
+
+static const bot_personality_entry_t botPersonalityMap[] = {
+	{ "graceful",		{ -8.0f, 0.35f, 0.40f, 0.80f } },
+	{ "relentless",		{ 14.0f, 0.88f, 0.90f, 0.25f } },
+	{ "nimble",			{ 4.0f, 0.60f, 0.72f, 0.60f } },
+	{ "methodical",		{ -2.0f, 0.45f, 0.48f, 0.45f } },
+	{ "untamed",		{ 16.0f, 0.92f, 0.95f, 0.10f } },
+	{ "calculating",	{ 6.0f, 0.55f, 0.70f, 0.30f } },
+	{ "bulldog",		{ 12.0f, 0.86f, 0.82f, 0.20f } },
+	{ "unflappable",	{ -6.0f, 0.30f, 0.30f, 0.60f } },
+	{ "opportunist",	{ 8.0f, 0.70f, 0.85f, 0.45f } },
+	{ "playful",		{ 2.0f, 0.58f, 0.62f, 0.92f } },
+	{ "precise",		{ 0.0f, 0.46f, 0.52f, 0.48f } },
+	{ "predatory",		{ 10.0f, 0.82f, 0.88f, 0.18f } },
+	{ "suave",			{ -4.0f, 0.40f, 0.45f, 0.85f } },
+	{ "enigmatic",		{ 3.0f, 0.62f, 0.66f, 0.70f } },
+	{ "steadfast",		{ -1.0f, 0.50f, 0.50f, 0.40f } },
+	{ "benevolent",		{ -10.0f, 0.22f, 0.25f, 1.00f } },
+	{ "domineering",	{ 15.0f, 0.90f, 0.86f, 0.12f } },
+	{ "clinical",		{ 5.0f, 0.56f, 0.58f, 0.15f } },
+	{ "mischievous",	{ 7.0f, 0.74f, 0.80f, 0.94f } },
+	{ "crafty",			{ 6.0f, 0.68f, 0.78f, 0.82f } },
+	{ "fearless",		{ 14.0f, 0.96f, 0.98f, 0.10f } },
+	{ "boisterous",		{ 9.0f, 0.76f, 0.72f, 0.96f } },
+	{ "hyperactive",	{ 11.0f, 0.84f, 0.92f, 0.98f } },
+	{ "stoic",			{ -5.0f, 0.34f, 0.36f, 0.05f } }
+};
+
+static const bot_personality_profile_t botDefaultPersonalityProfile = { 0.0f, 0.50f, 0.50f, 0.50f };
+
+const bot_personality_profile_t *BotPersonalityProfileForName( const char *name ) {
+	int i;
+
+	if ( !name || !name[0] ) {
+		return &botDefaultPersonalityProfile;
+	}
+
+	for ( i = 0; i < (int)( sizeof( botPersonalityMap ) / sizeof( botPersonalityMap[0] ) ); i++ ) {
+		if ( !Q_stricmp( name, botPersonalityMap[i].name ) ) {
+			return &botPersonalityMap[i].profile;
+		}
+	}
+	return &botDefaultPersonalityProfile;
+}
+
+int BotFavoriteWeaponFromName( const char *name ) {
+	if ( !name || !name[0] ) {
+		return WP_NONE;
+	}
+
+	if ( !Q_stricmp( name, "Machinegun" ) ) return WP_MACHINEGUN;
+	if ( !Q_stricmp( name, "Shotgun" ) ) return WP_SHOTGUN;
+	if ( !Q_stricmp( name, "Grenade Launcher" ) ) return WP_GRENADE_LAUNCHER;
+	if ( !Q_stricmp( name, "Rocket Launcher" ) ) return WP_ROCKET_LAUNCHER;
+	if ( !Q_stricmp( name, "Lightning" ) ) return WP_LIGHTNING;
+	if ( !Q_stricmp( name, "Railgun" ) ) return WP_RAILGUN;
+	if ( !Q_stricmp( name, "Plasmagun" ) ) return WP_PLASMAGUN;
+	if ( !Q_stricmp( name, "BFG10k" ) ) return WP_BFG;
+	if ( !Q_stricmp( name, "Flamethrower" ) ) return WP_FLAME_THROWER;
+	if ( !Q_stricmp( name, "Chainsaw" ) ) return WP_GAUNTLET;
+
+	return WP_NONE;
+}
+
 
 void ExitLevel( void );
 
@@ -1203,6 +1271,7 @@ BotAISetupClient
 */
 int BotAISetupClient(int client, struct bot_settings_s *settings, qboolean restart) {
 	char filename[144], name[144], gender[144];
+	const bot_personality_profile_t *personalityProfile;
 	bot_state_t *bs;
 	int errnum;
 
@@ -1276,6 +1345,13 @@ int BotAISetupClient(int client, struct bot_settings_s *settings, qboolean resta
 	bs->entergame_time = FloatTime();
 	bs->ms = trap_BotAllocMoveState();
 	bs->walker = trap_Characteristic_BFloat(bs->character, CHARACTERISTIC_WALKER, 0, 1);
+	personalityProfile = BotPersonalityProfileForName( settings->personality );
+	bs->personalityAggressionBias = personalityProfile->aggressionBias;
+	bs->personalityRisk = personalityProfile->risk;
+	bs->personalityOvertakeBias = personalityProfile->overtakeBias;
+	bs->personalityChatTone = personalityProfile->chatTone;
+	bs->favoriteWeapon = BotFavoriteWeaponFromName( settings->favoriteweapon );
+	bs->favoriteWeaponWeightBonus = ( bs->favoriteWeapon != WP_NONE ) ? 35.0f : 0.0f;
 	numbots++;
 
 	if (trap_Cvar_VariableIntegerValue("bot_testichat")) {

--- a/engine/code/game/ai_main.h
+++ b/engine/code/game/ai_main.h
@@ -131,6 +131,13 @@ typedef enum bot_recovery_state_e
 	BOT_RECOVERY_EMERGENCY_RESET_REQUEST
 } bot_recovery_state_t;
 
+typedef struct bot_personality_profile_s {
+	float aggressionBias;
+	float risk;
+	float overtakeBias;
+	float chatTone;
+} bot_personality_profile_t;
+
 //bot state
 typedef struct bot_state_s
 {
@@ -310,6 +317,12 @@ typedef struct bot_state_s
 	float ghostRecoveryReverseWindowStart;		//start time for reverse cycle counting
 	vec3_t ghostRecoveryReverseStartOrigin;		//position where the current reverse phase started
 	int ghostRecoveryReverseStartCollisionCount;	//collision pressure sampled at reverse phase start
+	float personalityAggressionBias;			//personality-driven aggression offset
+	float personalityRisk;						//personality-driven risk preference [0..1]
+	float personalityOvertakeBias;				//personality-driven overtake preference [0..1]
+	float personalityChatTone;					//personality-driven chat tone [0..1]
+	int favoriteWeapon;							//preferred weapon enum (WP_*)
+	float favoriteWeaponWeightBonus;			//bonus weight for preferred weapon selection
 } bot_state_t;
 
 //resets the whole bot state
@@ -330,3 +343,5 @@ int		BotAI_GetClientState( int clientNum, playerState_t *state );
 int		BotAI_GetEntityState( int entityNum, entityState_t *state );
 int		BotAI_GetSnapshotEntity( int clientNum, int sequence, entityState_t *state );
 int		BotTeamLeader(bot_state_t *bs);
+const bot_personality_profile_t *BotPersonalityProfileForName( const char *name );
+int	BotFavoriteWeaponFromName( const char *name );

--- a/engine/code/game/g_bot.c
+++ b/engine/code/game/g_bot.c
@@ -551,6 +551,8 @@ qboolean G_BotConnect( int clientNum, qboolean restart ) {
 	trap_GetUserinfo( clientNum, userinfo, sizeof(userinfo) );
 
 	Q_strncpyz( settings.characterfile, Info_ValueForKey( userinfo, "characterfile" ), sizeof(settings.characterfile) );
+	Q_strncpyz( settings.personality, Info_ValueForKey( userinfo, "bot_personality" ), sizeof(settings.personality) );
+	Q_strncpyz( settings.favoriteweapon, Info_ValueForKey( userinfo, "bot_favweapon" ), sizeof(settings.favoriteweapon) );
 	settings.skill = atof( Info_ValueForKey( userinfo, "skill" ) );
 
 	if (!BotAISetupClient( clientNum, &settings, restart )) {
@@ -713,6 +715,8 @@ static void G_AddBot( const char *name, float skill, const char *team, int delay
 		return;
 	}
 	Info_SetValueForKey( userinfo, "characterfile", s );
+	Info_SetValueForKey( userinfo, "bot_personality", Info_ValueForKey( botinfo, "personality" ) );
+	Info_SetValueForKey( userinfo, "bot_favweapon", Info_ValueForKey( botinfo, "favoriteweapon" ) );
 
 	// don't send tinfo to bots, they don't parse it
 	Info_SetValueForKey( userinfo, "teamoverlay", "0" );

--- a/engine/code/game/g_local.h
+++ b/engine/code/game/g_local.h
@@ -1103,6 +1103,8 @@ void BotInterbreedEndMatch( void );
 typedef struct bot_settings_s
 {
 	char characterfile[MAX_FILEPATH];
+	char personality[32];
+	char favoriteweapon[32];
 	float skill;
 } bot_settings_t;
 


### PR DESCRIPTION
### Motivation
- Bots sollen `personality` und `favoriteweapon` aus `bots.txt` bis in die Laufzeit-AI tragen, damit UI‑Text und AI‑Parameter aus einer zentralen Mapping‑Stelle abgeleitet werden. 

### Description
- Erweiterte `bot_settings_t` um `personality` und `favoriteweapon` und setzte die Userinfo‑Keys `bot_personality`/`bot_favweapon` in `G_AddBot` sowie deren Einlesung in `G_BotConnect` (`engine/code/game/g_bot.c`, `engine/code/game/g_local.h`).
- Eingeführt: zentrale Personality‑Mapping (`bot_personality_profile_t`) und Favorite‑Weapon→`WP_*` Mapper in `ai_main.c` mit Defaultprofil und Namensliste; API‑Funktionen `BotPersonalityProfileForName` und `BotFavoriteWeaponFromName` hinzugefügt.
- Laufzeit: neue Felder in `bot_state_t` für Personality‑Offsets und Favorite‑Weapon (AggressionBias, Risk, OvertakeBias, ChatTone, FavoriteWeaponWeightBonus) und Übernahme dieser Werte in `BotAISetupClient` (`engine/code/game/ai_main.c`).
- AI‑Integration: Personality‑Bias wird in `BotAggression` angewendet, Chat‑Ton skaliert Chat‑Reply‑Wahrscheinlichkeit, Favorite‑Weapon gibt temporären Gewichtungsbonus bei `BotChooseWeapon`, und Risk/Overtake‑Biasen beeinflussen Overtake/defend/abort‑Schwellen und Speed‑Bias in der Racing‑Decision‑Layer (`ai_dmq3.c`, `ai_dmnet.c`).

### Testing
- Erfolgreich gebaut: game‑module/QVMs mit `make -C engine BUILD_CLIENT=0 BUILD_SERVER=0 BUILD_GAME_SO=1 -j2` (erzeugt `baseq3r/*.so` und QVMs). 
- Voller Engine‑Build `make -C engine -j2` schlägt in dieser Umgebung fehl wegen fehlender Client‑SDL‑Header (`SDL_version.h`), was unrelated zur Spiel‑AI‑Änderung ist.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dbf0034db483239218f657dc5a7bcc)