### PR TITLE
Add mode-aware validation, sanitization, and API validation error codes

### DIFF
--- a/ladder_service/ladder_service/main.py
+++ b/ladder_service/ladder_service/main.py
@@ -6,7 +6,8 @@ import os
 from contextlib import asynccontextmanager
 from typing import AsyncIterator
 
-from fastapi import Depends, FastAPI, HTTPException, Path, Query, status
+from fastapi import Depends, FastAPI, HTTPException, Path, Query, Request, status
+from fastapi.exceptions import RequestValidationError
 from fastapi.responses import JSONResponse
 from sqlalchemy import Engine, select
 from sqlalchemy.exc import IntegrityError
@@ -47,6 +48,30 @@ app = FastAPI(
 )
 
 
+def _extract_error_code(message: str) -> str:
+    if message.startswith("[") and "]" in message:
+        return message[1 : message.index("]")]
+    return "VALIDATION_ERROR"
+
+
+@app.exception_handler(RequestValidationError)
+async def request_validation_exception_handler(
+    _: Request, exc: RequestValidationError
+) -> JSONResponse:
+    errors = exc.errors()
+    detail = []
+    codes: list[str] = []
+    for err in errors:
+        msg = err.get("msg", "")
+        code = _extract_error_code(msg)
+        detail.append({**err, "errorCode": code})
+        codes.append(code)
+    return JSONResponse(
+        status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+        content={"detail": detail, "validation": {"errorCodes": sorted(set(codes))}},
+    )
+
+
 @app.post(
     "/api/v1/matches",
     status_code=status.HTTP_201_CREATED,
@@ -69,7 +94,10 @@ def create_match(match: MatchCreate, session: Session = Depends(get_session)) ->
         session.rollback()
         raise HTTPException(
             status_code=status.HTTP_409_CONFLICT,
-            detail="matchId already exists",
+            detail={
+                "message": "matchId already exists",
+                "errorCode": "MATCH_ID_CONFLICT",
+            },
         ) from exc
 
     return {"matchId": match.matchId}

--- a/ladder_service/ladder_service/schemas.py
+++ b/ladder_service/ladder_service/schemas.py
@@ -26,6 +26,18 @@ Gametype = Literal[
 
 
 _VALID_GAMETYPES: set[str] = set(get_args(Gametype))
+_TEAM_MODES: set[str] = {
+    "GT_TEAM_RACING",
+    "GT_TEAM_RACING_DM",
+    "GT_TEAM",
+    "GT_CTF",
+    "GT_CTF4",
+    "GT_DOMINATION",
+}
+
+
+def _mode_error(code: str, message: str) -> ValueError:
+    return ValueError(f"[{code}] {message}")
 
 
 class ServerInfo(BaseModel):
@@ -121,6 +133,59 @@ class MatchCreate(BaseModel):
                 if upper in _VALID_GAMETYPES:
                     return upper
         return "GT_ELIMINATION"
+
+    @root_validator
+    def validate_mode_specific_payload(cls, values: dict[str, Any]) -> dict[str, Any]:
+        mode = values.get("mode")
+        players = values.get("players") or []
+        teams = values.get("teams")
+
+        if mode not in _TEAM_MODES:
+            if teams:
+                raise _mode_error(
+                    "MODE_FORBIDS_TEAMS",
+                    f"mode '{mode}' forbids teams payload",
+                )
+            for player in players:
+                if player.team is not None:
+                    player.team = None
+            values["teams"] = None
+            return values
+
+        if not teams:
+            raise _mode_error(
+                "MODE_REQUIRES_TEAMS",
+                f"mode '{mode}' requires a non-empty teams array",
+            )
+
+        team_names: set[str] = set()
+        for team in teams:
+            normalized_name = team.team.strip().lower()
+            if not normalized_name:
+                raise _mode_error("TEAM_NAME_INVALID", "team name must not be blank")
+            if normalized_name in team_names:
+                raise _mode_error(
+                    "TEAM_DUPLICATE",
+                    f"duplicate team '{team.team}' in teams payload",
+                )
+            team.team = normalized_name
+            team_names.add(normalized_name)
+
+        for player in players:
+            if player.team is None:
+                raise _mode_error(
+                    "PLAYER_TEAM_REQUIRED",
+                    f"player '{player.playerId}' is missing team in mode '{mode}'",
+                )
+            normalized_player_team = str(player.team).strip().lower()
+            if normalized_player_team not in team_names:
+                raise _mode_error(
+                    "PLAYER_TEAM_UNKNOWN",
+                    f"player '{player.playerId}' references unknown team '{player.team}'",
+                )
+            player.team = normalized_player_team
+
+        return values
 
     class Config:
         extra = "allow"

--- a/ladder_service/tests/test_api.py
+++ b/ladder_service/tests/test_api.py
@@ -15,6 +15,7 @@ sys.path.insert(0, str(REPO_ROOT))
 from ladder_service.ladder_service import main
 from ladder_service.ladder_service.db import session_scope
 from ladder_service.ladder_service.models import Base
+from ladder_service.ladder_service.schemas import _TEAM_MODES, _VALID_GAMETYPES
 
 
 @pytest.fixture(scope="module", autouse=True)
@@ -57,6 +58,21 @@ MATCH_TEMPLATE = {
         }
     ],
 }
+
+
+def _build_match(match_id: str, mode: str) -> dict[str, object]:
+    payload = {
+        **MATCH_TEMPLATE,
+        "matchId": match_id,
+        "mode": mode,
+    }
+    if mode in _TEAM_MODES:
+        payload["teams"] = [{"team": "red", "rawScore": 10}, {"team": "blue", "rawScore": 8}]
+        payload["players"] = [{**MATCH_TEMPLATE["players"][0], "team": "red"}]
+    else:
+        payload["teams"] = None
+        payload["players"] = [{**MATCH_TEMPLATE["players"][0], "team": None}]
+    return payload
 
 
 def test_create_match() -> None:
@@ -105,11 +121,7 @@ def test_list_matches_filter_mode() -> None:
 
 
 def test_list_matches_supports_team_race_dm_mode() -> None:
-    match = {
-        **MATCH_TEMPLATE,
-        "matchId": "srv-20240405-183011-44",
-        "mode": "GT_TEAM_RACING_DM",
-    }
+    match = _build_match("srv-20240405-183011-44", "GT_TEAM_RACING_DM")
     created = client.post("/api/v1/matches", json=match)
     assert created.status_code == 201, created.text
 
@@ -139,6 +151,74 @@ def test_create_match_accepts_sprint_mode() -> None:
     assert payload["mode"] == "GT_SPRINT"
 
     cleanup = client.delete(f"/api/v1/matches/{match['matchId']}")
+    assert cleanup.status_code == 204
+
+
+def test_mode_forbids_teams_with_validation_codes() -> None:
+    match = _build_match("srv-20240405-183011-46", "GT_RACING")
+    match["teams"] = [{"team": "red", "rawScore": 1}]
+
+    response = client.post("/api/v1/matches", json=match)
+    assert response.status_code == 422, response.text
+    data = response.json()
+    assert "MODE_FORBIDS_TEAMS" in data["validation"]["errorCodes"]
+    assert any(item["errorCode"] == "MODE_FORBIDS_TEAMS" for item in data["detail"])
+
+
+def test_team_mode_requires_teams() -> None:
+    match = _build_match("srv-20240405-183011-47", "GT_TEAM")
+    match["teams"] = None
+
+    response = client.post("/api/v1/matches", json=match)
+    assert response.status_code == 422, response.text
+    assert "MODE_REQUIRES_TEAMS" in response.json()["validation"]["errorCodes"]
+
+
+def test_team_mode_rejects_unknown_player_team() -> None:
+    match = _build_match("srv-20240405-183011-48", "GT_CTF")
+    match["players"][0]["team"] = "spectator"
+
+    response = client.post("/api/v1/matches", json=match)
+    assert response.status_code == 422, response.text
+    assert "PLAYER_TEAM_UNKNOWN" in response.json()["validation"]["errorCodes"]
+
+
+def test_non_team_mode_sanitizes_player_team() -> None:
+    match = _build_match("srv-20240405-183011-49", "GT_ELIMINATION")
+    match["players"][0]["team"] = "red"
+
+    response = client.post("/api/v1/matches", json=match)
+    assert response.status_code == 201, response.text
+
+    stored = client.get(f"/api/v1/matches/{match['matchId']}")
+    assert stored.status_code == 200, stored.text
+    data = stored.json()
+    assert data["players"][0]["team"] is None
+    assert data["teams"] is None
+
+    cleanup = client.delete(f"/api/v1/matches/{match['matchId']}")
+    assert cleanup.status_code == 204
+
+
+@pytest.mark.parametrize("mode", sorted(_VALID_GAMETYPES))
+def test_all_modes_accept_mode_specific_payload(mode: str) -> None:
+    match_id = f"srv-20240405-183011-{mode.lower()}"
+    match = _build_match(match_id, mode)
+
+    created = client.post("/api/v1/matches", json=match)
+    assert created.status_code == 201, f"{mode}: {created.text}"
+
+    stored = client.get(f"/api/v1/matches/{match_id}")
+    assert stored.status_code == 200, f"{mode}: {stored.text}"
+    payload = stored.json()
+    if mode in _TEAM_MODES:
+        assert payload["teams"] is not None
+        assert payload["players"][0]["team"] == "red"
+    else:
+        assert payload["teams"] is None
+        assert payload["players"][0]["team"] is None
+
+    cleanup = client.delete(f"/api/v1/matches/{match_id}")
     assert cleanup.status_code == 204
 
 


### PR DESCRIPTION
### Motivation
- Ensure the service enforces mode-specific payload rules (required/forbidden fields) and normalizes irrelevant fields server-side to prevent inconsistent or ambiguous data being stored. 
- Provide clear, machine-readable validation feedback (error codes) to help clients debug invalid payloads. 
- Cover the new behavior with automated tests across all supported game modes.

### Description
- Add `_TEAM_MODES` and a `_mode_error` helper and implement a `@root_validator` on `MatchCreate` that enforces mode-specific rules, normalizes team/player team fields, and raises typed validation errors such as `MODE_REQUIRES_TEAMS`, `MODE_FORBIDS_TEAMS`, `PLAYER_TEAM_UNKNOWN`, `TEAM_DUPLICATE`, and `TEAM_NAME_INVALID` in `ladder_service/ladder_service/schemas.py`.
- Server-side sanitization: non-team modes have `player.team` and `teams` cleared, and team modes normalize team names and player team references to lowercase.
- Add a custom `RequestValidationError` handler in `ladder_service/ladder_service/main.py` that injects per-error `errorCode` fields and returns a top-level `validation.errorCodes` array for aggregated client-side debugging, and make the 409 conflict response include `MATCH_ID_CONFLICT`.
- Extend `ladder_service/tests/test_api.py` with a `_build_match` helper and new tests for forbidden/required `teams`, unknown player-team rejection, sanitization in non-team modes, and a parametrized test that exercises payload behavior across all `_VALID_GAMETYPES`.

### Testing
- Ran `pytest -q ladder_service/tests/test_api.py`, which passed with `25 passed` and 1 warning. 
- All added tests for mode-specific validation, sanitization, and error-code propagation succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd5dbeeb048323b7da89ff6ba86e6e)