### PR TITLE
Implement LCS-specific defensive bot decision logic and tuning cvars

### DIFF
--- a/engine/code/game/ai_dmnet.c
+++ b/engine/code/game/ai_dmnet.c
@@ -294,6 +294,12 @@ static ghostRouteLineFamily_t Bot_SelectGhostLineFamily( const botCollisionRisk_
 	if ( !risk ) {
 		return GHOST_LINE_BASE;
 	}
+	if ( gametype == GT_LCS ) {
+		if ( chaosActive || risk->hasPredictedConflict || risk->nearestAheadDist < 130.0f ) {
+			return GHOST_LINE_SAFE;
+		}
+		return GHOST_LINE_DEFENSIVE;
+	}
 
 	if ( chaosActive ) {
 		return GHOST_LINE_SAFE;
@@ -807,6 +813,8 @@ BotNearbyGoal
 */
 int BotNearbyGoal(bot_state_t *bs, int tfl, bot_goal_t *ltg, float range) {
 	int ret;
+	float lcsThreatProximity = 0.0f;
+	int lcsOpponents = 0;
 
 	//check if the bot should go for air
 	if (BotGoForAir(bs, tfl, ltg, range)) return qtrue;
@@ -821,6 +829,18 @@ int BotNearbyGoal(bot_state_t *bs, int tfl, bot_goal_t *ltg, float range) {
 				bs->teamgoal.areanum, TFL_DEFAULT) < 300) {
 			//make the range really small
 			range = 50;
+		}
+	}
+	if ( BotGetLcsRiskMetrics(bs, NULL, &lcsThreatProximity, &lcsOpponents) ) {
+		if ( bs->inventory[INVENTORY_HEALTH] < 80 || bs->inventory[INVENTORY_ARMOR] < 60 || lcsThreatProximity > 0.50f ) {
+			if ( range < 260 ) {
+				range = 260;
+			}
+		} else {
+			range *= 0.55f;
+		}
+		if ( lcsOpponents > 2 && range > 220 ) {
+			range = 220;
 		}
 	}
 	//
@@ -2815,6 +2835,8 @@ void AIEnter_Battle_Fight(bot_state_t *bs, char *s) {
 // Q3Rally Code Start
    if ( gametype == GT_RACING || gametype == GT_SPRINT || gametype == GT_TEAM_RACING )
 		return;
+	if ( gametype == GT_LCS && !BotWantsToChase(bs) )
+		return;
 // END
 
 	BotRecordNodeSwitch(bs, "battle fight", "", s);
@@ -4280,6 +4302,13 @@ int AINode_MoveToNextCheckpoint( bot_state_t *bs )
 						}
 						break;
 				}
+				if ( gametype == GT_LCS ) {
+					if ( decisionState == GHOST_DECISION_PREPARE_OVERTAKE ||
+						decisionState == GHOST_DECISION_OVERTAKE_INSIDE ||
+						decisionState == GHOST_DECISION_OVERTAKE_OUTSIDE ) {
+						decisionState = GHOST_DECISION_DEFEND_LINE;
+					}
+				}
 			}
 
 			if ( decisionState != (ghostDecisionState_t)bs->ghostDecisionState ) {
@@ -4324,6 +4353,11 @@ int AINode_MoveToNextCheckpoint( bot_state_t *bs )
 				selectedFamily = GHOST_LINE_DEFENSIVE;
 			} else if ( decisionState == GHOST_DECISION_ABORT_OVERTAKE ) {
 				selectedFamily = GHOST_LINE_SAFE;
+			}
+			if ( gametype == GT_LCS ) {
+				if ( selectedFamily == GHOST_LINE_RACE ) {
+					selectedFamily = GHOST_LINE_DEFENSIVE;
+				}
 			}
 
 			baseTargetOffset = 0.0f;

--- a/engine/code/game/ai_dmq3.c
+++ b/engine/code/game/ai_dmq3.c
@@ -85,6 +85,8 @@ vmCvar_t bot_testrchat;
 vmCvar_t bot_challenge;
 vmCvar_t bot_predictobstacles;
 vmCvar_t g_spSkill;
+vmCvar_t g_botLcsAggressionBias;
+vmCvar_t g_botLcsEvasionBias;
 
 extern vmCvar_t bot_developer;
 
@@ -2781,6 +2783,69 @@ int TeamPlayIsOn(void) {
 	return ( gametype >= GT_TEAM );
 }
 
+qboolean BotGetLcsRiskMetrics(bot_state_t *bs, float *relativePosition, float *threatProximity, int *remainingOpponents) {
+	int i;
+	int opponents = 0;
+	int healthierOpponents = 0;
+	float nearestDist = 99999.0f;
+
+	if ( !bs || gametype != GT_LCS ) {
+		return qfalse;
+	}
+
+	for ( i = 0; i < level.maxclients; i++ ) {
+		gentity_t *other = &g_entities[i];
+		vec3_t toOther;
+		float dist;
+
+		if ( i == bs->client ) {
+			continue;
+		}
+		if ( level.clients[i].pers.connected != CON_CONNECTED ) {
+			continue;
+		}
+		if ( level.clients[i].sess.sessionTeam == TEAM_SPECTATOR ) {
+			continue;
+		}
+		if ( !other->inuse || !other->client || other->health <= 0 ) {
+			continue;
+		}
+
+		opponents++;
+		if ( other->health > bs->inventory[INVENTORY_HEALTH] ) {
+			healthierOpponents++;
+		}
+
+		VectorSubtract( other->client->ps.origin, bs->origin, toOther );
+		dist = VectorLength( toOther );
+		if ( dist < nearestDist ) {
+			nearestDist = dist;
+		}
+	}
+
+	if ( remainingOpponents ) {
+		*remainingOpponents = opponents;
+	}
+	if ( relativePosition ) {
+		if ( opponents <= 0 ) {
+			*relativePosition = 1.0f;
+		} else {
+			*relativePosition = 1.0f - ( (float)healthierOpponents / (float)opponents );
+		}
+	}
+	if ( threatProximity ) {
+		float threat = 0.0f;
+		if ( nearestDist < 1400.0f ) {
+			threat = 1.0f - ( nearestDist / 1400.0f );
+			if ( threat < 0.0f ) threat = 0.0f;
+			if ( threat > 1.0f ) threat = 1.0f;
+		}
+		*threatProximity = threat;
+	}
+
+	return qtrue;
+}
+
 /*
 ==================
 BotAggression
@@ -2788,6 +2853,9 @@ BotAggression
 */
 float BotAggression(bot_state_t *bs) {
 	float aggression;
+	float lcsRelativePosition = 0.5f;
+	float lcsThreatProximity = 0.0f;
+	int lcsRemainingOpponents = 0;
 
 	//if the bot has quad
 	if (bs->inventory[INVENTORY_QUAD]) {
@@ -2854,6 +2922,14 @@ float BotAggression(bot_state_t *bs) {
 
 apply_profile:
 	aggression += bs->personalityAggressionBias;
+	if ( BotGetLcsRiskMetrics(bs, &lcsRelativePosition, &lcsThreatProximity, &lcsRemainingOpponents) ) {
+		float lcsAggressionBias = g_botLcsAggressionBias.value;
+		float lcsEvasionBias = g_botLcsEvasionBias.value;
+		aggression *= 0.52f + lcsAggressionBias;
+		aggression -= lcsThreatProximity * (28.0f + lcsEvasionBias * 20.0f);
+		aggression -= lcsRemainingOpponents * (1.6f + lcsEvasionBias * 0.5f);
+		aggression += lcsRelativePosition * 10.0f;
+	}
 	if ( aggression < 0 ) {
 		aggression = 0;
 	} else if ( aggression > 100 ) {
@@ -2890,6 +2966,9 @@ BotWantsToRetreat
 */
 int BotWantsToRetreat(bot_state_t *bs) {
 	aas_entityinfo_t entinfo;
+	float lcsRelativePosition = 0.5f;
+	float lcsThreatProximity = 0.0f;
+	int lcsRemainingOpponents = 0;
 
 	if (gametype == GT_CTF) {
 		//always retreat when carrying a CTF flag
@@ -2933,6 +3012,19 @@ int BotWantsToRetreat(bot_state_t *bs) {
 	//if the bot is getting the flag
 	if (bs->ltgtype == LTG_GETFLAG)
 		return qtrue;
+
+	if ( BotGetLcsRiskMetrics(bs, &lcsRelativePosition, &lcsThreatProximity, &lcsRemainingOpponents) ) {
+		float retreatThreshold = 58.0f + g_botLcsEvasionBias.value * 12.0f;
+		if ( lcsThreatProximity > 0.38f ) {
+			return qtrue;
+		}
+		if ( lcsRemainingOpponents > 2 ) {
+			return qtrue;
+		}
+		if ( BotAggression(bs) < retreatThreshold ) {
+			return qtrue;
+		}
+	}
 	//
 	if (BotAggression(bs) < 50)
 		return qtrue;
@@ -2946,6 +3038,9 @@ BotWantsToChase
 */
 int BotWantsToChase(bot_state_t *bs) {
 	aas_entityinfo_t entinfo;
+	float lcsRelativePosition = 0.5f;
+	float lcsThreatProximity = 0.0f;
+	int lcsRemainingOpponents = 0;
 
 	if (gametype == GT_CTF) {
 		//never chase when carrying a CTF flag
@@ -2987,6 +3082,16 @@ int BotWantsToChase(bot_state_t *bs) {
 	//if the bot is getting the flag
 	if (bs->ltgtype == LTG_GETFLAG)
 		return qfalse;
+
+	if ( BotGetLcsRiskMetrics(bs, &lcsRelativePosition, &lcsThreatProximity, &lcsRemainingOpponents) ) {
+		float aggressionThreshold = 62.0f + g_botLcsEvasionBias.value * 10.0f;
+		qboolean closeOpportunity = ( bs->inventory[ENEMY_HORIZONTAL_DIST] > 0 && bs->inventory[ENEMY_HORIZONTAL_DIST] < 260 );
+		if ( lcsRemainingOpponents <= 2 && lcsRelativePosition > 0.45f && closeOpportunity &&
+			lcsThreatProximity > 0.52f && BotAggression(bs) >= aggressionThreshold ) {
+			return qtrue;
+		}
+		return qfalse;
+	}
 	//
 	if (BotAggression(bs) > 50)
 		return qtrue;
@@ -3185,7 +3290,9 @@ BotGoForPowerups
 void BotGoForPowerups(bot_state_t *bs) {
 
 	//don't avoid any of the powerups anymore
-	BotDontAvoid(bs, "Quad Damage");
+	if ( gametype != GT_LCS ) {
+		BotDontAvoid(bs, "Quad Damage");
+	}
 	BotDontAvoid(bs, "Auto Repair");
 	BotDontAvoid(bs, "Battle Suit");
 	BotDontAvoid(bs, "Speed");
@@ -6128,6 +6235,8 @@ void BotSetupDeathmatchAI(void) {
 	trap_Cvar_Register(&bot_challenge, "bot_challenge", "0", 0);
 	trap_Cvar_Register(&bot_predictobstacles, "bot_predictobstacles", "1", 0);
 	trap_Cvar_Register(&g_spSkill, "g_spSkill", "2", 0);
+	trap_Cvar_Register(&g_botLcsAggressionBias, "g_botLcsAggressionBias", "0.18", CVAR_ARCHIVE);
+	trap_Cvar_Register(&g_botLcsEvasionBias, "g_botLcsEvasionBias", "0.32", CVAR_ARCHIVE);
 	//
 	if (gametype == GT_CTF) {
 		if (trap_BotGetLevelItemGoal(-1, "Red Flag", &ctf_redflag) < 0)

--- a/engine/code/game/ai_dmq3.h
+++ b/engine/code/game/ai_dmq3.h
@@ -109,6 +109,7 @@ bot_moveresult_t BotAttackMove(bot_state_t *bs, int tfl);
 int BotSameTeam(bot_state_t *bs, int entnum);
 //returns true if teamplay is on
 int TeamPlayIsOn(void);
+qboolean BotGetLcsRiskMetrics(bot_state_t *bs, float *relativePosition, float *threatProximity, int *remainingOpponents);
 // returns the client number of the team mate flag carrier (-1 if none)
 int BotTeamFlagCarrier(bot_state_t *bs);
 //returns visible team mate flag carrier if available
@@ -212,6 +213,8 @@ extern vmCvar_t bot_fastchat;
 extern vmCvar_t bot_nochat;
 extern vmCvar_t bot_testrchat;
 extern vmCvar_t bot_challenge;
+extern vmCvar_t g_botLcsAggressionBias;
+extern vmCvar_t g_botLcsEvasionBias;
 
 extern bot_goal_t ctf_redflag;
 extern bot_goal_t ctf_blueflag;


### PR DESCRIPTION
### Motivation
- Make bots behave survival-first in GT_LCS (Last Car Standing) by exposing LCS-aware risk metrics and using them to reduce aggressive fight-chasing and prefer defensive choices.
- Provide server-side tuning knobs for LCS balancing so maps/servers can adjust bot risk appetite without changing code.

### Description
- Added an LCS risk metrics API `BotGetLcsRiskMetrics(...)` in `ai_dmq3` (declared in `ai_dmq3.h`) that reports `relativePosition`, `threatProximity` and `remainingOpponents` for `GT_LCS` matches.
- Introduced two new cvars `g_botLcsAggressionBias` and `g_botLcsEvasionBias` (externs in `ai_dmq3.h`, registered in `BotSetupDeathmatchAI`) for server tuning.
- Made combat heuristics LCS-aware: `BotAggression`, `BotWantsToRetreat` and `BotWantsToChase` now incorporate the LCS risk metrics and the new cvars to prefer defensive/evasive behavior and only allow opportunistic engagements.
- Adjusted pickup/powerup logic and nearby-goal selection for LCS: `BotGoForPowerups` avoids auto-prioritizing `Quad Damage` in LCS, and `BotNearbyGoal` adapts search range to favor escape/defense pickups when threatened or low.
- Reduced engagement aggressiveness in the DMNet flow: `AIEnter_Battle_Fight` will not enter full fight mode in `GT_LCS` unless `BotWantsToChase` permits it, and ghost-route line/over­take logic in `ai_dmnet.c` favors `GHOST_LINE_SAFE`/`GHOST_LINE_DEFENSIVE` and collapses overtake states into defensive choices for LCS.

### Testing
- Ran repository searches (`rg`) and inspected changed regions (`sed`/`nl`) to verify symbol placement and diffs; these inspections succeeded.
- Verified diffs with `git diff` and `git status` to confirm the three modified files contain the intended changes; verification succeeded.
- Attempted a local build check with `make -C engine/code/game`, which failed because no Makefile/target is present in this environment (expected environment limitation), so a full compile test could not be completed.
- Committed the changes and generated the PR metadata after validation of the edits and diffs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc987fa6a883239694d1070c5c8bd4)