### PR TITLE
Add CTF4 team AI, objective chatter and improved flag-targeting/score logic

### DIFF
--- a/baseq3r/botfiles/teamplay.h
+++ b/baseq3r/botfiles/teamplay.h
@@ -542,3 +542,22 @@ type "cmd_takeb"
 {
 0, " dominate point B";
 }
+
+// CTF4 objective event chatter
+type "ctf4_own_flag_stolen"
+{
+"Our flag is out, rotate back now!";
+"They're running our flag, collapse on return!";
+}
+
+type "ctf4_enemy_carrier_visible"
+{
+"Enemy carrier is spotted, intercept!";
+"Carrier seen, cut them off!";
+}
+
+type "ctf4_score_pressure"
+{
+"We're behind, push for a fast capture!";
+"Score pressure on us, full offense!";
+}

--- a/engine/code/game/ai_dmq3.c
+++ b/engine/code/game/ai_dmq3.c
@@ -175,6 +175,10 @@ int BotOppositeTeam(bot_state_t *bs) {
 	int team, i, enemyTeams[3], enemyCount, bestTeam, bestTravel;
 	bot_goal_t *goal;
 	int travelTime;
+	char flagStatus[8];
+	int ownFlagIndex, ownFlagStolen;
+	int lowEnemyScore;
+	qboolean scorePressure;
 
 	team = BotTeam(bs);
 	if (team < TEAM_RED || team > TEAM_YELLOW) {
@@ -182,6 +186,7 @@ int BotOppositeTeam(bot_state_t *bs) {
 	}
 
 	enemyCount = 0;
+	lowEnemyScore = 0x7fffffff;
 	for (i = TEAM_RED; i <= TEAM_YELLOW; i++) {
 		if (i == team) {
 			continue;
@@ -191,6 +196,12 @@ int BotOppositeTeam(bot_state_t *bs) {
 			(i == TEAM_GREEN) ? &ctf_greenflag : &ctf_yellowflag;
 		if (!goal->areanum) {
 			continue;
+		}
+		if (TeamCount(-1, i) <= 0) {
+			continue;
+		}
+		if (level.teamScores[i] < lowEnemyScore) {
+			lowEnemyScore = level.teamScores[i];
 		}
 		enemyTeams[enemyCount++] = i;
 	}
@@ -204,16 +215,51 @@ int BotOppositeTeam(bot_state_t *bs) {
 
 	bestTeam = enemyTeams[0];
 	bestTravel = 0x7fffffff;
+	trap_GetConfigstring(CS_FLAGSTATUS, flagStatus, sizeof(flagStatus));
+	ownFlagIndex = (team == TEAM_RED) ? 0 :
+		(team == TEAM_BLUE) ? 1 :
+		(team == TEAM_GREEN) ? 2 :
+		(team == TEAM_YELLOW) ? 3 : -1;
+	ownFlagStolen = (ownFlagIndex >= 0 && flagStatus[ownFlagIndex] && flagStatus[ownFlagIndex] != '0');
+	scorePressure = (g_capturelimit.integer > 0);
+	if (scorePressure) {
+		int topEnemy = -1;
+		for (i = 0; i < enemyCount; i++) {
+			if (level.teamScores[enemyTeams[i]] > topEnemy) {
+				topEnemy = level.teamScores[enemyTeams[i]];
+			}
+		}
+		scorePressure = (topEnemy >= g_capturelimit.integer - 1 ||
+			topEnemy - level.teamScores[team] >= 2);
+	}
+
 	for (i = 0; i < enemyCount; i++) {
+		int score;
+		int idx;
 		goal = (enemyTeams[i] == TEAM_RED) ? &ctf_redflag :
 			(enemyTeams[i] == TEAM_BLUE) ? &ctf_blueflag :
 			(enemyTeams[i] == TEAM_GREEN) ? &ctf_greenflag : &ctf_yellowflag;
 		travelTime = trap_AAS_AreaTravelTimeToGoalArea(bs->areanum, bs->origin, goal->areanum, TFL_DEFAULT);
-		if (!travelTime) {
-			continue;
+		score = travelTime > 0 ? travelTime : 10000;
+		// favor the weaker enemy team as primary farm target
+		score += (level.teamScores[enemyTeams[i]] - lowEnemyScore) * 120;
+		idx = (enemyTeams[i] == TEAM_RED) ? 0 :
+			(enemyTeams[i] == TEAM_BLUE) ? 1 :
+			(enemyTeams[i] == TEAM_GREEN) ? 2 : 3;
+		// if this flag is already missing from base, spread pressure to other teams
+		if (flagStatus[idx] && flagStatus[idx] != '0') {
+			score += 220;
 		}
-		if (travelTime < bestTravel) {
-			bestTravel = travelTime;
+		// when under pressure, deprioritize distant targets if own flag is currently stolen
+		if (ownFlagStolen && scorePressure) {
+			score += 120;
+		}
+		if (scorePressure && g_capturelimit.integer > 0 &&
+			level.teamScores[enemyTeams[i]] >= g_capturelimit.integer - 1) {
+			score -= 320;
+		}
+		if (score < bestTravel) {
+			bestTravel = score;
 			bestTeam = enemyTeams[i];
 		}
 	}

--- a/engine/code/game/ai_dmq3.h
+++ b/engine/code/game/ai_dmq3.h
@@ -63,6 +63,10 @@ qboolean EntityIsDead(aas_entityinfo_t *entinfo);
 qboolean EntityIsInvisible(aas_entityinfo_t *entinfo);
 //returns true if the entity is shooting
 qboolean EntityIsShooting(aas_entityinfo_t *entinfo);
+//returns true if the entity carries any CTF flag
+qboolean EntityCarriesFlag(aas_entityinfo_t *entinfo);
+//returns true if the entity carries harvester cubes (missionpack)
+qboolean EntityCarriesCubes(aas_entityinfo_t *entinfo);
 #ifdef MISSIONPACK
 //returns true if this entity has the kamikaze
 qboolean EntityHasKamikaze(aas_entityinfo_t *entinfo);

--- a/engine/code/game/ai_team.c
+++ b/engine/code/game/ai_team.c
@@ -846,6 +846,182 @@ void BotCTFOrders(bot_state_t *bs) {
 	}
 }
 
+static int BotCTF4TeamToFlagIndex(int team) {
+	switch (team) {
+		case TEAM_RED: return 0;
+		case TEAM_BLUE: return 1;
+		case TEAM_GREEN: return 2;
+		case TEAM_YELLOW: return 3;
+		default: return -1;
+	}
+}
+
+static int BotCTF4EnemyCarrierVisible(bot_state_t *bs) {
+	int i;
+	float vis;
+	aas_entityinfo_t entinfo;
+
+	for (i = 0; i < level.maxclients; i++) {
+		if (i == bs->client) {
+			continue;
+		}
+		BotEntityInfo(i, &entinfo);
+		if (!entinfo.valid || !EntityCarriesFlag(&entinfo) || BotSameTeam(bs, i)) {
+			continue;
+		}
+		vis = BotEntityVisible(bs->entitynum, bs->eye, bs->cur_ps.viewangles, 360, i);
+		if (vis > 0) {
+			return i;
+		}
+	}
+	return -1;
+}
+
+static int BotCTF4BestEnemyFlagTeam(bot_state_t *bs, const char *flagStatus, qboolean scorePressure) {
+	int team, i, bestTeam, bestScore;
+	int ownTeam = BotTeam(bs);
+	int enemyTeams[3];
+	int enemyCount = 0;
+	int lowEnemyScore = 0x7fffffff;
+
+	for (team = TEAM_RED; team <= TEAM_YELLOW; team++) {
+		if (team == ownTeam || TeamCount(-1, team) <= 0) {
+			continue;
+		}
+		if (level.teamScores[team] < lowEnemyScore) {
+			lowEnemyScore = level.teamScores[team];
+		}
+		enemyTeams[enemyCount++] = team;
+	}
+	if (!enemyCount) {
+		return TEAM_FREE;
+	}
+
+	bestTeam = enemyTeams[0];
+	bestScore = 0x7fffffff;
+	for (i = 0; i < enemyCount; i++) {
+		int travel = 0;
+		int score = 0;
+		int idx = BotCTF4TeamToFlagIndex(enemyTeams[i]);
+		bot_goal_t *goal = (enemyTeams[i] == TEAM_RED) ? &ctf_redflag :
+			(enemyTeams[i] == TEAM_BLUE) ? &ctf_blueflag :
+			(enemyTeams[i] == TEAM_GREEN) ? &ctf_greenflag : &ctf_yellowflag;
+
+		if (goal->areanum) {
+			travel = trap_AAS_AreaTravelTimeToGoalArea(bs->areanum, bs->origin, goal->areanum, TFL_DEFAULT);
+		}
+		score = travel > 0 ? travel : 10000;
+		// prefer weaker teams, then shorter runs
+		score += (level.teamScores[enemyTeams[i]] - lowEnemyScore) * 120;
+		// if an enemy flag is already out, deprioritize to avoid overstacking one objective
+		if (flagStatus && idx >= 0 && flagStatus[idx] != '0') {
+			score += 220;
+		}
+		if (scorePressure && g_capturelimit.integer > 0 &&
+			level.teamScores[enemyTeams[i]] >= g_capturelimit.integer - 1) {
+			// when close to losing, pressure the current leaders harder
+			score -= 300;
+		}
+		if (score < bestScore) {
+			bestScore = score;
+			bestTeam = enemyTeams[i];
+		}
+	}
+	return bestTeam;
+}
+
+static qboolean BotCTF4ScorePressure(bot_state_t *bs) {
+	int team, ownScore, bestEnemyScore;
+
+	if (g_capturelimit.integer <= 0) {
+		return qfalse;
+	}
+
+	team = BotTeam(bs);
+	ownScore = level.teamScores[team];
+	bestEnemyScore = -1;
+	for (team = TEAM_RED; team <= TEAM_YELLOW; team++) {
+		if (team == BotTeam(bs) || TeamCount(-1, team) <= 0) {
+			continue;
+		}
+		if (level.teamScores[team] > bestEnemyScore) {
+			bestEnemyScore = level.teamScores[team];
+		}
+	}
+	if (bestEnemyScore < 0) {
+		return qfalse;
+	}
+	if (bestEnemyScore >= g_capturelimit.integer - 1) {
+		return qtrue;
+	}
+	return (bestEnemyScore - ownScore >= 2);
+}
+
+/*
+==================
+BotCTF4Orders
+==================
+*/
+void BotCTF4Orders(bot_state_t *bs) {
+	int i, numteammates, defenders, interceptors;
+	int teammates[MAX_CLIENTS] = {0};
+	int ownIndex, enemyCarrier, targetTeam;
+	qboolean ownFlagStolen, scorePressure;
+	char flagStatus[8];
+	char name[MAX_NETNAME];
+
+	trap_GetConfigstring(CS_FLAGSTATUS, flagStatus, sizeof(flagStatus));
+	ownIndex = BotCTF4TeamToFlagIndex(BotTeam(bs));
+	ownFlagStolen = (ownIndex >= 0 && flagStatus[ownIndex] && flagStatus[ownIndex] != '0');
+	scorePressure = BotCTF4ScorePressure(bs);
+	enemyCarrier = BotCTF4EnemyCarrierVisible(bs);
+	targetTeam = BotCTF4BestEnemyFlagTeam(bs, flagStatus, scorePressure);
+
+	numteammates = BotSortTeamMatesByBaseTravelTime(bs, teammates, sizeof(teammates));
+	BotSortTeamMatesByTaskPreference(bs, teammates, numteammates);
+	if (numteammates <= 1) {
+		return;
+	}
+
+	defenders = 1;
+	if (!scorePressure && numteammates >= 6) {
+		defenders = 2;
+	}
+	interceptors = (enemyCarrier >= 0) ? 2 : (ownFlagStolen ? 1 : 0);
+	if (scorePressure && interceptors > 0) {
+		interceptors--;
+	}
+	if (defenders + interceptors >= numteammates) {
+		interceptors = numteammates - defenders - 1;
+		if (interceptors < 0) {
+			interceptors = 0;
+		}
+	}
+	for (i = 0; i < defenders && i < numteammates; i++) {
+		ClientName(teammates[i], name, sizeof(name));
+		BotAI_BotInitialChat(bs, "cmd_defendbase", name, NULL);
+		BotSayTeamOrder(bs, teammates[i]);
+		BotSayVoiceTeamOrder(bs, teammates[i], VOICECHAT_DEFEND);
+	}
+	for (; i < defenders + interceptors && i < numteammates; i++) {
+		ClientName(teammates[i], name, sizeof(name));
+		BotAI_BotInitialChat(bs, "cmd_returnflag", name, NULL);
+		BotSayTeamOrder(bs, teammates[i]);
+		BotSayVoiceTeamOrder(bs, teammates[i], VOICECHAT_RETURNFLAG);
+	}
+	for (; i < numteammates; i++) {
+		ClientName(teammates[i], name, sizeof(name));
+		if (targetTeam == TEAM_FREE) {
+			BotAI_BotInitialChat(bs, "cmd_getflag", name, NULL);
+			BotSayVoiceTeamOrder(bs, teammates[i], VOICECHAT_GETFLAG);
+		} else {
+			BotAI_BotInitialChat(bs, "cmd_attackenemybase", name, NULL);
+			BotSayVoiceTeamOrder(bs, teammates[i], VOICECHAT_OFFENSE);
+		}
+		BotSayTeamOrder(bs, teammates[i]);
+	}
+}
+
 
 /*
 ==================
@@ -1894,6 +2070,9 @@ static int botKOTHOwnerSnapshot[MAX_CLIENTS];
 static int botKOTHContestedSnapshot[MAX_CLIENTS];
 static int botDominationOrderModeSnapshot[MAX_CLIENTS];
 static int botKOTHOrderModeSnapshot[MAX_CLIENTS];
+static char botCTF4FlagStatusSnapshot[MAX_CLIENTS][8];
+static int botCTF4EnemyCarrierVisibleSnapshot[MAX_CLIENTS];
+static int botCTF4ScorePressureSnapshot[MAX_CLIENTS];
 
 typedef enum {
 	BOT_DOM_ORDER_HOLD = 0,
@@ -2257,6 +2436,53 @@ void BotTeamAI(bot_state_t *bs) {
 				BotCTFOrders(bs);
 				//
 				bs->teamgiveorders_time = 0;
+			}
+			break;
+		}
+		case GT_CTF4:
+		{
+			char flagStatus[8];
+			int ownIndex, ownWasStolen, ownNowStolen;
+			int enemyCarrierVisible;
+			int scorePressure;
+
+			trap_GetConfigstring(CS_FLAGSTATUS, flagStatus, sizeof(flagStatus));
+			ownIndex = BotCTF4TeamToFlagIndex(BotTeam(bs));
+			ownWasStolen = (ownIndex >= 0 && botCTF4FlagStatusSnapshot[bs->client][ownIndex] &&
+				botCTF4FlagStatusSnapshot[bs->client][ownIndex] != '0');
+			ownNowStolen = (ownIndex >= 0 && flagStatus[ownIndex] && flagStatus[ownIndex] != '0');
+			enemyCarrierVisible = (BotCTF4EnemyCarrierVisible(bs) >= 0);
+			scorePressure = BotCTF4ScorePressure(bs);
+
+			if (!ownWasStolen && ownNowStolen) {
+				BotChat_ObjectiveEvent(bs, "ctf4_own_flag_stolen");
+				BotVoiceChat(bs, -1, VOICECHAT_RETURNFLAG);
+			}
+			if (!botCTF4EnemyCarrierVisibleSnapshot[bs->client] && enemyCarrierVisible) {
+				BotChat_ObjectiveEvent(bs, "ctf4_enemy_carrier_visible");
+				BotVoiceChat(bs, -1, VOICECHAT_RETURNFLAG);
+			}
+			if (!botCTF4ScorePressureSnapshot[bs->client] && scorePressure) {
+				BotChat_ObjectiveEvent(bs, "ctf4_score_pressure");
+				BotVoiceChat(bs, -1, VOICECHAT_OFFENSE);
+			}
+
+			if (bs->numteammates != numteammates ||
+				Q_stricmp(botCTF4FlagStatusSnapshot[bs->client], flagStatus) ||
+				botCTF4EnemyCarrierVisibleSnapshot[bs->client] != enemyCarrierVisible ||
+				botCTF4ScorePressureSnapshot[bs->client] != scorePressure ||
+				bs->forceorders) {
+				bs->teamgiveorders_time = FloatTime();
+				bs->numteammates = numteammates;
+				Q_strncpyz(botCTF4FlagStatusSnapshot[bs->client], flagStatus, sizeof(botCTF4FlagStatusSnapshot[bs->client]));
+				botCTF4EnemyCarrierVisibleSnapshot[bs->client] = enemyCarrierVisible;
+				botCTF4ScorePressureSnapshot[bs->client] = scorePressure;
+				bs->forceorders = qfalse;
+			}
+
+			if (bs->teamgiveorders_time && bs->teamgiveorders_time < FloatTime() - 2) {
+				BotCTF4Orders(bs);
+				bs->teamgiveorders_time = FloatTime() + 20;
 			}
 			break;
 		}


### PR DESCRIPTION
### Motivation

- Add support for improved 4-team CTF behavior so bots can select and pressure enemy flags intelligently. 
- Notify teammates and play voice lines on important objective events such as own flag stolen, visible enemy carrier, and score pressure. 
- Make enemy-target selection aware of flag status and score pressure to avoid overstacking or to prioritize leaders.

### Description

- Added new objective chat strings in `baseq3r/botfiles/teamplay.h` for `ctf4_own_flag_stolen`, `ctf4_enemy_carrier_visible`, and `ctf4_score_pressure`.
- Extended `ai_dmq3.h` with `EntityCarriesFlag` and `EntityCarriesCubes` prototypes.
- Enhanced `BotOppositeTeam` in `engine/code/game/ai_dmq3.c` to consult `CS_FLAGSTATUS`, consider team sizes, team scores, own-flag stolen state, and score pressure when scoring candidate enemy teams.
- Implemented CTF4-specific helpers and ordering logic in `engine/code/game/ai_team.c`, including `BotCTF4TeamToFlagIndex`, `BotCTF4EnemyCarrierVisible`, `BotCTF4BestEnemyFlagTeam`, `BotCTF4ScorePressure`, and `BotCTF4Orders`, and integrated these into `BotTeamAI` with per-client snapshots and objective-event notifications.
- Added snapshot state variables for tracking `CTF4` flag status, visible enemy carrier, and score pressure per client.

### Testing

- Performed an automated project build with `make` which completed successfully with no compilation errors.
- Executed an automated bot-AI smoke test run configured for `GT_CTF4` which completed without crashes and produced objective order/chat events in the logs as expected.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc168bb1d08323ac57c1878864912d)