### PR TITLE
Zentrale Ladder-Payload-Validierung mit strukturierten Issue-Codes hinzufügen

### DIFF
--- a/engine/code/game/bg_ladder.h
+++ b/engine/code/game/bg_ladder.h
@@ -20,6 +20,17 @@
 #define LADDER_MAX_MODEL                MAX_QPATH
 #define LADDER_MAX_VEHICLE              MAX_QPATH
 #define LADDER_MAX_LAP_TIMES            32
+#define LADDER_MAX_VALIDATION_REASON    128
+
+typedef enum ladderPayloadIssue_e {
+        LADDER_PAYLOAD_WARN_FORBIDDEN_MODE_FIELDS = 1 << 0,
+        LADDER_PAYLOAD_WARN_KD_RATIO_REPAIRED     = 1 << 1,
+        LADDER_PAYLOAD_WARN_LAPCOUNT_REPAIRED     = 1 << 2,
+
+        LADDER_PAYLOAD_ERR_MISSING_REQUIRED       = 1 << 8,
+        LADDER_PAYLOAD_ERR_VALUE_RANGE            = 1 << 9,
+        LADDER_PAYLOAD_ERR_INTERNAL_CONSISTENCY   = 1 << 10
+} ladderPayloadIssue_t;
 
 #ifndef RACE_MAX_RECORDED_LAPS
 #define RACE_MAX_RECORDED_LAPS          LADDER_MAX_LAP_TIMES
@@ -176,6 +187,9 @@ typedef struct ladderPlayerPayload_s {
 
 typedef struct ladderMatchPayload_s {
         qboolean        valid;
+        int                     validationWarnings;
+        int                     validationErrors;
+        char            validationReason[LADDER_MAX_VALIDATION_REASON];
         char            matchId[LADDER_MAX_MATCH_ID];
         char            mode[LADDER_MAX_MODE];
         int                     gametype;

--- a/engine/code/server/sv_ladder.c
+++ b/engine/code/server/sv_ladder.c
@@ -404,6 +404,131 @@ static const char *SV_LadderTeamName( int team ) {
         return "free";
 }
 
+static qboolean G_LadderGametypeHasRaceFields( int gametype ) {
+        return ( gametype == GT_RACING ||
+                 gametype == GT_RACING_DM ||
+                 gametype == GT_SPRINT ||
+                 gametype == GT_TEAM_RACING ||
+                 gametype == GT_TEAM_RACING_DM ||
+                 gametype == GT_ELIMINATION );
+}
+
+qboolean G_LadderValidatePayload( ladderMatchPayload_t *payload, qboolean blockOnHardErrors ) {
+        int i;
+        qboolean hasRaceFields;
+        qboolean killSemantics;
+        qboolean hasHardErrors;
+
+        if ( !payload ) {
+                return qfalse;
+        }
+
+        payload->validationWarnings = 0;
+        payload->validationErrors = 0;
+        payload->validationReason[0] = '\0';
+
+        if ( !payload->matchId[0] || !payload->mode[0] || !payload->mapName[0] ) {
+                payload->validationErrors |= LADDER_PAYLOAD_ERR_MISSING_REQUIRED;
+                Q_strncpyz( payload->validationReason, "missing_required_fields", sizeof( payload->validationReason ) );
+        }
+
+        if ( payload->durationSeconds < 0 || payload->startEpoch < 0 || payload->endEpoch < 0 ) {
+                payload->validationErrors |= LADDER_PAYLOAD_ERR_VALUE_RANGE;
+                Q_strncpyz( payload->validationReason, "negative_match_timing", sizeof( payload->validationReason ) );
+        }
+
+        hasRaceFields = G_LadderGametypeHasRaceFields( payload->gametype );
+        if ( hasRaceFields ) {
+                if ( payload->numberOfLaps <= 0 ) {
+                        payload->validationErrors |= LADDER_PAYLOAD_ERR_MISSING_REQUIRED;
+                        Q_strncpyz( payload->validationReason, "numberOfLaps_required_for_race_mode", sizeof( payload->validationReason ) );
+                }
+        } else if ( payload->numberOfLaps != 0 || payload->raceStartTime != 0 || payload->raceEndTime != 0 ) {
+                payload->validationWarnings |= LADDER_PAYLOAD_WARN_FORBIDDEN_MODE_FIELDS;
+        }
+
+        killSemantics = ( payload->gametype == GT_DEATHMATCH ||
+                          payload->gametype == GT_TEAM ||
+                          payload->gametype == GT_DERBY ||
+                          payload->gametype == GT_LCS ||
+                          payload->gametype == GT_ELIMINATION ||
+                          payload->gametype == GT_RACING_DM ||
+                          payload->gametype == GT_TEAM_RACING_DM ||
+                          payload->gametype == GT_CTF ||
+                          payload->gametype == GT_CTF4 ||
+                          payload->gametype == GT_DOMINATION ||
+                          payload->gametype == GT_KOTH );
+
+        if ( payload->playerCount < 0 || payload->playerCount > MAX_CLIENTS ) {
+                payload->validationErrors |= LADDER_PAYLOAD_ERR_VALUE_RANGE;
+                Q_strncpyz( payload->validationReason, "playerCount_out_of_range", sizeof( payload->validationReason ) );
+                if ( payload->playerCount < 0 ) {
+                        payload->playerCount = 0;
+                } else if ( payload->playerCount > MAX_CLIENTS ) {
+                        payload->playerCount = MAX_CLIENTS;
+                }
+                payload->validationWarnings |= LADDER_PAYLOAD_WARN_LAPCOUNT_REPAIRED;
+        }
+
+        for ( i = 0; i < payload->playerCount; ++i ) {
+                ladderPlayerPayload_t *player = &payload->players[i];
+                int expectedLapCount;
+                int j;
+                float expectedKdRatio;
+
+                if ( player->team < TEAM_FREE || player->team > TEAM_SPECTATOR ) {
+                        payload->validationErrors |= LADDER_PAYLOAD_ERR_VALUE_RANGE;
+                        Q_strncpyz( payload->validationReason, "invalid_team_id", sizeof( payload->validationReason ) );
+                }
+                if ( player->bestLapMs < 0 || player->totalRaceMs < 0 || player->finishRaceTime < 0 || player->deaths < 0 ) {
+                        payload->validationErrors |= LADDER_PAYLOAD_ERR_VALUE_RANGE;
+                        Q_strncpyz( payload->validationReason, "negative_player_timing_or_deaths", sizeof( payload->validationReason ) );
+                }
+
+                expectedLapCount = player->lapCount;
+                if ( expectedLapCount < 0 ) {
+                        expectedLapCount = 0;
+                }
+                if ( expectedLapCount > LADDER_MAX_LAP_TIMES ) {
+                        expectedLapCount = LADDER_MAX_LAP_TIMES;
+                }
+                if ( hasRaceFields && payload->numberOfLaps > 0 && expectedLapCount > payload->numberOfLaps ) {
+                        payload->validationWarnings |= LADDER_PAYLOAD_WARN_LAPCOUNT_REPAIRED;
+                }
+                if ( expectedLapCount != player->lapCount ) {
+                        payload->validationWarnings |= LADDER_PAYLOAD_WARN_LAPCOUNT_REPAIRED;
+                        player->lapCount = expectedLapCount;
+                }
+
+                for ( j = 0; j < player->lapCount; ++j ) {
+                        if ( player->lapTimes[j] <= 0 ) {
+                                payload->validationErrors |= LADDER_PAYLOAD_ERR_INTERNAL_CONSISTENCY;
+                                Q_strncpyz( payload->validationReason, "lapCount_lapTimes_inconsistent", sizeof( payload->validationReason ) );
+                                break;
+                        }
+                }
+
+                if ( killSemantics ) {
+                        if ( player->deaths > 0 ) {
+                                expectedKdRatio = (float)player->kills / (float)player->deaths;
+                        } else {
+                                expectedKdRatio = (float)player->kills;
+                        }
+                        if ( fabsf( expectedKdRatio - player->kdRatio ) > 0.01f ) {
+                                payload->validationWarnings |= LADDER_PAYLOAD_WARN_KD_RATIO_REPAIRED;
+                                player->kdRatio = expectedKdRatio;
+                        }
+                }
+        }
+
+        hasHardErrors = payload->validationErrors != 0;
+        if ( hasHardErrors && blockOnHardErrors ) {
+                payload->valid = qfalse;
+        }
+
+        return hasHardErrors ? qfalse : qtrue;
+}
+
 static qboolean SV_LadderJsonAppendKey( ladderJsonBuilder_t *builder, const char *key, qboolean *first ) {
         if ( !SV_LadderJsonEnsure( builder, 1 ) ) {
                 return qfalse;
@@ -853,6 +978,21 @@ static char *SV_LadderSerializeMatch( const ladderMatchPayload_t *payload, size_
 
         if ( !SV_LadderJsonAppendKey( &builder, "matchId", &first ) ||
              !SV_LadderJsonAppendString( &builder, payload->matchId ) ) {
+                Z_Free( builder.data );
+                return NULL;
+        }
+        if ( !SV_LadderJsonAppendKey( &builder, "validationWarnings", &first ) ||
+             !SV_LadderJsonAppendInt( &builder, payload->validationWarnings ) ) {
+                Z_Free( builder.data );
+                return NULL;
+        }
+        if ( !SV_LadderJsonAppendKey( &builder, "validationErrors", &first ) ||
+             !SV_LadderJsonAppendInt( &builder, payload->validationErrors ) ) {
+                Z_Free( builder.data );
+                return NULL;
+        }
+        if ( !SV_LadderJsonAppendKey( &builder, "validationReason", &first ) ||
+             !SV_LadderJsonAppendString( &builder, payload->validationReason ) ) {
                 Z_Free( builder.data );
                 return NULL;
         }
@@ -2321,6 +2461,7 @@ void SV_LadderShutdown( void ) {
 
 void SV_LadderSubmit( const ladderMatchPayload_t *payload ) {
         ladderRequest_t *request;
+        ladderMatchPayload_t validatedPayload;
         char *json;
         size_t length = 0;
         int total;
@@ -2338,6 +2479,15 @@ void SV_LadderSubmit( const ladderMatchPayload_t *payload ) {
         }
 
         if ( !payload || !payload->valid ) {
+                return;
+        }
+
+        Com_Memcpy( &validatedPayload, payload, sizeof( validatedPayload ) );
+        if ( !G_LadderValidatePayload( &validatedPayload, qtrue ) ) {
+                Com_Printf( "Ladder: blocking submit for match %s (errors=%d reason=%s)\n",
+                        validatedPayload.matchId[0] ? validatedPayload.matchId : "<unknown>",
+                        validatedPayload.validationErrors,
+                        validatedPayload.validationReason[0] ? validatedPayload.validationReason : "validation_failed" );
                 return;
         }
 
@@ -2364,11 +2514,11 @@ void SV_LadderSubmit( const ladderMatchPayload_t *payload ) {
         total = sv_ladder.queueSize + ( sv_ladder.active ? 1 : 0 );
         if ( total >= sv_ladder.maxQueue ) {
                 Com_Printf( "Ladder: queue full, dropping match %s\n",
-                        payload->matchId[0] ? payload->matchId : "<unknown>" );
+                        validatedPayload.matchId[0] ? validatedPayload.matchId : "<unknown>" );
                 return;
         }
 
-        json = SV_LadderSerializeMatch( payload, &length );
+        json = SV_LadderSerializeMatch( &validatedPayload, &length );
         if ( !json || !length ) {
                         Com_Printf( "Ladder: failed to serialize match payload\n" );
                 if ( json ) {
@@ -2383,10 +2533,10 @@ void SV_LadderSubmit( const ladderMatchPayload_t *payload ) {
                 return;
         }
 
-        Com_Memcpy( &request->payload, payload, sizeof( *payload ) );
+        Com_Memcpy( &request->payload, &validatedPayload, sizeof( validatedPayload ) );
         request->json = json;
         request->jsonLength = length;
-        Q_strncpyz( request->matchId, payload->matchId, sizeof( request->matchId ) );
+        Q_strncpyz( request->matchId, validatedPayload.matchId, sizeof( request->matchId ) );
         request->nextAttemptTime = 0;
         request->attempt = 0;
 
@@ -2400,7 +2550,7 @@ void SV_LadderSubmit( const ladderMatchPayload_t *payload ) {
 #ifndef USE_CURL
         if ( !sv_ladder.warnedNoCurl ) {
                 Com_Printf( "Ladder: built without libcurl support, dropping match %s\n",
-                        payload->matchId[0] ? payload->matchId : "<unknown>" );
+                        validatedPayload.matchId[0] ? validatedPayload.matchId : "<unknown>" );
                 sv_ladder.warnedNoCurl = qtrue;
         }
         SV_LadderFreeRequest( request, qfalse );

--- a/tests/ladder_payload_validation_test.c
+++ b/tests/ladder_payload_validation_test.c
@@ -1,0 +1,63 @@
+#include <assert.h>
+#include <stdio.h>
+#include <string.h>
+
+#include "server.h"
+
+cvar_t *sv_ladderUrl = NULL;
+cvar_t *sv_ladderApiKey = NULL;
+cvar_t *sv_ladderEnabled = NULL;
+cvar_t *sv_telemetryMaxBatch = NULL;
+
+#include "sv_ladder_for_test.c"
+
+static void InitPayload( ladderMatchPayload_t *payload, int gametype ) {
+    Com_Memset( payload, 0, sizeof( *payload ) );
+    payload->valid = qtrue;
+    payload->gametype = gametype;
+    Q_strncpyz( payload->matchId, "match-1", sizeof( payload->matchId ) );
+    Q_strncpyz( payload->mode, "mode", sizeof( payload->mode ) );
+    Q_strncpyz( payload->mapName, "q3r_test", sizeof( payload->mapName ) );
+    payload->playerCount = 1;
+    payload->players[0].team = TEAM_FREE;
+}
+
+int main( void ) {
+    ladderMatchPayload_t payload;
+
+    InitPayload( &payload, GT_RACING );
+    payload.numberOfLaps = 3;
+    payload.players[0].lapCount = 2;
+    payload.players[0].lapTimes[0] = 12000;
+    payload.players[0].lapTimes[1] = 11000;
+    assert( G_LadderValidatePayload( &payload, qtrue ) == qtrue );
+    assert( payload.validationErrors == 0 );
+
+    InitPayload( &payload, GT_RACING );
+    payload.numberOfLaps = 0;
+    assert( G_LadderValidatePayload( &payload, qtrue ) == qfalse );
+    assert( payload.valid == qfalse );
+    assert( payload.validationErrors & LADDER_PAYLOAD_ERR_MISSING_REQUIRED );
+
+    InitPayload( &payload, GT_DEATHMATCH );
+    payload.players[0].kills = 10;
+    payload.players[0].deaths = 0;
+    payload.players[0].kdRatio = 0.0f;
+    assert( G_LadderValidatePayload( &payload, qtrue ) == qtrue );
+    assert( payload.validationWarnings & LADDER_PAYLOAD_WARN_KD_RATIO_REPAIRED );
+    assert( payload.players[0].kdRatio == 10.0f );
+
+    InitPayload( &payload, GT_TEAM );
+    payload.players[0].team = 77;
+    assert( G_LadderValidatePayload( &payload, qtrue ) == qfalse );
+    assert( payload.validationErrors & LADDER_PAYLOAD_ERR_VALUE_RANGE );
+
+    InitPayload( &payload, GT_CTF );
+    payload.players[0].lapCount = 1;
+    payload.players[0].lapTimes[0] = 0;
+    assert( G_LadderValidatePayload( &payload, qtrue ) == qfalse );
+    assert( payload.validationErrors & LADDER_PAYLOAD_ERR_INTERNAL_CONSISTENCY );
+
+    puts( "ok" );
+    return 0;
+}

--- a/tests/server.h
+++ b/tests/server.h
@@ -32,6 +32,27 @@ typedef struct {
         int dummy;
 } car_t;
 
+typedef struct {
+        const char *name;
+        int minimumScore;
+} profile_rank_def_t;
+
+typedef struct {
+        int playerScore;
+} profile_stats_t;
+
+typedef struct {
+        int index;
+        const profile_rank_def_t *current;
+} profile_rank_t;
+
+#define PROFILE_RANK_TABLE(X) \
+        X("Bronze", 0) \
+        X("Silver", 1000)
+
+static inline qboolean Profile_GetRankForScore( const profile_stats_t *stats, const profile_rank_def_t *table, size_t count, profile_rank_t *outRank ) {\
+        (void)stats; (void)table; (void)count; if ( outRank ) { outRank->index = 0; outRank->current = NULL; } return qtrue; }
+
 #define MAX_CLIENTS 64
 #define TEAM_NUM_TEAMS 4
 #define MAX_QPATH 64
@@ -45,6 +66,22 @@ typedef struct {
 #define TEAM_BLUE 2
 #define TEAM_SPECTATOR 3
 
+#define GT_RACING 0
+#define GT_RACING_DM 1
+#define GT_SINGLE_PLAYER 2
+#define GT_DERBY 3
+#define GT_LCS 4
+#define GT_ELIMINATION 5
+#define GT_DEATHMATCH 6
+#define GT_SPRINT 7
+#define GT_TEAM 16
+#define GT_TEAM_RACING 17
+#define GT_TEAM_RACING_DM 18
+#define GT_CTF 19
+#define GT_CTF4 20
+#define GT_DOMINATION 21
+#define GT_KOTH 22
+
 #define LADDER_MAX_MATCH_ID             64
 #define LADDER_MAX_MODE                 32
 #define LADDER_MAX_TIME_STRING          32
@@ -56,10 +93,63 @@ typedef struct {
 #define LADDER_MAX_MODEL                MAX_QPATH
 #define LADDER_MAX_VEHICLE              MAX_QPATH
 #define LADDER_MAX_LAP_TIMES            32
+#define LADDER_MAX_VALIDATION_REASON    128
+
+typedef enum ladderPayloadIssue_e {
+        LADDER_PAYLOAD_WARN_FORBIDDEN_MODE_FIELDS = 1 << 0,
+        LADDER_PAYLOAD_WARN_KD_RATIO_REPAIRED     = 1 << 1,
+        LADDER_PAYLOAD_WARN_LAPCOUNT_REPAIRED     = 1 << 2,
+
+        LADDER_PAYLOAD_ERR_MISSING_REQUIRED       = 1 << 8,
+        LADDER_PAYLOAD_ERR_VALUE_RANGE            = 1 << 9,
+        LADDER_PAYLOAD_ERR_INTERNAL_CONSISTENCY   = 1 << 10
+} ladderPayloadIssue_t;
 
 #ifndef RACE_MAX_RECORDED_LAPS
 #define RACE_MAX_RECORDED_LAPS          LADDER_MAX_LAP_TIMES
 #endif
+
+typedef struct ladderProfileSnapshot_s {
+        qboolean        valid;
+        int             snapshotEpoch;
+        int             snapshotRevision;
+        int             playerScore;
+        int             currentRank;
+        int             highestRank;
+        int             wins;
+        int             losses;
+        int             kills;
+        int             deaths;
+        int             flagCaptures;
+        int             flagAssists;
+        int             bestLapMs;
+        int             accuracyAwards;
+        int             excellentAwards;
+        int             impressiveAwards;
+        int             perfectAwards;
+        int             damageDealt;
+        int             damageTaken;
+        float           distanceKm;
+        float           topSpeedKph;
+        float           fuelUsed;
+        char            mostUsedVehicle[64];
+        int             gamesPlayed;
+        int             achievementTiers[11];
+        int             racingWins, racingPodiums, racingCompleted, racingTotalMs;
+        int             racingDmWins, racingDmPodiums, racingDmCompleted, racingDmTotalMs;
+        int             sprintWins, sprintCompleted, sprintBestMs;
+        int             eliminationWins, eliminationCompleted, eliminationTotalRoundsLasted;
+        int             lcsWins, lcsCompleted, lcsTotalSurvivalMs;
+        int             derbyWins, derbyCompleted, derbyKills;
+        int             dmWins, dmCompleted, dmKills;
+        int             ctfWins, ctfCompleted, ctfCaptures;
+        int             ctf4Wins, ctf4Completed, ctf4Captures;
+        int             teamWins, teamCompleted, teamKills;
+        int             teamRacingWins, teamRacingCompleted, teamRacingPodiums;
+        int             teamRacingDmWins, teamRacingDmCompleted, teamRacingDmPodiums;
+        int             dominationWins, dominationCompleted, dominationZoneHoldMs;
+        int             kothWins, kothCompleted, kothZoneHoldMs;
+} ladderProfileSnapshot_t;
 
 typedef struct ladderPlayerPayload_s {
         int                     clientNum;
@@ -102,10 +192,15 @@ typedef struct ladderPlayerPayload_s {
         float           eliminationMetric;
         int                     finishRaceTime;
         float           kdRatio;
+        qboolean        profileAttached;
+        ladderProfileSnapshot_t profile;
 } ladderPlayerPayload_t;
 
 typedef struct ladderMatchPayload_s {
         qboolean        valid;
+        int                     validationWarnings;
+        int                     validationErrors;
+        char            validationReason[LADDER_MAX_VALIDATION_REASON];
         char            matchId[LADDER_MAX_MATCH_ID];
         char            mode[LADDER_MAX_MODE];
         int                     gametype;
@@ -133,6 +228,7 @@ typedef struct ladderMatchPayload_s {
         int                     teamScores[TEAM_NUM_TEAMS];
         int                     teamTimes[TEAM_NUM_TEAMS];
         int                     playerCount;
+        qboolean        isDedicated;
         ladderPlayerPayload_t players[MAX_CLIENTS];
 } ladderMatchPayload_t;
 
@@ -251,5 +347,13 @@ static inline void Q_strncpyz( char *dest, const char *src, int destsize ) {
 static inline int Q_stricmp( const char *s1, const char *s2 ) {
         return strcasecmp( s1 ? s1 : "", s2 ? s2 : "" );
 }
+
+static inline void Q_strcat( char *dest, int size, const char *src ) {
+        strncat( dest, src, (size_t)size - strlen( dest ) - 1 );
+}
+
+static inline void Cbuf_AddText( const char *text ) { (void)text; }
+static inline void Cmd_AddCommand( const char *name, void (*fn)(void) ) { (void)name; (void)fn; }
+static inline void Cmd_RemoveCommand( const char *name ) { (void)name; }
 
 #endif /* TEST_SERVER_H */

--- a/tests/test_ladder_payload_validation.py
+++ b/tests/test_ladder_payload_validation.py
@@ -1,0 +1,46 @@
+import pathlib
+import subprocess
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[1]
+SOURCE_FILE = REPO_ROOT / "engine" / "code" / "server" / "sv_ladder.c"
+GENERATED_SOURCE = REPO_ROOT / "tests" / "sv_ladder_for_test.c"
+TEST_BINARY = REPO_ROOT / "tests" / "ladder_payload_validation_test"
+
+COMPILE_ARGS = [
+    "gcc",
+    "-I" + str(REPO_ROOT / "tests"),
+    "-I" + str(REPO_ROOT / "engine" / "code" / "server"),
+    "-I" + str(REPO_ROOT / "engine" / "code" / "qcommon"),
+    "-I" + str(REPO_ROOT / "engine" / "code" / "game"),
+    "-DARCH_STRING=\"test\"",
+    "-DOS_STRING=\"linux\"",
+    "-DID_INLINE=inline",
+    "-DPATH_SEP='/'",
+    "-DDLL_EXT=\".so\"",
+    "-DQ3_LITTLE_ENDIAN",
+    "-DUNIT_TEST",
+    str(REPO_ROOT / "tests" / "ladder_payload_validation_test.c"),
+    "-o",
+    str(TEST_BINARY),
+]
+
+
+def _prepare_source() -> None:
+    patched_lines = []
+    for line in SOURCE_FILE.read_text().splitlines():
+        if line.startswith('#include "../'):
+            patched_lines.append(line.replace('#include "../', '#include "../engine/code/'))
+        else:
+            patched_lines.append(line)
+    GENERATED_SOURCE.write_text("\n".join(patched_lines) + "\n")
+
+
+def test_ladder_payload_validation_across_modes() -> None:
+    _prepare_source()
+    subprocess.run(COMPILE_ARGS, check=True)
+    try:
+        result = subprocess.run([str(TEST_BINARY)], check=True, capture_output=True, text=True)
+    finally:
+        TEST_BINARY.unlink(missing_ok=True)
+        GENERATED_SOURCE.unlink(missing_ok=True)
+    assert "ok" in result.stdout


### PR DESCRIPTION
### Motivation
- Payloads für Ladder-Uploads brauchen eine zentrale Validierung, die modus-spezifische Pflicht-/Verbotsfelder, Wertebereiche und interne Konsistenz prüft und bei harten Fehlern das Submit verhindert. 

### Description
- Neue Funktion `G_LadderValidatePayload(ladderMatchPayload_t*, qboolean)` in `sv_ladder.c` führt modusabhängige Prüfungen durch, repariert kleinere Probleme und setzt strukturierte Warn-/Fehler-Bitmasks plus eine kurze `validationReason`. 
- `ladderMatchPayload_t` wurde um `validationWarnings`, `validationErrors` und `validationReason` erweitert (Header: `bg_ladder.h`) und diese Felder werden in die JSON-Serialisierung aufgenommen. 
- `SV_LadderSubmit` validiert nun vor Serialisierung und blockiert Uploads bei harten Fehlern; ansonsten wird der ggf. reparierte Payload weiterverwendet. 
- Testinfrastruktur: `tests/server.h` erweitert um nötige Test-Stubs, hinzugefügte Unit-Tests `tests/ladder_payload_validation_test.c` plus Pytest-Wrapper `tests/test_ladder_payload_validation.py` im bestehenden Muster. 

### Testing
- Ausführung: `pytest -q tests/test_ladder_json.py tests/test_ladder_payload_validation.py`. 
- Ergebnis: Alle Tests erfolgreich, `2 passed`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd430e89d88323abecf17a1a3e9305)