### PR TITLE
Profil-Snapshot für Ladder: konsistent, explizit und Flush-vor-Submit

### DIFF
--- a/engine/code/game/bg_ladder.h
+++ b/engine/code/game/bg_ladder.h
@@ -30,6 +30,8 @@
  * profile data available on the server. */
 typedef struct ladderProfileSnapshot_s {
         qboolean        valid;
+        int             snapshotEpoch;
+        int             snapshotRevision;
         /* ── Allgemein ─────────────────────────────────────────────────── */
         int             playerScore;
         int             currentRank;
@@ -168,6 +170,7 @@ typedef struct ladderPlayerPayload_s {
         float           eliminationMetric;
         int                     finishRaceTime;
         float           kdRatio;
+        qboolean        profileAttached; /* profile block explicitly attached (valid true/false) */
         ladderProfileSnapshot_t profile;   /* career snapshot, valid only for local client */
 } ladderPlayerPayload_t;
 

--- a/engine/code/game/g_main.c
+++ b/engine/code/game/g_main.c
@@ -1082,42 +1082,45 @@ static qboolean G_LadderPopulatePlayer( ladderMatchPayload_t *payload, int clien
         }
 
         /* Attach career profile snapshot for the local client only.
-         * Remote players do not have their profile data available on the server. */
+         * Prefer runtime state (g_profile), use file-read fallback only when needed. */
         if ( client->pers.localClient ) {
                 ladderProfileSnapshot_t *snap = &player->profile;
+                int snapshotRevision = 0;
+                int snapshotEpoch = 0;
                 char profileName[PROFILE_MAX_NAME];
                 char profilePath[MAX_QPATH];
                 fileHandle_t fh;
                 int len;
                 int i;
 
+                player->profileAttached = qtrue;
                 Com_Memset( snap, 0, sizeof( *snap ) );
+                snap->valid = qfalse;
 
-                trap_Cvar_VariableStringBuffer( "profile_active", profileName, sizeof( profileName ) );
-                if ( profileName[0] ) {
-                        Com_sprintf( profilePath, sizeof( profilePath ), "profiles/%s.json", profileName );
-                        len = trap_FS_FOpenFile( profilePath, &fh, FS_READ );
-                        if ( len > 0 ) {
-                                static char profileBuf[8192];
-                                if ( len >= (int)sizeof( profileBuf ) ) len = sizeof( profileBuf ) - 1;
-                                trap_FS_Read( profileBuf, len, fh );
-                                profileBuf[len] = '\0';
-                                trap_FS_FCloseFile( fh );
+                if ( G_Profile_GetLadderSnapshot( snap, &snapshotRevision, &snapshotEpoch ) ) {
+                        snap->valid = qtrue;
+                        snap->snapshotRevision = snapshotRevision;
+                        snap->snapshotEpoch = snapshotEpoch;
+                } else {
+                        trap_Cvar_VariableStringBuffer( "profile_active", profileName, sizeof( profileName ) );
+                        if ( profileName[0] ) {
+                                Com_sprintf( profilePath, sizeof( profilePath ), "profiles/%s.json", profileName );
+                                len = trap_FS_FOpenFile( profilePath, &fh, FS_READ );
+                                if ( len > 0 ) {
+                                        static char profileBuf[8192];
+                                        const char *statsSection;
+                                        const char *infoSection;
+                                        const char *statsBuf;
+                                        const char *infoBuf;
+                                        if ( len >= (int)sizeof( profileBuf ) ) len = sizeof( profileBuf ) - 1;
+                                        trap_FS_Read( profileBuf, len, fh );
+                                        profileBuf[len] = '\0';
+                                        trap_FS_FCloseFile( fh );
 
-                                /* Profile JSON structure:
-                                 * { "name": "...", "info": { "currentRank": N, "highestRank": N, ... },
-                                 *   "stats": { "playerScore": N, "kills": N, ... } }
-                                 * Info fields are at top level of "info" object,
-                                 * stats fields are nested under "stats". */
-                                {
-                                        /* Find the opening brace of each section to avoid
-                                         * parsing keys from sibling sections. */
-                                        const char *statsSection = strstr( profileBuf, "\"stats\"" );
-                                        const char *infoSection  = strstr( profileBuf, "\"info\"" );
-                                        /* Advance past the colon and opening brace so the parser
-                                         * only sees content inside that section. */
-                                        const char *statsBuf = profileBuf;
-                                        const char *infoBuf  = profileBuf;
+                                        statsSection = strstr( profileBuf, "\"stats\"" );
+                                        infoSection  = strstr( profileBuf, "\"info\"" );
+                                        statsBuf = profileBuf;
+                                        infoBuf  = profileBuf;
                                         if ( statsSection ) {
                                                 const char *brace = strchr( statsSection, '{' );
                                                 if ( brace ) statsBuf = brace;
@@ -1128,6 +1131,8 @@ static qboolean G_LadderPopulatePlayer( ladderMatchPayload_t *payload, int clien
                                         }
 
                                         snap->valid            = qtrue;
+                                        snap->snapshotRevision = G_Profile_ParseIntPublic( profileBuf, "revision", 0 );
+                                        snap->snapshotEpoch    = G_Profile_ParseIntPublic( profileBuf, "timestamp", 0 );
                                         snap->playerScore      = G_Profile_ParseIntPublic( statsBuf,  "playerScore",     0 );
                                         snap->currentRank      = G_Profile_ParseIntPublic( infoBuf,   "currentRank",     0 );
                                         snap->highestRank      = G_Profile_ParseIntPublic( infoBuf,   "highestRank",     0 );
@@ -1150,103 +1155,73 @@ static qboolean G_LadderPopulatePlayer( ladderMatchPayload_t *payload, int clien
                                         snap->gamesPlayed      = G_Profile_ParseIntPublic( statsBuf,  "gamesPlayed",     0 );
                                         G_Profile_ParseStringPublic( statsBuf, "mostUsedVehicle",
                                                 snap->mostUsedVehicle, sizeof( snap->mostUsedVehicle ), "" );
-
-                                        /* ── GT_RACING ── */
-                                        snap->racingWins       = G_Profile_ParseIntPublic( statsBuf, "racingWins",      0 );
-                                        snap->racingPodiums    = G_Profile_ParseIntPublic( statsBuf, "racingPodiums",   0 );
-                                        snap->racingCompleted  = G_Profile_ParseIntPublic( statsBuf, "racingCompleted", 0 );
-                                        snap->racingTotalMs    = G_Profile_ParseIntPublic( statsBuf, "racingTotalMs",   0 );
-
-                                        /* ── GT_RACING_DM ── */
-                                        snap->racingDmWins      = G_Profile_ParseIntPublic( statsBuf, "racingDmWins",      0 );
-                                        snap->racingDmPodiums   = G_Profile_ParseIntPublic( statsBuf, "racingDmPodiums",   0 );
+                                        snap->racingWins = G_Profile_ParseIntPublic( statsBuf, "racingWins", 0 );
+                                        snap->racingPodiums = G_Profile_ParseIntPublic( statsBuf, "racingPodiums", 0 );
+                                        snap->racingCompleted = G_Profile_ParseIntPublic( statsBuf, "racingCompleted", 0 );
+                                        snap->racingTotalMs = G_Profile_ParseIntPublic( statsBuf, "racingTotalMs", 0 );
+                                        snap->racingDmWins = G_Profile_ParseIntPublic( statsBuf, "racingDmWins", 0 );
+                                        snap->racingDmPodiums = G_Profile_ParseIntPublic( statsBuf, "racingDmPodiums", 0 );
                                         snap->racingDmCompleted = G_Profile_ParseIntPublic( statsBuf, "racingDmCompleted", 0 );
-                                        snap->racingDmTotalMs   = G_Profile_ParseIntPublic( statsBuf, "racingDmTotalMs",   0 );
-
-                                        /* ── GT_SPRINT ── */
-                                        snap->sprintWins      = G_Profile_ParseIntPublic( statsBuf, "sprintWins",      0 );
+                                        snap->racingDmTotalMs = G_Profile_ParseIntPublic( statsBuf, "racingDmTotalMs", 0 );
+                                        snap->sprintWins = G_Profile_ParseIntPublic( statsBuf, "sprintWins", 0 );
                                         snap->sprintCompleted = G_Profile_ParseIntPublic( statsBuf, "sprintCompleted", 0 );
-                                        snap->sprintBestMs    = G_Profile_ParseIntPublic( statsBuf, "sprintBestMs",    0 );
-
-                                        /* ── GT_ELIMINATION ── */
-                                        snap->eliminationWins               = G_Profile_ParseIntPublic( statsBuf, "eliminationWins",               0 );
-                                        snap->eliminationCompleted          = G_Profile_ParseIntPublic( statsBuf, "eliminationCompleted",          0 );
-                                        snap->eliminationTotalRoundsLasted  = G_Profile_ParseIntPublic( statsBuf, "eliminationTotalRoundsLasted",  0 );
-
-                                        /* ── GT_LCS ── */
-                                        snap->lcsWins            = G_Profile_ParseIntPublic( statsBuf, "lcsWins",            0 );
-                                        snap->lcsCompleted       = G_Profile_ParseIntPublic( statsBuf, "lcsCompleted",       0 );
+                                        snap->sprintBestMs = G_Profile_ParseIntPublic( statsBuf, "sprintBestMs", 0 );
+                                        snap->eliminationWins = G_Profile_ParseIntPublic( statsBuf, "eliminationWins", 0 );
+                                        snap->eliminationCompleted = G_Profile_ParseIntPublic( statsBuf, "eliminationCompleted", 0 );
+                                        snap->eliminationTotalRoundsLasted = G_Profile_ParseIntPublic( statsBuf, "eliminationTotalRoundsLasted", 0 );
+                                        snap->lcsWins = G_Profile_ParseIntPublic( statsBuf, "lcsWins", 0 );
+                                        snap->lcsCompleted = G_Profile_ParseIntPublic( statsBuf, "lcsCompleted", 0 );
                                         snap->lcsTotalSurvivalMs = G_Profile_ParseIntPublic( statsBuf, "lcsTotalSurvivalMs", 0 );
-
-                                        /* ── GT_DERBY ── */
-                                        snap->derbyWins      = G_Profile_ParseIntPublic( statsBuf, "derbyWins",      0 );
+                                        snap->derbyWins = G_Profile_ParseIntPublic( statsBuf, "derbyWins", 0 );
                                         snap->derbyCompleted = G_Profile_ParseIntPublic( statsBuf, "derbyCompleted", 0 );
-                                        snap->derbyKills     = G_Profile_ParseIntPublic( statsBuf, "derbyKills",     0 );
-
-                                        /* ── GT_DEATHMATCH ── */
-                                        snap->dmWins      = G_Profile_ParseIntPublic( statsBuf, "dmWins",      0 );
+                                        snap->derbyKills = G_Profile_ParseIntPublic( statsBuf, "derbyKills", 0 );
+                                        snap->dmWins = G_Profile_ParseIntPublic( statsBuf, "dmWins", 0 );
                                         snap->dmCompleted = G_Profile_ParseIntPublic( statsBuf, "dmCompleted", 0 );
-                                        snap->dmKills     = G_Profile_ParseIntPublic( statsBuf, "dmKills",     0 );
-
-                                        /* ── GT_CTF ── */
-                                        snap->ctfWins      = G_Profile_ParseIntPublic( statsBuf, "ctfWins",      0 );
+                                        snap->dmKills = G_Profile_ParseIntPublic( statsBuf, "dmKills", 0 );
+                                        snap->ctfWins = G_Profile_ParseIntPublic( statsBuf, "ctfWins", 0 );
                                         snap->ctfCompleted = G_Profile_ParseIntPublic( statsBuf, "ctfCompleted", 0 );
-                                        snap->ctfCaptures  = G_Profile_ParseIntPublic( statsBuf, "ctfCaptures",  0 );
-
-                                        /* ── GT_CTF4 ── */
-                                        snap->ctf4Wins      = G_Profile_ParseIntPublic( statsBuf, "ctf4Wins",      0 );
+                                        snap->ctfCaptures = G_Profile_ParseIntPublic( statsBuf, "ctfCaptures", 0 );
+                                        snap->ctf4Wins = G_Profile_ParseIntPublic( statsBuf, "ctf4Wins", 0 );
                                         snap->ctf4Completed = G_Profile_ParseIntPublic( statsBuf, "ctf4Completed", 0 );
-                                        snap->ctf4Captures  = G_Profile_ParseIntPublic( statsBuf, "ctf4Captures",  0 );
-
-                                        /* ── GT_TEAM ── */
-                                        snap->teamWins      = G_Profile_ParseIntPublic( statsBuf, "teamWins",      0 );
+                                        snap->ctf4Captures = G_Profile_ParseIntPublic( statsBuf, "ctf4Captures", 0 );
+                                        snap->teamWins = G_Profile_ParseIntPublic( statsBuf, "teamWins", 0 );
                                         snap->teamCompleted = G_Profile_ParseIntPublic( statsBuf, "teamCompleted", 0 );
-                                        snap->teamKills     = G_Profile_ParseIntPublic( statsBuf, "teamKills",     0 );
-
-                                        /* ── GT_TEAM_RACING ── */
-                                        snap->teamRacingWins      = G_Profile_ParseIntPublic( statsBuf, "teamRacingWins",      0 );
+                                        snap->teamKills = G_Profile_ParseIntPublic( statsBuf, "teamKills", 0 );
+                                        snap->teamRacingWins = G_Profile_ParseIntPublic( statsBuf, "teamRacingWins", 0 );
                                         snap->teamRacingCompleted = G_Profile_ParseIntPublic( statsBuf, "teamRacingCompleted", 0 );
-                                        snap->teamRacingPodiums   = G_Profile_ParseIntPublic( statsBuf, "teamRacingPodiums",   0 );
-
-                                        /* ── GT_TEAM_RACING_DM ── */
-                                        snap->teamRacingDmWins      = G_Profile_ParseIntPublic( statsBuf, "teamRacingDmWins",      0 );
+                                        snap->teamRacingPodiums = G_Profile_ParseIntPublic( statsBuf, "teamRacingPodiums", 0 );
+                                        snap->teamRacingDmWins = G_Profile_ParseIntPublic( statsBuf, "teamRacingDmWins", 0 );
                                         snap->teamRacingDmCompleted = G_Profile_ParseIntPublic( statsBuf, "teamRacingDmCompleted", 0 );
-                                        snap->teamRacingDmPodiums   = G_Profile_ParseIntPublic( statsBuf, "teamRacingDmPodiums",   0 );
-
-                                        /* ── GT_DOMINATION ── */
-                                        snap->dominationWins        = G_Profile_ParseIntPublic( statsBuf, "dominationWins",        0 );
-                                        snap->dominationCompleted   = G_Profile_ParseIntPublic( statsBuf, "dominationCompleted",   0 );
-                                        snap->dominationZoneHoldMs  = G_Profile_ParseIntPublic( statsBuf, "dominationZoneHoldMs",  0 );
-
-                                        /* ── GT_KOTH ── */
-                                        snap->kothWins       = G_Profile_ParseIntPublic( statsBuf, "kothWins",       0 );
-                                        snap->kothCompleted  = G_Profile_ParseIntPublic( statsBuf, "kothCompleted",  0 );
+                                        snap->teamRacingDmPodiums = G_Profile_ParseIntPublic( statsBuf, "teamRacingDmPodiums", 0 );
+                                        snap->dominationWins = G_Profile_ParseIntPublic( statsBuf, "dominationWins", 0 );
+                                        snap->dominationCompleted = G_Profile_ParseIntPublic( statsBuf, "dominationCompleted", 0 );
+                                        snap->dominationZoneHoldMs = G_Profile_ParseIntPublic( statsBuf, "dominationZoneHoldMs", 0 );
+                                        snap->kothWins = G_Profile_ParseIntPublic( statsBuf, "kothWins", 0 );
+                                        snap->kothCompleted = G_Profile_ParseIntPublic( statsBuf, "kothCompleted", 0 );
                                         snap->kothZoneHoldMs = G_Profile_ParseIntPublic( statsBuf, "kothZoneHoldMs", 0 );
-                                }
 
-                                /* Achievement tiers – reuse bg_achievements logic */
-                                {
-                                        int sprintWins = G_Profile_ParseIntPublic( profileBuf, "sprintWins", 0 );
-                                        double progress_table[BG_ACHIEVEMENT_CATEGORY_COUNT];
-                                        progress_table[BG_ACHIEVEMENT_DISTANCE]      = snap->distanceKm;
-                                        progress_table[BG_ACHIEVEMENT_KILLS]         = (double)snap->kills;
-                                        progress_table[BG_ACHIEVEMENT_WINS]          = (double)snap->wins;
-                                        progress_table[BG_ACHIEVEMENT_SPRINT_WINS]   = (double)sprintWins;
-                                        progress_table[BG_ACHIEVEMENT_FLAG_CAPTURES] = (double)snap->flagCaptures;
-                                        progress_table[BG_ACHIEVEMENT_FLAG_ASSISTS]  = (double)snap->flagAssists;
-                                        progress_table[BG_ACHIEVEMENT_FUEL]          = snap->fuelUsed;
-                                        progress_table[BG_ACHIEVEMENT_ACCURACY]      = (double)snap->accuracyAwards;
-                                        progress_table[BG_ACHIEVEMENT_EXCELLENT]     = (double)snap->excellentAwards;
-                                        progress_table[BG_ACHIEVEMENT_IMPRESSIVE]    = (double)snap->impressiveAwards;
-                                        progress_table[BG_ACHIEVEMENT_PERFECT]       = (double)snap->perfectAwards;
+                                        {
+                                                double progress_table[BG_ACHIEVEMENT_CATEGORY_COUNT];
+                                                progress_table[BG_ACHIEVEMENT_DISTANCE]      = snap->distanceKm;
+                                                progress_table[BG_ACHIEVEMENT_KILLS]         = (double)snap->kills;
+                                                progress_table[BG_ACHIEVEMENT_WINS]          = (double)snap->wins;
+                                                progress_table[BG_ACHIEVEMENT_SPRINT_WINS]   = (double)snap->sprintWins;
+                                                progress_table[BG_ACHIEVEMENT_FLAG_CAPTURES] = (double)snap->flagCaptures;
+                                                progress_table[BG_ACHIEVEMENT_FLAG_ASSISTS]  = (double)snap->flagAssists;
+                                                progress_table[BG_ACHIEVEMENT_FUEL]          = snap->fuelUsed;
+                                                progress_table[BG_ACHIEVEMENT_ACCURACY]      = (double)snap->accuracyAwards;
+                                                progress_table[BG_ACHIEVEMENT_EXCELLENT]     = (double)snap->excellentAwards;
+                                                progress_table[BG_ACHIEVEMENT_IMPRESSIVE]    = (double)snap->impressiveAwards;
+                                                progress_table[BG_ACHIEVEMENT_PERFECT]       = (double)snap->perfectAwards;
 
-                                        for ( i = 0; i < BG_ACHIEVEMENT_CATEGORY_COUNT; ++i ) {
-                                                const bgAchievementCategoryDef_t *cat = BG_AchievementGetCategory( i );
-                                                snap->achievementTiers[i] = BG_AchievementUnlockedTiers( cat, progress_table[i] );
+                                                for ( i = 0; i < BG_ACHIEVEMENT_CATEGORY_COUNT; ++i ) {
+                                                        const bgAchievementCategoryDef_t *cat = BG_AchievementGetCategory( i );
+                                                        snap->achievementTiers[i] = BG_AchievementUnlockedTiers( cat, progress_table[i] );
+                                                }
                                         }
+                                } else if ( fh ) {
+                                        trap_FS_FCloseFile( fh );
                                 }
-                        } else if ( fh ) {
-                                trap_FS_FCloseFile( fh );
                         }
                 }
         }
@@ -2496,13 +2471,13 @@ void LogExit( const char *string ) {
 
         }
 
-	G_LadderSubmitMatchReport( string );
-
 	G_Profile_FlushIfDirty();
 
         if ( G_Profile_IsDirty() ) {
                 G_Profile_FlushIfDirty();
         }
+
+	G_LadderSubmitMatchReport( string );
 
 #ifdef MISSIONPACK
         if (g_singlePlayer.integer) {

--- a/engine/code/game/g_profile.c
+++ b/engine/code/game/g_profile.c
@@ -1,6 +1,7 @@
 #include "profile_shared.h"
 #include "g_local.h"
 #include "g_profile.h"
+#include "bg_ladder.h"
 #include "bg_achievements.h"
 
 #ifdef Q3_VM
@@ -383,6 +384,128 @@ qboolean G_Profile_GetUUID( char *out, int outSize ) {
     }
 
     Q_strncpyz( out, s_profileState.info.uuid, outSize );
+    return qtrue;
+}
+
+static int G_Profile_ComputeSnapshotRevision( void ) {
+    int revision = 0;
+
+    revision ^= s_profileState.stats.playerScore;
+    revision ^= ( s_profileState.stats.wins << 1 );
+    revision ^= ( s_profileState.stats.losses << 2 );
+    revision ^= ( s_profileState.stats.kills << 3 );
+    revision ^= ( s_profileState.stats.deaths << 4 );
+    revision ^= ( s_profileState.stats.gamesPlayed << 5 );
+    revision ^= ( s_profileState.info.currentRank << 6 );
+    revision ^= ( s_profileState.info.highestRank << 7 );
+    revision ^= ( s_profileState.stats.bestLapMs << 8 );
+    return revision;
+}
+
+qboolean G_Profile_GetLadderSnapshot( ladderProfileSnapshot_t *outSnapshot,
+                                      int *outSnapshotRevision,
+                                      int *outSnapshotEpoch ) {
+    int i;
+    qtime_t now;
+
+    if ( !outSnapshot ) {
+        return qfalse;
+    }
+
+    Com_Memset( outSnapshot, 0, sizeof( *outSnapshot ) );
+    if ( outSnapshotRevision ) {
+        *outSnapshotRevision = 0;
+    }
+    if ( outSnapshotEpoch ) {
+        *outSnapshotEpoch = 0;
+    }
+
+    if ( !s_profileState.loaded ) {
+        return qfalse;
+    }
+
+    outSnapshot->valid = qtrue;
+    outSnapshot->snapshotRevision = G_Profile_ComputeSnapshotRevision();
+    outSnapshot->snapshotEpoch = trap_RealTime( &now );
+
+    outSnapshot->playerScore = s_profileState.stats.playerScore;
+    outSnapshot->currentRank = s_profileState.info.currentRank;
+    outSnapshot->highestRank = s_profileState.info.highestRank;
+    outSnapshot->wins = s_profileState.stats.wins;
+    outSnapshot->losses = s_profileState.stats.losses;
+    outSnapshot->kills = s_profileState.stats.kills;
+    outSnapshot->deaths = s_profileState.stats.deaths;
+    outSnapshot->flagCaptures = s_profileState.stats.flagCaptures;
+    outSnapshot->flagAssists = s_profileState.stats.flagAssists;
+    outSnapshot->bestLapMs = s_profileState.stats.bestLapMs;
+    outSnapshot->accuracyAwards = s_profileState.stats.accuracyAwards;
+    outSnapshot->excellentAwards = s_profileState.stats.excellentAwards;
+    outSnapshot->impressiveAwards = s_profileState.stats.impressiveAwards;
+    outSnapshot->perfectAwards = s_profileState.stats.perfectAwards;
+    outSnapshot->damageDealt = s_profileState.stats.damageDealt;
+    outSnapshot->damageTaken = s_profileState.stats.damageTaken;
+    outSnapshot->distanceKm = (float)s_profileState.stats.distanceKm;
+    outSnapshot->topSpeedKph = (float)s_profileState.stats.topSpeedKph;
+    outSnapshot->fuelUsed = (float)s_profileState.stats.fuelUsed;
+    Q_strncpyz( outSnapshot->mostUsedVehicle, s_profileState.stats.mostUsedVehicle, sizeof( outSnapshot->mostUsedVehicle ) );
+    outSnapshot->gamesPlayed = s_profileState.stats.gamesPlayed;
+
+    outSnapshot->racingWins = s_profileState.stats.racingWins;
+    outSnapshot->racingPodiums = s_profileState.stats.racingPodiums;
+    outSnapshot->racingCompleted = s_profileState.stats.racingCompleted;
+    outSnapshot->racingTotalMs = s_profileState.stats.racingTotalMs;
+    outSnapshot->racingDmWins = s_profileState.stats.racingDmWins;
+    outSnapshot->racingDmPodiums = s_profileState.stats.racingDmPodiums;
+    outSnapshot->racingDmCompleted = s_profileState.stats.racingDmCompleted;
+    outSnapshot->racingDmTotalMs = s_profileState.stats.racingDmTotalMs;
+    outSnapshot->sprintWins = s_profileState.stats.sprintWins;
+    outSnapshot->sprintCompleted = s_profileState.stats.sprintCompleted;
+    outSnapshot->sprintBestMs = s_profileState.stats.sprintBestMs;
+    outSnapshot->eliminationWins = s_profileState.stats.eliminationWins;
+    outSnapshot->eliminationCompleted = s_profileState.stats.eliminationCompleted;
+    outSnapshot->eliminationTotalRoundsLasted = s_profileState.stats.eliminationTotalRoundsLasted;
+    outSnapshot->lcsWins = s_profileState.stats.lcsWins;
+    outSnapshot->lcsCompleted = s_profileState.stats.lcsCompleted;
+    outSnapshot->lcsTotalSurvivalMs = s_profileState.stats.lcsTotalSurvivalMs;
+    outSnapshot->derbyWins = s_profileState.stats.derbyWins;
+    outSnapshot->derbyCompleted = s_profileState.stats.derbyCompleted;
+    outSnapshot->derbyKills = s_profileState.stats.derbyKills;
+    outSnapshot->dmWins = s_profileState.stats.dmWins;
+    outSnapshot->dmCompleted = s_profileState.stats.dmCompleted;
+    outSnapshot->dmKills = s_profileState.stats.dmKills;
+    outSnapshot->ctfWins = s_profileState.stats.ctfWins;
+    outSnapshot->ctfCompleted = s_profileState.stats.ctfCompleted;
+    outSnapshot->ctfCaptures = s_profileState.stats.ctfCaptures;
+    outSnapshot->ctf4Wins = s_profileState.stats.ctf4Wins;
+    outSnapshot->ctf4Completed = s_profileState.stats.ctf4Completed;
+    outSnapshot->ctf4Captures = s_profileState.stats.ctf4Captures;
+    outSnapshot->teamWins = s_profileState.stats.teamWins;
+    outSnapshot->teamCompleted = s_profileState.stats.teamCompleted;
+    outSnapshot->teamKills = s_profileState.stats.teamKills;
+    outSnapshot->teamRacingWins = s_profileState.stats.teamRacingWins;
+    outSnapshot->teamRacingCompleted = s_profileState.stats.teamRacingCompleted;
+    outSnapshot->teamRacingPodiums = s_profileState.stats.teamRacingPodiums;
+    outSnapshot->teamRacingDmWins = s_profileState.stats.teamRacingDmWins;
+    outSnapshot->teamRacingDmCompleted = s_profileState.stats.teamRacingDmCompleted;
+    outSnapshot->teamRacingDmPodiums = s_profileState.stats.teamRacingDmPodiums;
+    outSnapshot->dominationWins = s_profileState.stats.dominationWins;
+    outSnapshot->dominationCompleted = s_profileState.stats.dominationCompleted;
+    outSnapshot->dominationZoneHoldMs = s_profileState.stats.dominationZoneHoldMs;
+    outSnapshot->kothWins = s_profileState.stats.kothWins;
+    outSnapshot->kothCompleted = s_profileState.stats.kothCompleted;
+    outSnapshot->kothZoneHoldMs = s_profileState.stats.kothZoneHoldMs;
+
+    for ( i = 0; i < BG_ACHIEVEMENT_CATEGORY_COUNT; ++i ) {
+        outSnapshot->achievementTiers[i] = s_profileState.achievementsUnlocked[i];
+    }
+
+    if ( outSnapshotRevision ) {
+        *outSnapshotRevision = outSnapshot->snapshotRevision;
+    }
+    if ( outSnapshotEpoch ) {
+        *outSnapshotEpoch = outSnapshot->snapshotEpoch;
+    }
+
     return qtrue;
 }
 

--- a/engine/code/game/g_profile.h
+++ b/engine/code/game/g_profile.h
@@ -3,6 +3,7 @@
 
 struct profile_stats_s;
 struct profile_rank_s;
+struct ladderProfileSnapshot_s;
 
 struct gclient_s;
 struct gentity_s;
@@ -42,6 +43,9 @@ void     G_Profile_ParseStringPublic( const char *buffer, const char *key, char 
 
 qboolean G_Profile_GetRank( const struct profile_stats_s *stats, struct profile_rank_s *outRank );
 int G_Profile_GetPlayerScore( void );
+qboolean G_Profile_GetLadderSnapshot( struct ladderProfileSnapshot_s *outSnapshot,
+                                      int *outSnapshotRevision,
+                                      int *outSnapshotEpoch );
 
 /* Gibt die UUID des aktiven Profils zurück.
  * Schreibt in out (muss mindestens PROFILE_MAX_UUID Bytes groß sein).

--- a/engine/code/server/sv_ladder.c
+++ b/engine/code/server/sv_ladder.c
@@ -678,7 +678,7 @@ static qboolean SV_LadderJsonAppendPlayer( ladderJsonBuilder_t *builder, const l
         }
 
         /* Career profile snapshot */
-        if ( player->profile.valid ) {
+        if ( player->profileAttached ) {
                 const ladderProfileSnapshot_t *snap = &player->profile;
                 qboolean profFirst = qtrue;
                 int i;
@@ -698,121 +698,133 @@ static qboolean SV_LadderJsonAppendPlayer( ladderJsonBuilder_t *builder, const l
                 if ( !SV_LadderJsonAppendKey( builder, key, &profFirst ) || \
                      !SV_LadderJsonAppendString( builder, snap->field ) ) { return qfalse; }
 
-                SNAP_INT( "playerScore",      playerScore      )
-                SNAP_INT( "currentRank",      currentRank      )
-                SNAP_INT( "highestRank",      highestRank      )
-                SNAP_INT( "wins",             wins             )
-                SNAP_INT( "losses",           losses           )
-                SNAP_INT( "kills",            kills            )
-                SNAP_INT( "deaths",           deaths           )
-                SNAP_INT( "flagCaptures",     flagCaptures     )
-                SNAP_INT( "flagAssists",      flagAssists      )
-                SNAP_INT( "bestLapMs",        bestLapMs        )
-                SNAP_INT( "accuracyAwards",   accuracyAwards   )
-                SNAP_INT( "excellentAwards",  excellentAwards  )
-                SNAP_INT( "impressiveAwards", impressiveAwards )
-                SNAP_INT( "perfectAwards",    perfectAwards    )
-                SNAP_INT( "damageDealt",      damageDealt      )
-                SNAP_INT( "damageTaken",      damageTaken      )
-                SNAP_FLT( "distanceKm",       distanceKm       )
-                SNAP_FLT( "topSpeedKph",      topSpeedKph      )
-                SNAP_FLT( "fuelUsed",         fuelUsed         )
-                SNAP_STR( "mostUsedVehicle",  mostUsedVehicle  )
-                SNAP_INT( "gamesPlayed",      gamesPlayed      )
+                if ( !SV_LadderJsonAppendKey( builder, "valid", &profFirst ) ||
+                     !SV_LadderJsonAppendBoolean( builder, snap->valid ) ) {
+                        return qfalse;
+                }
 
-                /* ── GT_RACING ── */
-                SNAP_INT( "racingWins",       racingWins       )
-                SNAP_INT( "racingPodiums",    racingPodiums    )
-                SNAP_INT( "racingCompleted",  racingCompleted  )
-                SNAP_INT( "racingTotalMs",    racingTotalMs    )
+                if ( !snap->valid ) {
+                        if ( !SV_LadderJsonAppendChar( builder, '}' ) ) {
+                                return qfalse;
+                        }
+                } else {
+                        SNAP_INT( "snapshotEpoch",    snapshotEpoch    )
+                        SNAP_INT( "snapshotRevision", snapshotRevision )
+                        SNAP_INT( "playerScore",      playerScore      )
+                        SNAP_INT( "currentRank",      currentRank      )
+                        SNAP_INT( "highestRank",      highestRank      )
+                        SNAP_INT( "wins",             wins             )
+                        SNAP_INT( "losses",           losses           )
+                        SNAP_INT( "kills",            kills            )
+                        SNAP_INT( "deaths",           deaths           )
+                        SNAP_INT( "flagCaptures",     flagCaptures     )
+                        SNAP_INT( "flagAssists",      flagAssists      )
+                        SNAP_INT( "bestLapMs",        bestLapMs        )
+                        SNAP_INT( "accuracyAwards",   accuracyAwards   )
+                        SNAP_INT( "excellentAwards",  excellentAwards  )
+                        SNAP_INT( "impressiveAwards", impressiveAwards )
+                        SNAP_INT( "perfectAwards",    perfectAwards    )
+                        SNAP_INT( "damageDealt",      damageDealt      )
+                        SNAP_INT( "damageTaken",      damageTaken      )
+                        SNAP_FLT( "distanceKm",       distanceKm       )
+                        SNAP_FLT( "topSpeedKph",      topSpeedKph      )
+                        SNAP_FLT( "fuelUsed",         fuelUsed         )
+                        SNAP_STR( "mostUsedVehicle",  mostUsedVehicle  )
+                        SNAP_INT( "gamesPlayed",      gamesPlayed      )
 
-                /* ── GT_RACING_DM ── */
-                SNAP_INT( "racingDmWins",       racingDmWins       )
-                SNAP_INT( "racingDmPodiums",    racingDmPodiums    )
-                SNAP_INT( "racingDmCompleted",  racingDmCompleted  )
-                SNAP_INT( "racingDmTotalMs",    racingDmTotalMs    )
+                        /* ── GT_RACING ── */
+                        SNAP_INT( "racingWins",       racingWins       )
+                        SNAP_INT( "racingPodiums",    racingPodiums    )
+                        SNAP_INT( "racingCompleted",  racingCompleted  )
+                        SNAP_INT( "racingTotalMs",    racingTotalMs    )
 
-                /* ── GT_SPRINT ── */
-                SNAP_INT( "sprintWins",       sprintWins       )
-                SNAP_INT( "sprintCompleted",  sprintCompleted  )
-                SNAP_INT( "sprintBestMs",     sprintBestMs     )
+                        /* ── GT_RACING_DM ── */
+                        SNAP_INT( "racingDmWins",       racingDmWins       )
+                        SNAP_INT( "racingDmPodiums",    racingDmPodiums    )
+                        SNAP_INT( "racingDmCompleted",  racingDmCompleted  )
+                        SNAP_INT( "racingDmTotalMs",    racingDmTotalMs    )
 
-                /* ── GT_ELIMINATION ── */
-                SNAP_INT( "eliminationWins",              eliminationWins              )
-                SNAP_INT( "eliminationCompleted",         eliminationCompleted         )
-                SNAP_INT( "eliminationTotalRoundsLasted", eliminationTotalRoundsLasted )
+                        /* ── GT_SPRINT ── */
+                        SNAP_INT( "sprintWins",       sprintWins       )
+                        SNAP_INT( "sprintCompleted",  sprintCompleted  )
+                        SNAP_INT( "sprintBestMs",     sprintBestMs     )
 
-                /* ── GT_LCS ── */
-                SNAP_INT( "lcsWins",             lcsWins            )
-                SNAP_INT( "lcsCompleted",        lcsCompleted       )
-                SNAP_INT( "lcsTotalSurvivalMs",  lcsTotalSurvivalMs )
+                        /* ── GT_ELIMINATION ── */
+                        SNAP_INT( "eliminationWins",              eliminationWins              )
+                        SNAP_INT( "eliminationCompleted",         eliminationCompleted         )
+                        SNAP_INT( "eliminationTotalRoundsLasted", eliminationTotalRoundsLasted )
 
-                /* ── GT_DERBY ── */
-                SNAP_INT( "derbyWins",       derbyWins       )
-                SNAP_INT( "derbyCompleted",  derbyCompleted  )
-                SNAP_INT( "derbyKills",      derbyKills      )
+                        /* ── GT_LCS ── */
+                        SNAP_INT( "lcsWins",             lcsWins            )
+                        SNAP_INT( "lcsCompleted",        lcsCompleted       )
+                        SNAP_INT( "lcsTotalSurvivalMs",  lcsTotalSurvivalMs )
 
-                /* ── GT_DEATHMATCH ── */
-                SNAP_INT( "dmWins",       dmWins       )
-                SNAP_INT( "dmCompleted",  dmCompleted  )
-                SNAP_INT( "dmKills",      dmKills      )
+                        /* ── GT_DERBY ── */
+                        SNAP_INT( "derbyWins",       derbyWins       )
+                        SNAP_INT( "derbyCompleted",  derbyCompleted  )
+                        SNAP_INT( "derbyKills",      derbyKills      )
 
-                /* ── GT_CTF ── */
-                SNAP_INT( "ctfWins",       ctfWins       )
-                SNAP_INT( "ctfCompleted",  ctfCompleted  )
-                SNAP_INT( "ctfCaptures",   ctfCaptures   )
+                        /* ── GT_DEATHMATCH ── */
+                        SNAP_INT( "dmWins",       dmWins       )
+                        SNAP_INT( "dmCompleted",  dmCompleted  )
+                        SNAP_INT( "dmKills",      dmKills      )
 
-                /* ── GT_CTF4 ── */
-                SNAP_INT( "ctf4Wins",       ctf4Wins       )
-                SNAP_INT( "ctf4Completed",  ctf4Completed  )
-                SNAP_INT( "ctf4Captures",   ctf4Captures   )
+                        /* ── GT_CTF ── */
+                        SNAP_INT( "ctfWins",       ctfWins       )
+                        SNAP_INT( "ctfCompleted",  ctfCompleted  )
+                        SNAP_INT( "ctfCaptures",   ctfCaptures   )
 
-                /* ── GT_TEAM ── */
-                SNAP_INT( "teamWins",       teamWins       )
-                SNAP_INT( "teamCompleted",  teamCompleted  )
-                SNAP_INT( "teamKills",      teamKills      )
+                        /* ── GT_CTF4 ── */
+                        SNAP_INT( "ctf4Wins",       ctf4Wins       )
+                        SNAP_INT( "ctf4Completed",  ctf4Completed  )
+                        SNAP_INT( "ctf4Captures",   ctf4Captures   )
 
-                /* ── GT_TEAM_RACING ── */
-                SNAP_INT( "teamRacingWins",       teamRacingWins       )
-                SNAP_INT( "teamRacingCompleted",  teamRacingCompleted  )
-                SNAP_INT( "teamRacingPodiums",    teamRacingPodiums    )
+                        /* ── GT_TEAM ── */
+                        SNAP_INT( "teamWins",       teamWins       )
+                        SNAP_INT( "teamCompleted",  teamCompleted  )
+                        SNAP_INT( "teamKills",      teamKills      )
 
-                /* ── GT_TEAM_RACING_DM ── */
-                SNAP_INT( "teamRacingDmWins",       teamRacingDmWins       )
-                SNAP_INT( "teamRacingDmCompleted",  teamRacingDmCompleted  )
-                SNAP_INT( "teamRacingDmPodiums",    teamRacingDmPodiums    )
+                        /* ── GT_TEAM_RACING ── */
+                        SNAP_INT( "teamRacingWins",       teamRacingWins       )
+                        SNAP_INT( "teamRacingCompleted",  teamRacingCompleted  )
+                        SNAP_INT( "teamRacingPodiums",    teamRacingPodiums    )
 
-                /* ── GT_DOMINATION ── */
-                SNAP_INT( "dominationWins",        dominationWins        )
-                SNAP_INT( "dominationCompleted",   dominationCompleted   )
-                SNAP_INT( "dominationZoneHoldMs",  dominationZoneHoldMs  )
+                        /* ── GT_TEAM_RACING_DM ── */
+                        SNAP_INT( "teamRacingDmWins",       teamRacingDmWins       )
+                        SNAP_INT( "teamRacingDmCompleted",  teamRacingDmCompleted  )
+                        SNAP_INT( "teamRacingDmPodiums",    teamRacingDmPodiums    )
 
-                /* ── GT_KOTH ── */
-                SNAP_INT( "kothWins",        kothWins        )
-                SNAP_INT( "kothCompleted",   kothCompleted   )
-                SNAP_INT( "kothZoneHoldMs",  kothZoneHoldMs  )
+                        /* ── GT_DOMINATION ── */
+                        SNAP_INT( "dominationWins",        dominationWins        )
+                        SNAP_INT( "dominationCompleted",   dominationCompleted   )
+                        SNAP_INT( "dominationZoneHoldMs",  dominationZoneHoldMs  )
 
+                        /* ── GT_KOTH ── */
+                        SNAP_INT( "kothWins",        kothWins        )
+                        SNAP_INT( "kothCompleted",   kothCompleted   )
+                        SNAP_INT( "kothZoneHoldMs",  kothZoneHoldMs  )
+
+                        if ( !SV_LadderJsonAppendKey( builder, "achievementTiers", &profFirst ) ||
+                             !SV_LadderJsonAppendChar( builder, '[' ) ) {
+                                return qfalse;
+                        }
+                        for ( i = 0; i < (int)( sizeof( snap->achievementTiers ) / sizeof( snap->achievementTiers[0] ) ); ++i ) {
+                                if ( i > 0 && !SV_LadderJsonAppendChar( builder, ',' ) ) {
+                                        return qfalse;
+                                }
+                                if ( !SV_LadderJsonAppendInt( builder, snap->achievementTiers[i] ) ) {
+                                        return qfalse;
+                                }
+                        }
+                        if ( !SV_LadderJsonAppendChar( builder, ']' ) ||
+                             !SV_LadderJsonAppendChar( builder, '}' ) ) {
+                                return qfalse;
+                        }
+                }
+        }
 #undef SNAP_INT
 #undef SNAP_FLT
 #undef SNAP_STR
-
-                if ( !SV_LadderJsonAppendKey( builder, "achievementTiers", &profFirst ) ||
-                     !SV_LadderJsonAppendChar( builder, '[' ) ) {
-                        return qfalse;
-                }
-                for ( i = 0; i < (int)( sizeof( snap->achievementTiers ) / sizeof( snap->achievementTiers[0] ) ); ++i ) {
-                        if ( i > 0 && !SV_LadderJsonAppendChar( builder, ',' ) ) {
-                                return qfalse;
-                        }
-                        if ( !SV_LadderJsonAppendInt( builder, snap->achievementTiers[i] ) ) {
-                                return qfalse;
-                        }
-                }
-                if ( !SV_LadderJsonAppendChar( builder, ']' ) ||
-                     !SV_LadderJsonAppendChar( builder, '}' ) ) {
-                        return qfalse;
-                }
-        }
 
         if ( !SV_LadderJsonAppendChar( builder, '}' ) ) {
                 return qfalse;


### PR DESCRIPTION
### Motivation
- Verhindern von inkonsistenten/mixed Profilwerten in Ladder-Payloads, indem die Quelle und Emissionsbedingungen des `player.profile`-Blocks vereinheitlicht werden.
- Sicherstellen, dass Backend Stale-Checks möglich sind, durch Hinzufügen von Snapshot-Freshness-Metadaten.
- Garantieren, dass persistente Profiländerungen auf die Festplatte geschrieben werden, bevor ein Ladder-Submit stattfindet.

### Description
- Hinzugefügt `snapshotEpoch` und `snapshotRevision` in `ladderProfileSnapshot_t` und ein Flag `profileAttached` in `ladderPlayerPayload_t` (Datei: `engine/code/game/bg_ladder.h`).
- Neues API `G_Profile_GetLadderSnapshot(...)` in `g_profile.h`/`g_profile.c`, das Laufzeitzustand (`s_profileState`) in ein `ladderProfileSnapshot_t` übersetzt und eine einfache Revisionsberechnung sowie Epoch-Timestamp liefert.
- `G_LadderPopulatePlayer` (in `g_main.c`) verwendet jetzt bevorzugt `G_Profile_GetLadderSnapshot` und greift nur noch auf Dateilesen als Fallback zurück; der Snapshot wird als explizit angehängt markiert (`profileAttached`) und bei fehlendem Laufzeitprofil wird `profile.valid = false` gesetzt (keine Mischwerte).
- Ladder-JSON-Serializer (`sv_ladder.c`) wurde angepasst, sodass bei angehängtem Profil stets ein `profile`-Objekt ausgegeben wird und zuerst `profile.valid` gesendet wird; sind `valid==false` werden keine weiteren Snapshot-Felder ausgesendet, andernfalls werden `snapshotEpoch`/`snapshotRevision` und alle Snapshot-Felder serialisiert.
- Reihenfolge in `LogExit` korrigiert: Profil-Flush (`G_Profile_FlushIfDirty`) erfolgt vor dem Aufruf von `G_LadderSubmitMatchReport`, um sicherzustellen, dass auf-disk Daten aktuell sind.

### Testing
- Automatischer Ladder-JSON Unit-Test ausgeführt mit `python3 tests/test_ladder_json.py`, der erfolgreich durchlief.
- Projekttests/Serialisierungsharness bestätigten, dass die JSON-Ausgabe weiterhin erzeugt wird und die erwarteten Felder (z.B. Lap-/bestLap-Felder) vorhanden sind.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd3fdc127c8323862452cf706a1811)