### PR TITLE
Add KOTH/DOM objective chat hooks and new bot chat types

### DIFF
--- a/baseq3r/botfiles/bots/angelyss_t.c
+++ b/baseq3r/botfiles/bots/angelyss_t.c
@@ -285,5 +285,30 @@ chat "Angelyss"
 		// 4 = level's title
 		// 5 = random weapon from weapon list
 	} //end type
+
+	type "koth_contest" //initiated when the hill becomes contested
+	{
+		"Hill is contested, push in hard!";
+		"Stay sharp, we are fighting for the hill.";
+		"Dance fight on the hill, go go go!";
+	} //end type
+	type "koth_capture" //initiated when our team captures the hill
+	{
+		"Hill secured, lock it down!";
+		"We have control of the hill, hold positions.";
+		"King of the hill, that is us!";
+	} //end type
+	type "dom_lost_sigil" //initiated when our team loses a sigil
+	{
+		"We lost a sigil, take it back now!";
+		"Sigil lost, regroup and recover it.";
+		"Uh-oh, sigil slipped away, let us yoink it back!";
+	} //end type
+	type "dom_push_sigil" //initiated when team orders switch to sigil pressure
+	{
+		"Push the next sigil, no mercy!";
+		"Advance on the next sigil together.";
+		"New target sigil, wheels up!";
+	} //end type
 } //end chat
 

--- a/baseq3r/botfiles/bots/arachna_t.c
+++ b/baseq3r/botfiles/bots/arachna_t.c
@@ -271,5 +271,30 @@ chat "Arachna"
 		// 4 = level's title
 		// 5 = random weapon from weapon list
 	} //end type
+
+	type "koth_contest" //initiated when the hill becomes contested
+	{
+		"Contest on hill, move now.";
+		"Hill pressure rising, rotate in.";
+		"Crowded hill, time to crash the party.";
+	} //end type
+	type "koth_capture" //initiated when our team captures the hill
+	{
+		"Hill captured, set a perimeter.";
+		"Control gained, keep formation.";
+		"We got the hill, cue victory honk.";
+	} //end type
+	type "dom_lost_sigil" //initiated when our team loses a sigil
+	{
+		"Enemy flipped one of ours, respond.";
+		"We dropped a sigil, stabilize.";
+		"They snagged a sigil, rude. Let us fix that.";
+	} //end type
+	type "dom_push_sigil" //initiated when team orders switch to sigil pressure
+	{
+		"Switch orders: push that sigil.";
+		"New plan, pressure their sigil.";
+		"Target swap: sigil smash time.";
+	} //end type
 } //end chat
 

--- a/baseq3r/botfiles/bots/ayumi_t.c
+++ b/baseq3r/botfiles/bots/ayumi_t.c
@@ -247,5 +247,30 @@ chat "Ayumi"
 		// 4 = level's title
 		// 5 = random weapon from weapon list
 	} //end type
+
+	type "koth_contest" //initiated when the hill becomes contested
+	{
+		"Their pressure is on the hill, collapse on it.";
+		"Hill is hot, contest with discipline.";
+		"Hill brawl time, bring your best moves.";
+	} //end type
+	type "koth_capture" //initiated when our team captures the hill
+	{
+		"Captured the hill, punish every push.";
+		"Hill belongs to us, play it clean.";
+		"Hill is ours, and yes, I called dibs.";
+	} //end type
+	type "dom_lost_sigil" //initiated when our team loses a sigil
+	{
+		"We just lost a sigil, retaliate immediately.";
+		"Sigil control slipped, reclaim methodically.";
+		"Lost sigil detected, comedy is over, push back.";
+	} //end type
+	type "dom_push_sigil" //initiated when team orders switch to sigil pressure
+	{
+		"Orders changed, spearhead the sigil push.";
+		"Rotate and pressure the sigil objective.";
+		"Fresh order: sigil sprint, make it stylish.";
+	} //end type
 } //end chat
 

--- a/baseq3r/botfiles/bots/beret_t.c
+++ b/baseq3r/botfiles/bots/beret_t.c
@@ -274,5 +274,30 @@ chat "Beret"
 		// 4 = level's title
 		// 5 = random weapon from weapon list
 	} //end type
+
+	type "koth_contest" //initiated when the hill becomes contested
+	{
+		"Hill is contested, push in hard!";
+		"Stay sharp, we are fighting for the hill.";
+		"Dance fight on the hill, go go go!";
+	} //end type
+	type "koth_capture" //initiated when our team captures the hill
+	{
+		"Hill secured, lock it down!";
+		"We have control of the hill, hold positions.";
+		"King of the hill, that is us!";
+	} //end type
+	type "dom_lost_sigil" //initiated when our team loses a sigil
+	{
+		"We lost a sigil, take it back now!";
+		"Sigil lost, regroup and recover it.";
+		"Uh-oh, sigil slipped away, let us yoink it back!";
+	} //end type
+	type "dom_push_sigil" //initiated when team orders switch to sigil pressure
+	{
+		"Push the next sigil, no mercy!";
+		"Advance on the next sigil together.";
+		"New target sigil, wheels up!";
+	} //end type
 } //end chat
 

--- a/baseq3r/botfiles/bots/dark_t.c
+++ b/baseq3r/botfiles/bots/dark_t.c
@@ -285,5 +285,30 @@ chat "Dark"
 		// 4 = level's title
 		// 5 = random weapon from weapon list
 	} //end type
+
+	type "koth_contest" //initiated when the hill becomes contested
+	{
+		"Contest on hill, move now.";
+		"Hill pressure rising, rotate in.";
+		"Crowded hill, time to crash the party.";
+	} //end type
+	type "koth_capture" //initiated when our team captures the hill
+	{
+		"Hill captured, set a perimeter.";
+		"Control gained, keep formation.";
+		"We got the hill, cue victory honk.";
+	} //end type
+	type "dom_lost_sigil" //initiated when our team loses a sigil
+	{
+		"Enemy flipped one of ours, respond.";
+		"We dropped a sigil, stabilize.";
+		"They snagged a sigil, rude. Let us fix that.";
+	} //end type
+	type "dom_push_sigil" //initiated when team orders switch to sigil pressure
+	{
+		"Switch orders: push that sigil.";
+		"New plan, pressure their sigil.";
+		"Target swap: sigil smash time.";
+	} //end type
 } //end chat
 

--- a/baseq3r/botfiles/bots/default_t.c
+++ b/baseq3r/botfiles/bots/default_t.c
@@ -174,5 +174,30 @@ chat "default"
 		// 4 = level's title
 		// 5 = random weapon from weapon list
 	} //end type
+
+	type "koth_contest" //initiated when the hill becomes contested
+	{
+		"Their pressure is on the hill, collapse on it.";
+		"Hill is hot, contest with discipline.";
+		"Hill brawl time, bring your best moves.";
+	} //end type
+	type "koth_capture" //initiated when our team captures the hill
+	{
+		"Captured the hill, punish every push.";
+		"Hill belongs to us, play it clean.";
+		"Hill is ours, and yes, I called dibs.";
+	} //end type
+	type "dom_lost_sigil" //initiated when our team loses a sigil
+	{
+		"We just lost a sigil, retaliate immediately.";
+		"Sigil control slipped, reclaim methodically.";
+		"Lost sigil detected, comedy is over, push back.";
+	} //end type
+	type "dom_push_sigil" //initiated when team orders switch to sigil pressure
+	{
+		"Orders changed, spearhead the sigil push.";
+		"Rotate and pressure the sigil objective.";
+		"Fresh order: sigil sprint, make it stylish.";
+	} //end type
 } //end chat
 

--- a/baseq3r/botfiles/bots/gargoyle_t.c
+++ b/baseq3r/botfiles/bots/gargoyle_t.c
@@ -263,4 +263,32 @@ chat "gargoyle"
 		"So, how about them Cubs?";
 		"This is the year that the Cubs win the World Series!";
 	}
+	type "koth_contest" //initiated when the hill becomes contested
+	{
+		"Hill is contested, push in hard!";
+		"Stay sharp, we are fighting for the hill.";
+		"Dance fight on the hill, go go go!";
+	}
+
+	type "koth_capture" //initiated when our team captures the hill
+	{
+		"Hill secured, lock it down!";
+		"We have control of the hill, hold positions.";
+		"King of the hill, that is us!";
+	}
+
+	type "dom_lost_sigil" //initiated when our team loses a sigil
+	{
+		"We lost a sigil, take it back now!";
+		"Sigil lost, regroup and recover it.";
+		"Uh-oh, sigil slipped away, let us yoink it back!";
+	}
+
+	type "dom_push_sigil" //initiated when team orders switch to sigil pressure
+	{
+		"Push the next sigil, no mercy!";
+		"Advance on the next sigil together.";
+		"New target sigil, wheels up!";
+	}
+
 }

--- a/baseq3r/botfiles/bots/grism_t.c
+++ b/baseq3r/botfiles/bots/grism_t.c
@@ -199,4 +199,32 @@ chat "grism"
 		"Is it true that ", peeps, " is a bot?";
 		
 	}
+	type "koth_contest" //initiated when the hill becomes contested
+	{
+		"Contest on hill, move now.";
+		"Hill pressure rising, rotate in.";
+		"Crowded hill, time to crash the party.";
+	}
+
+	type "koth_capture" //initiated when our team captures the hill
+	{
+		"Hill captured, set a perimeter.";
+		"Control gained, keep formation.";
+		"We got the hill, cue victory honk.";
+	}
+
+	type "dom_lost_sigil" //initiated when our team loses a sigil
+	{
+		"Enemy flipped one of ours, respond.";
+		"We dropped a sigil, stabilize.";
+		"They snagged a sigil, rude. Let us fix that.";
+	}
+
+	type "dom_push_sigil" //initiated when team orders switch to sigil pressure
+	{
+		"Switch orders: push that sigil.";
+		"New plan, pressure their sigil.";
+		"Target swap: sigil smash time.";
+	}
+
 }

--- a/baseq3r/botfiles/bots/grunt_t.c
+++ b/baseq3r/botfiles/bots/grunt_t.c
@@ -263,4 +263,32 @@ chat "grunt"
 		"So, how about them Cubs?";
 		"This is the year that the Cubs win the World Series!";
 	}
+	type "koth_contest" //initiated when the hill becomes contested
+	{
+		"Their pressure is on the hill, collapse on it.";
+		"Hill is hot, contest with discipline.";
+		"Hill brawl time, bring your best moves.";
+	}
+
+	type "koth_capture" //initiated when our team captures the hill
+	{
+		"Captured the hill, punish every push.";
+		"Hill belongs to us, play it clean.";
+		"Hill is ours, and yes, I called dibs.";
+	}
+
+	type "dom_lost_sigil" //initiated when our team loses a sigil
+	{
+		"We just lost a sigil, retaliate immediately.";
+		"Sigil control slipped, reclaim methodically.";
+		"Lost sigil detected, comedy is over, push back.";
+	}
+
+	type "dom_push_sigil" //initiated when team orders switch to sigil pressure
+	{
+		"Orders changed, spearhead the sigil push.";
+		"Rotate and pressure the sigil objective.";
+		"Fresh order: sigil sprint, make it stylish.";
+	}
+
 }

--- a/baseq3r/botfiles/bots/jenna_t.c
+++ b/baseq3r/botfiles/bots/jenna_t.c
@@ -271,5 +271,33 @@ chat "Jenna"
 		// 4 = level's title
 		// 5 = random weapon from weapon list
 	} //end type
+	type "koth_contest" //initiated when the hill becomes contested
+	{
+		"Hill is contested, push in hard!";
+		"Stay sharp, we are fighting for the hill.";
+		"Dance fight on the hill, go go go!";
+	}
+
+	type "koth_capture" //initiated when our team captures the hill
+	{
+		"Hill secured, lock it down!";
+		"We have control of the hill, hold positions.";
+		"King of the hill, that is us!";
+	}
+
+	type "dom_lost_sigil" //initiated when our team loses a sigil
+	{
+		"We lost a sigil, take it back now!";
+		"Sigil lost, regroup and recover it.";
+		"Uh-oh, sigil slipped away, let us yoink it back!";
+	}
+
+	type "dom_push_sigil" //initiated when team orders switch to sigil pressure
+	{
+		"Push the next sigil, no mercy!";
+		"Advance on the next sigil together.";
+		"New target sigil, wheels up!";
+	}
+
 } //end chat
 

--- a/baseq3r/botfiles/bots/kyonshi_t.c
+++ b/baseq3r/botfiles/bots/kyonshi_t.c
@@ -209,4 +209,32 @@ chat "kyonshi"
 		
 		
 	}
+	type "koth_contest" //initiated when the hill becomes contested
+	{
+		"Contest on hill, move now.";
+		"Hill pressure rising, rotate in.";
+		"Crowded hill, time to crash the party.";
+	}
+
+	type "koth_capture" //initiated when our team captures the hill
+	{
+		"Hill captured, set a perimeter.";
+		"Control gained, keep formation.";
+		"We got the hill, cue victory honk.";
+	}
+
+	type "dom_lost_sigil" //initiated when our team loses a sigil
+	{
+		"Enemy flipped one of ours, respond.";
+		"We dropped a sigil, stabilize.";
+		"They snagged a sigil, rude. Let us fix that.";
+	}
+
+	type "dom_push_sigil" //initiated when team orders switch to sigil pressure
+	{
+		"Switch orders: push that sigil.";
+		"New plan, pressure their sigil.";
+		"Target swap: sigil smash time.";
+	}
+
 }

--- a/baseq3r/botfiles/bots/liz_t.c
+++ b/baseq3r/botfiles/bots/liz_t.c
@@ -247,5 +247,33 @@ chat "Liz"
 		// 4 = level's title
 		// 5 = random weapon from weapon list
 	} //end type
+	type "koth_contest" //initiated when the hill becomes contested
+	{
+		"Their pressure is on the hill, collapse on it.";
+		"Hill is hot, contest with discipline.";
+		"Hill brawl time, bring your best moves.";
+	}
+
+	type "koth_capture" //initiated when our team captures the hill
+	{
+		"Captured the hill, punish every push.";
+		"Hill belongs to us, play it clean.";
+		"Hill is ours, and yes, I called dibs.";
+	}
+
+	type "dom_lost_sigil" //initiated when our team loses a sigil
+	{
+		"We just lost a sigil, retaliate immediately.";
+		"Sigil control slipped, reclaim methodically.";
+		"Lost sigil detected, comedy is over, push back.";
+	}
+
+	type "dom_push_sigil" //initiated when team orders switch to sigil pressure
+	{
+		"Orders changed, spearhead the sigil push.";
+		"Rotate and pressure the sigil objective.";
+		"Fresh order: sigil sprint, make it stylish.";
+	}
+
 } //end chat
 

--- a/baseq3r/botfiles/bots/major_t.c
+++ b/baseq3r/botfiles/bots/major_t.c
@@ -286,5 +286,33 @@ chat "Major"
 		// 4 = level's title
 		// 5 = random weapon from weapon list
 	} //end type
+	type "koth_contest" //initiated when the hill becomes contested
+	{
+		"Hill is contested, push in hard!";
+		"Stay sharp, we are fighting for the hill.";
+		"Dance fight on the hill, go go go!";
+	}
+
+	type "koth_capture" //initiated when our team captures the hill
+	{
+		"Hill secured, lock it down!";
+		"We have control of the hill, hold positions.";
+		"King of the hill, that is us!";
+	}
+
+	type "dom_lost_sigil" //initiated when our team loses a sigil
+	{
+		"We lost a sigil, take it back now!";
+		"Sigil lost, regroup and recover it.";
+		"Uh-oh, sigil slipped away, let us yoink it back!";
+	}
+
+	type "dom_push_sigil" //initiated when team orders switch to sigil pressure
+	{
+		"Push the next sigil, no mercy!";
+		"Advance on the next sigil together.";
+		"New target sigil, wheels up!";
+	}
+
 } //end chat
 

--- a/baseq3r/botfiles/bots/merman_t.c
+++ b/baseq3r/botfiles/bots/merman_t.c
@@ -281,5 +281,33 @@ chat "Merman"
 		// 4 = level's title
 		// 5 = random weapon from weapon list
 	} //end type
+	type "koth_contest" //initiated when the hill becomes contested
+	{
+		"Contest on hill, move now.";
+		"Hill pressure rising, rotate in.";
+		"Crowded hill, time to crash the party.";
+	}
+
+	type "koth_capture" //initiated when our team captures the hill
+	{
+		"Hill captured, set a perimeter.";
+		"Control gained, keep formation.";
+		"We got the hill, cue victory honk.";
+	}
+
+	type "dom_lost_sigil" //initiated when our team loses a sigil
+	{
+		"Enemy flipped one of ours, respond.";
+		"We dropped a sigil, stabilize.";
+		"They snagged a sigil, rude. Let us fix that.";
+	}
+
+	type "dom_push_sigil" //initiated when team orders switch to sigil pressure
+	{
+		"Switch orders: push that sigil.";
+		"New plan, pressure their sigil.";
+		"Target swap: sigil smash time.";
+	}
+
 } //end chat
 

--- a/baseq3r/botfiles/bots/neko_t.c
+++ b/baseq3r/botfiles/bots/neko_t.c
@@ -281,5 +281,33 @@ chat "Neko"
 		// 4 = level's title
 		// 5 = random weapon from weapon list
 	} //end type
+	type "koth_contest" //initiated when the hill becomes contested
+	{
+		"Their pressure is on the hill, collapse on it.";
+		"Hill is hot, contest with discipline.";
+		"Hill brawl time, bring your best moves.";
+	}
+
+	type "koth_capture" //initiated when our team captures the hill
+	{
+		"Captured the hill, punish every push.";
+		"Hill belongs to us, play it clean.";
+		"Hill is ours, and yes, I called dibs.";
+	}
+
+	type "dom_lost_sigil" //initiated when our team loses a sigil
+	{
+		"We just lost a sigil, retaliate immediately.";
+		"Sigil control slipped, reclaim methodically.";
+		"Lost sigil detected, comedy is over, push back.";
+	}
+
+	type "dom_push_sigil" //initiated when team orders switch to sigil pressure
+	{
+		"Orders changed, spearhead the sigil push.";
+		"Rotate and pressure the sigil objective.";
+		"Fresh order: sigil sprint, make it stylish.";
+	}
+
 } //end chat
 

--- a/baseq3r/botfiles/bots/penguin_t.c
+++ b/baseq3r/botfiles/bots/penguin_t.c
@@ -272,5 +272,33 @@ chat "Penguin"
 		// 4 = level's title
 		// 5 = random weapon from weapon list
 	} //end type
+	type "koth_contest" //initiated when the hill becomes contested
+	{
+		"Hill is contested, push in hard!";
+		"Stay sharp, we are fighting for the hill.";
+		"Dance fight on the hill, go go go!";
+	}
+
+	type "koth_capture" //initiated when our team captures the hill
+	{
+		"Hill secured, lock it down!";
+		"We have control of the hill, hold positions.";
+		"King of the hill, that is us!";
+	}
+
+	type "dom_lost_sigil" //initiated when our team loses a sigil
+	{
+		"We lost a sigil, take it back now!";
+		"Sigil lost, regroup and recover it.";
+		"Uh-oh, sigil slipped away, let us yoink it back!";
+	}
+
+	type "dom_push_sigil" //initiated when team orders switch to sigil pressure
+	{
+		"Push the next sigil, no mercy!";
+		"Advance on the next sigil together.";
+		"New target sigil, wheels up!";
+	}
+
 } //end chat
 

--- a/baseq3r/botfiles/bots/rai_t.c
+++ b/baseq3r/botfiles/bots/rai_t.c
@@ -285,5 +285,33 @@ chat "Rai"
 		// 4 = level's title
 		// 5 = random weapon from weapon list
 	} //end type
+	type "koth_contest" //initiated when the hill becomes contested
+	{
+		"Contest on hill, move now.";
+		"Hill pressure rising, rotate in.";
+		"Crowded hill, time to crash the party.";
+	}
+
+	type "koth_capture" //initiated when our team captures the hill
+	{
+		"Hill captured, set a perimeter.";
+		"Control gained, keep formation.";
+		"We got the hill, cue victory honk.";
+	}
+
+	type "dom_lost_sigil" //initiated when our team loses a sigil
+	{
+		"Enemy flipped one of ours, respond.";
+		"We dropped a sigil, stabilize.";
+		"They snagged a sigil, rude. Let us fix that.";
+	}
+
+	type "dom_push_sigil" //initiated when team orders switch to sigil pressure
+	{
+		"Switch orders: push that sigil.";
+		"New plan, pressure their sigil.";
+		"Target swap: sigil smash time.";
+	}
+
 } //end chat
 

--- a/baseq3r/botfiles/bots/sarge_t.c
+++ b/baseq3r/botfiles/bots/sarge_t.c
@@ -199,4 +199,32 @@ chat "sarge"
 		"Is it true that ", peeps, " is a bot?";
 		
 	}
+	type "koth_contest" //initiated when the hill becomes contested
+	{
+		"Their pressure is on the hill, collapse on it.";
+		"Hill is hot, contest with discipline.";
+		"Hill brawl time, bring your best moves.";
+	}
+
+	type "koth_capture" //initiated when our team captures the hill
+	{
+		"Captured the hill, punish every push.";
+		"Hill belongs to us, play it clean.";
+		"Hill is ours, and yes, I called dibs.";
+	}
+
+	type "dom_lost_sigil" //initiated when our team loses a sigil
+	{
+		"We just lost a sigil, retaliate immediately.";
+		"Sigil control slipped, reclaim methodically.";
+		"Lost sigil detected, comedy is over, push back.";
+	}
+
+	type "dom_push_sigil" //initiated when team orders switch to sigil pressure
+	{
+		"Orders changed, spearhead the sigil push.";
+		"Rotate and pressure the sigil objective.";
+		"Fresh order: sigil sprint, make it stylish.";
+	}
+
 }

--- a/baseq3r/botfiles/bots/sergei_t.c
+++ b/baseq3r/botfiles/bots/sergei_t.c
@@ -280,5 +280,33 @@ chat "Sergei"
 		// 4 = level's title
 		// 5 = random weapon from weapon list
 	} //end type
+	type "koth_contest" //initiated when the hill becomes contested
+	{
+		"Hill is contested, push in hard!";
+		"Stay sharp, we are fighting for the hill.";
+		"Dance fight on the hill, go go go!";
+	}
+
+	type "koth_capture" //initiated when our team captures the hill
+	{
+		"Hill secured, lock it down!";
+		"We have control of the hill, hold positions.";
+		"King of the hill, that is us!";
+	}
+
+	type "dom_lost_sigil" //initiated when our team loses a sigil
+	{
+		"We lost a sigil, take it back now!";
+		"Sigil lost, regroup and recover it.";
+		"Uh-oh, sigil slipped away, let us yoink it back!";
+	}
+
+	type "dom_push_sigil" //initiated when team orders switch to sigil pressure
+	{
+		"Push the next sigil, no mercy!";
+		"Advance on the next sigil together.";
+		"New target sigil, wheels up!";
+	}
+
 } //end chat
 

--- a/baseq3r/botfiles/bots/skelebot_t.c
+++ b/baseq3r/botfiles/bots/skelebot_t.c
@@ -199,4 +199,32 @@ chat "skelebot"
 		"Is it true that ", peeps, " is a bot?";
 		
 	}
+	type "koth_contest" //initiated when the hill becomes contested
+	{
+		"Contest on hill, move now.";
+		"Hill pressure rising, rotate in.";
+		"Crowded hill, time to crash the party.";
+	}
+
+	type "koth_capture" //initiated when our team captures the hill
+	{
+		"Hill captured, set a perimeter.";
+		"Control gained, keep formation.";
+		"We got the hill, cue victory honk.";
+	}
+
+	type "dom_lost_sigil" //initiated when our team loses a sigil
+	{
+		"Enemy flipped one of ours, respond.";
+		"We dropped a sigil, stabilize.";
+		"They snagged a sigil, rude. Let us fix that.";
+	}
+
+	type "dom_push_sigil" //initiated when team orders switch to sigil pressure
+	{
+		"Switch orders: push that sigil.";
+		"New plan, pressure their sigil.";
+		"Target swap: sigil smash time.";
+	}
+
 }

--- a/baseq3r/botfiles/bots/sly_t.c
+++ b/baseq3r/botfiles/bots/sly_t.c
@@ -285,5 +285,33 @@ chat "Sly"
 		// 4 = level's title
 		// 5 = random weapon from weapon list
 	} //end type
+	type "koth_contest" //initiated when the hill becomes contested
+	{
+		"Their pressure is on the hill, collapse on it.";
+		"Hill is hot, contest with discipline.";
+		"Hill brawl time, bring your best moves.";
+	}
+
+	type "koth_capture" //initiated when our team captures the hill
+	{
+		"Captured the hill, punish every push.";
+		"Hill belongs to us, play it clean.";
+		"Hill is ours, and yes, I called dibs.";
+	}
+
+	type "dom_lost_sigil" //initiated when our team loses a sigil
+	{
+		"We just lost a sigil, retaliate immediately.";
+		"Sigil control slipped, reclaim methodically.";
+		"Lost sigil detected, comedy is over, push back.";
+	}
+
+	type "dom_push_sigil" //initiated when team orders switch to sigil pressure
+	{
+		"Orders changed, spearhead the sigil push.";
+		"Rotate and pressure the sigil objective.";
+		"Fresh order: sigil sprint, make it stylish.";
+	}
+
 } //end chat
 

--- a/baseq3r/botfiles/bots/tanisha_t.c
+++ b/baseq3r/botfiles/bots/tanisha_t.c
@@ -285,5 +285,33 @@ chat "Tanisha"
 		// 4 = level's title
 		// 5 = random weapon from weapon list
 	} //end type
+	type "koth_contest" //initiated when the hill becomes contested
+	{
+		"Hill is contested, push in hard!";
+		"Stay sharp, we are fighting for the hill.";
+		"Dance fight on the hill, go go go!";
+	}
+
+	type "koth_capture" //initiated when our team captures the hill
+	{
+		"Hill secured, lock it down!";
+		"We have control of the hill, hold positions.";
+		"King of the hill, that is us!";
+	}
+
+	type "dom_lost_sigil" //initiated when our team loses a sigil
+	{
+		"We lost a sigil, take it back now!";
+		"Sigil lost, regroup and recover it.";
+		"Uh-oh, sigil slipped away, let us yoink it back!";
+	}
+
+	type "dom_push_sigil" //initiated when team orders switch to sigil pressure
+	{
+		"Push the next sigil, no mercy!";
+		"Advance on the next sigil together.";
+		"New target sigil, wheels up!";
+	}
+
 } //end chat
 

--- a/baseq3r/botfiles/bots/tony_t.c
+++ b/baseq3r/botfiles/bots/tony_t.c
@@ -199,4 +199,32 @@ chat "Tony"
 		"Is it true that ", peeps, " is a bot?";
 		
 	}
+	type "koth_contest" //initiated when the hill becomes contested
+	{
+		"Contest on hill, move now.";
+		"Hill pressure rising, rotate in.";
+		"Crowded hill, time to crash the party.";
+	}
+
+	type "koth_capture" //initiated when our team captures the hill
+	{
+		"Hill captured, set a perimeter.";
+		"Control gained, keep formation.";
+		"We got the hill, cue victory honk.";
+	}
+
+	type "dom_lost_sigil" //initiated when our team loses a sigil
+	{
+		"Enemy flipped one of ours, respond.";
+		"We dropped a sigil, stabilize.";
+		"They snagged a sigil, rude. Let us fix that.";
+	}
+
+	type "dom_push_sigil" //initiated when team orders switch to sigil pressure
+	{
+		"Switch orders: push that sigil.";
+		"New plan, pressure their sigil.";
+		"Target swap: sigil smash time.";
+	}
+
 }

--- a/baseq3r/botfiles/bots/widowe_t.c
+++ b/baseq3r/botfiles/bots/widowe_t.c
@@ -271,5 +271,33 @@ chat "Widowe"
 		// 4 = level's title
 		// 5 = random weapon from weapon list
 	} //end type
+	type "koth_contest" //initiated when the hill becomes contested
+	{
+		"Their pressure is on the hill, collapse on it.";
+		"Hill is hot, contest with discipline.";
+		"Hill brawl time, bring your best moves.";
+	}
+
+	type "koth_capture" //initiated when our team captures the hill
+	{
+		"Captured the hill, punish every push.";
+		"Hill belongs to us, play it clean.";
+		"Hill is ours, and yes, I called dibs.";
+	}
+
+	type "dom_lost_sigil" //initiated when our team loses a sigil
+	{
+		"We just lost a sigil, retaliate immediately.";
+		"Sigil control slipped, reclaim methodically.";
+		"Lost sigil detected, comedy is over, push back.";
+	}
+
+	type "dom_push_sigil" //initiated when team orders switch to sigil pressure
+	{
+		"Orders changed, spearhead the sigil push.";
+		"Rotate and pressure the sigil objective.";
+		"Fresh order: sigil sprint, make it stylish.";
+	}
+
 } //end chat
 

--- a/engine/code/game/ai_chat.c
+++ b/engine/code/game/ai_chat.c
@@ -962,6 +962,29 @@ int BotChat_Random(bot_state_t *bs) {
 	return qtrue;
 }
 
+
+/*
+==================
+BotChat_ObjectiveEvent
+==================
+*/
+int BotChat_ObjectiveEvent(bot_state_t *bs, char *chattype) {
+	if (bot_nochat.integer) return qfalse;
+	if (BotIsObserver(bs)) return qfalse;
+	if (!TeamPlayIsOn()) return qfalse;
+	if (bs->lastchat_time > FloatTime() - TIME_BETWEENCHATTING) return qfalse;
+	if (!BotValidChatPosition(bs)) return qfalse;
+	if (BotVisibleEnemies(bs)) return qfalse;
+	if (!chattype || !chattype[0]) return qfalse;
+	if (!trap_BotNumInitialChats(bs->cs, chattype)) return qfalse;
+
+	BotAI_BotInitialChat(bs, chattype, NULL);
+	bs->chatto = CHAT_TEAM;
+	bs->lastchat_time = FloatTime();
+	trap_BotEnterChat(bs->cs, 0, CHAT_TEAM);
+	return qtrue;
+}
+
 /*
 ==================
 BotChatTime

--- a/engine/code/game/ai_chat.h
+++ b/engine/code/game/ai_chat.h
@@ -53,6 +53,8 @@ int BotChat_Kill(bot_state_t *bs);
 int BotChat_EnemySuicide(bot_state_t *bs);
 //
 int BotChat_Random(bot_state_t *bs);
+// objective/team event chat line (koth/dom)
+int BotChat_ObjectiveEvent(bot_state_t *bs, char *chattype);
 // time the selected chat takes to type in
 float BotChatTime(bot_state_t *bs);
 // returns true if the bot can chat at the current position

--- a/engine/code/game/ai_team.c
+++ b/engine/code/game/ai_team.c
@@ -1892,6 +1892,76 @@ void BotHarvesterOrders(bot_state_t *bs) {
 static char botDominationStatusSnapshot[MAX_CLIENTS][MAX_INFO_STRING];
 static int botKOTHOwnerSnapshot[MAX_CLIENTS];
 static int botKOTHContestedSnapshot[MAX_CLIENTS];
+static int botDominationOrderModeSnapshot[MAX_CLIENTS];
+static int botKOTHOrderModeSnapshot[MAX_CLIENTS];
+
+typedef enum {
+	BOT_DOM_ORDER_HOLD = 0,
+	BOT_DOM_ORDER_PUSH_NEUTRAL,
+	BOT_DOM_ORDER_PUSH_ENEMY
+} bot_dom_order_mode_t;
+
+typedef enum {
+	BOT_KOTH_ORDER_HOLD = 0,
+	BOT_KOTH_ORDER_CONTEST
+} bot_koth_order_mode_t;
+
+/*
+==================
+BotCountDominationOwnedSigils
+==================
+*/
+static int BotCountDominationOwnedSigils(int team, char *sigilStatus) {
+	int i, owned;
+	int ownedStatus;
+
+	if (!sigilStatus || !sigilStatus[0]) {
+		return 0;
+	}
+
+	ownedStatus = (team == TEAM_RED) ? SIGIL_ISRED : SIGIL_ISBLUE;
+	owned = 0;
+	for (i = 0; sigilStatus[i]; i++) {
+		if (sigilStatus[i] == ('0' + ownedStatus)) {
+			owned++;
+		}
+	}
+	return owned;
+}
+
+/*
+==================
+BotDominationOrderMode
+==================
+*/
+static int BotDominationOrderMode(bot_state_t *bs) {
+	int sigilStatus = SIGIL_NONE;
+	bot_goal_t sigilGoal;
+
+	if (!BotGetDominationSigilGoal(bs, &sigilGoal, &sigilStatus)) {
+		return BOT_DOM_ORDER_HOLD;
+	}
+	if (sigilStatus == SIGIL_ISWHITE) {
+		return BOT_DOM_ORDER_PUSH_NEUTRAL;
+	}
+	if ((BotTeam(bs) == TEAM_RED && sigilStatus == SIGIL_ISBLUE) ||
+		(BotTeam(bs) == TEAM_BLUE && sigilStatus == SIGIL_ISRED)) {
+		return BOT_DOM_ORDER_PUSH_ENEMY;
+	}
+	return BOT_DOM_ORDER_HOLD;
+}
+
+/*
+==================
+BotKOTHOrderMode
+==================
+*/
+static int BotKOTHOrderMode(int owner, int contested, int team) {
+	if (owner == team && !contested) {
+		return BOT_KOTH_ORDER_HOLD;
+	}
+	return BOT_KOTH_ORDER_CONTEST;
+}
 
 /*
 ==================
@@ -2193,14 +2263,29 @@ void BotTeamAI(bot_state_t *bs) {
 		case GT_DOMINATION:
 		{
 			char sigilStatus[MAX_INFO_STRING];
+			int newOrderMode;
+			int oldOwned, newOwned;
 
 			trap_GetConfigstring(CS_SIGILSTATUS, sigilStatus, sizeof(sigilStatus));
+			oldOwned = BotCountDominationOwnedSigils(BotTeam(bs), botDominationStatusSnapshot[bs->client]);
+			newOwned = BotCountDominationOwnedSigils(BotTeam(bs), sigilStatus);
+			if (newOwned < oldOwned) {
+				BotChat_ObjectiveEvent(bs, "dom_lost_sigil");
+			}
+
+			newOrderMode = BotDominationOrderMode(bs);
+			if (botDominationOrderModeSnapshot[bs->client] != newOrderMode &&
+				newOrderMode != BOT_DOM_ORDER_HOLD) {
+				BotChat_ObjectiveEvent(bs, "dom_push_sigil");
+			}
+
 			if (bs->numteammates != numteammates ||
 				Q_stricmp(botDominationStatusSnapshot[bs->client], sigilStatus) ||
 				bs->forceorders) {
 				bs->teamgiveorders_time = FloatTime();
 				bs->numteammates = numteammates;
 				Q_strncpyz(botDominationStatusSnapshot[bs->client], sigilStatus, sizeof(botDominationStatusSnapshot[bs->client]));
+				botDominationOrderModeSnapshot[bs->client] = newOrderMode;
 				bs->forceorders = qfalse;
 			}
 
@@ -2213,10 +2298,23 @@ void BotTeamAI(bot_state_t *bs) {
 		case GT_KOTH:
 		{
 			int owner, contested;
+			int newOrderMode;
 
 			if (!BotGetKOTHStatus(&owner, &contested, NULL, NULL, NULL)) {
 				owner = TEAM_FREE;
 				contested = qfalse;
+			}
+			if (botKOTHOwnerSnapshot[bs->client] != owner && owner == BotTeam(bs)) {
+				BotChat_ObjectiveEvent(bs, "koth_capture");
+			}
+			if (!botKOTHContestedSnapshot[bs->client] && contested) {
+				BotChat_ObjectiveEvent(bs, "koth_contest");
+			}
+
+			newOrderMode = BotKOTHOrderMode(owner, contested, BotTeam(bs));
+			if (botKOTHOrderModeSnapshot[bs->client] != newOrderMode &&
+				newOrderMode == BOT_KOTH_ORDER_CONTEST) {
+				BotChat_ObjectiveEvent(bs, "koth_contest");
 			}
 
 			if (bs->numteammates != numteammates ||
@@ -2227,6 +2325,7 @@ void BotTeamAI(bot_state_t *bs) {
 				bs->numteammates = numteammates;
 				botKOTHOwnerSnapshot[bs->client] = owner;
 				botKOTHContestedSnapshot[bs->client] = contested;
+				botKOTHOrderModeSnapshot[bs->client] = newOrderMode;
 				bs->forceorders = qfalse;
 			}
 
@@ -2295,4 +2394,3 @@ void BotTeamAI(bot_state_t *bs) {
 #endif
 	}
 }
-


### PR DESCRIPTION
### Motivation

- Provide team-objective chat lines for KOTH and Domination so bots can react to owner changes, contested phases and order-mode switches. 
- Let team-leader bots announce objective events (capture/contest/push/loss) while respecting existing anti-spam and safety gates. 
- Offer personality-dependent variants in bot chat files so different bot voices respond differently to the same objective events.

### Description

- Added a new helper `BotChat_ObjectiveEvent(bot_state_t *bs, char *chattype)` in `engine/code/game/ai_chat.c` and declared it in `ai_chat.h`; it uses existing gates (`bot_nochat`, observer checks, `TIME_BETWEENCHATTING`, valid chat position, visible-enemy check) and emits a team chat (`CHAT_TEAM`) via `trap_BotEnterChat`.
- Extended `engine/code/game/ai_team.c` with lightweight snapshots and order-mode helpers plus enums and helpers: `BotCountDominationOwnedSigils`, `BotDominationOrderMode`, `BotKOTHOrderMode`; these detect transitions and trigger objective chats for `koth_capture`, `koth_contest`, `dom_lost_sigil`, and `dom_push_sigil` when appropriate.
- Updated team-AI flows (KOTH/DOM) to call `BotChat_ObjectiveEvent` on owner changes, contest start, sigil losses and when the team order-mode changes to a push/contest mode, while storing mode snapshots to avoid repeated spam.
- Added the new initial chat types to every bot chat file under `baseq3r/botfiles/bots/*_t.c`: `koth_contest`, `koth_capture`, `dom_lost_sigil`, and `dom_push_sigil`, with multiple phrasing variants to provide differing personalities/styles.

### Testing

- Ran repository static/diff checks to detect whitespace/file issues and found no errors (check passed).
- Executed an automated verification script that ensures each `baseq3r/botfiles/bots/*_t.c` includes the four new chat types (`koth_contest`, `koth_capture`, `dom_lost_sigil`, `dom_push_sigil`), and the script succeeded for all files.
- Performed a workspace status verification to confirm the modified files are consistent and present; the check completed with no blocking issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dbfc498a34832396be061462a32bee)