### PR TITLE
Rebalance profile scoring and prevent duplicate match-outcome scoring

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -12,6 +12,7 @@ Changed:
 
 - Match payload validation now enforces mode-specific required fields instead of generic score-only acceptance.
 - Deprecated aliases are still accepted, but normalized to canonical mode-aware fields during ingest.
+- Profile scoring rebalanced for fairer progression: lower achievement/death/loss inflation, higher objective rewards (CTF/Domination), reduced online positive-score multiplier (1.25x -> 1.10x), race win raised to +12, and explicit race placement handling to avoid duplicate match-outcome scoring while adding separate P2/P3 podium bonuses.
 
 Breaking Changes:
 

--- a/engine/code/game/g_client.c
+++ b/engine/code/game/g_client.c
@@ -1297,10 +1297,13 @@ void ClientBegin( int clientNum ) {
 	}
 //	trap_SendServerCommand( -1, va("raceTime %i", level.startRaceTime) );
 
-        client->buttons = 0;
-        client->oldbuttons = 0;
-        client->lastCheckpointTime = 0;
-        G_ResetClientLapData( client );
+	client->buttons = 0;
+	client->oldbuttons = 0;
+	client->lastCheckpointTime = 0;
+	client->pers.profileRacePlacementPenalized = qfalse;
+	client->pers.profileRacePlacementRecorded = qfalse;
+	client->pers.profileMatchOutcomeRecorded = qfalse;
+	G_ResetClientLapData( client );
 // END
 
         if ( ent->r.linked ) {
@@ -1938,5 +1941,4 @@ void ClientDisconnect( int clientNum ) {
 		BotAIShutdownClient( clientNum, qfalse );
 	}
 }
-
 

--- a/engine/code/game/g_local.h
+++ b/engine/code/game/g_local.h
@@ -436,6 +436,8 @@ typedef struct {
 	qboolean	manualShift;		// shift manually?
 	char                    vehicleClass[MAX_QPATH];
         qboolean        profileRacePlacementPenalized; // profile penalty for poor race placement already applied
+        qboolean        profileRacePlacementRecorded;  // race placement score/podium already processed for this match
+        qboolean        profileMatchOutcomeRecorded;   // win/loss scoring already processed for this match
         char            uuid[PROFILE_MAX_UUID];         // cl_uuid aus dem Userinfo; leer wenn kein UUID-Client
 // END
 } clientPersistant_t;

--- a/engine/code/game/g_profile.c
+++ b/engine/code/game/g_profile.c
@@ -11,16 +11,20 @@
 #define PROFILE_AUTOSAVE_INTERVAL 30000
 #define PROFILE_DISPLAY_L_PER_100KM 9.0f
 #define PROFILE_SCORE_FRAG 2
-#define PROFILE_SCORE_DEATH -2
+#define PROFILE_SCORE_DEATH -1
 #define PROFILE_SCORE_SUICIDE -5
-#define PROFILE_SCORE_FLAG_CAPTURE 5
-#define PROFILE_SCORE_FLAG_ASSIST 2
-#define PROFILE_SCORE_DOMINATION_CAPTURE 5
-#define PROFILE_SCORE_LAP 2
-#define PROFILE_SCORE_LEAD_LAP 2
-#define PROFILE_SCORE_RACE_WIN 10
+#define PROFILE_SCORE_FLAG_CAPTURE 7
+#define PROFILE_SCORE_FLAG_ASSIST 4
+#define PROFILE_SCORE_DOMINATION_CAPTURE 6
+#define PROFILE_SCORE_LAP 1
+#define PROFILE_SCORE_LEAD_LAP 1
+#define PROFILE_SCORE_RACE_WIN 12
 #define PROFILE_SCORE_ELIMINATION_WIN 10
-#define PROFILE_SCORE_ACHIEVEMENT_TIER 20
+#define PROFILE_SCORE_ACHIEVEMENT_TIER 8
+#define PROFILE_SCORE_LOSS_PENALTY_NON_RACING -2
+#define PROFILE_SCORE_RACE_PLACEMENT_PENALTY -5
+#define PROFILE_SCORE_RACE_PLACE_SECOND 6
+#define PROFILE_SCORE_RACE_PLACE_THIRD 3
 
 #define PROFILE_RANK_ENTRY( name, threshold ) { name, threshold },
 static const profile_rank_def_t s_profileRankTable[] = {
@@ -1708,11 +1712,11 @@ void G_Profile_AddScore( int delta ) {
         return;
     }
 
-    /* Online-Bonus: Score-Punkte werden mit 1.25 multipliziert wenn
+    /* Online-Bonus: Score-Punkte werden mit 1.10 multipliziert wenn
      * der Spieler über einen dedizierten Server verbunden ist.
      * Nur auf positive Deltas — Strafen bleiben unverändert. */
     if ( s_profileState.isOnlineSession && delta > 0 ) {
-        delta = (int)( delta * 1.25f );
+        delta = (int)( delta * 1.10f );
         if ( delta < 1 ) delta = 1;
     }
 
@@ -1852,6 +1856,8 @@ void G_Profile_RecordLapComplete( gclient_t *client, qboolean isLeader, qboolean
 }
 
 void G_Profile_RecordRacePlacement( gclient_t *client, int position ) {
+    int placementScore = 0;
+
     if ( !G_Profile_ShouldTrackClient( client ) ) {
         return;
     }
@@ -1861,6 +1867,10 @@ void G_Profile_RecordRacePlacement( gclient_t *client, int position ) {
     }
 
     if ( position <= 0 ) {
+        return;
+    }
+
+    if ( client->pers.profileRacePlacementRecorded ) {
         return;
     }
 
@@ -1883,16 +1893,24 @@ void G_Profile_RecordRacePlacement( gclient_t *client, int position ) {
             break;
         }
         s_profileState.dirty = qtrue;
-        return;
+        if ( position == 2 ) {
+            placementScore = PROFILE_SCORE_RACE_PLACE_SECOND;
+        } else if ( position == 3 ) {
+            placementScore = PROFILE_SCORE_RACE_PLACE_THIRD;
+        }
+    } else {
+        /* Position schlechter als 3 — Strafpunkte */
+        if ( !client->pers.profileRacePlacementPenalized ) {
+            G_Profile_AddScore( PROFILE_SCORE_RACE_PLACEMENT_PENALTY );
+            client->pers.profileRacePlacementPenalized = qtrue;
+        }
     }
 
-    /* Position schlechter als 3 — Strafpunkte */
-    if ( client->pers.profileRacePlacementPenalized ) {
-        return;
-    }
+    client->pers.profileRacePlacementRecorded = qtrue;
 
-    G_Profile_AddScore( -5 );
-    client->pers.profileRacePlacementPenalized = qtrue;
+    if ( placementScore != 0 ) {
+        G_Profile_AddScore( placementScore );
+    }
 }
 
 /* Gesamte Rennzeit für Racing-Modi akkumulieren.
@@ -2018,6 +2036,11 @@ void G_Profile_RecordWin( gclient_t *client ) {
         return;
     }
 
+    if ( client->pers.profileMatchOutcomeRecorded ) {
+        return;
+    }
+    client->pers.profileMatchOutcomeRecorded = qtrue;
+
     s_profileState.stats.wins++;
     s_profileState.dirty = qtrue;
 
@@ -2102,6 +2125,11 @@ void G_Profile_RecordLoss( gclient_t *client ) {
         return;
     }
 
+    if ( client->pers.profileMatchOutcomeRecorded ) {
+        return;
+    }
+    client->pers.profileMatchOutcomeRecorded = qtrue;
+
     s_profileState.stats.losses++;
     s_profileState.stats.gamesPlayed++;
     s_profileState.dirty = qtrue;
@@ -2156,7 +2184,7 @@ void G_Profile_RecordLoss( gclient_t *client ) {
     }
 
     if ( G_Profile_ShouldTrackClient( client ) && !G_Profile_IsRacingGametype() ) {
-        G_Profile_AddScore( -5 );
+        G_Profile_AddScore( PROFILE_SCORE_LOSS_PENALTY_NON_RACING );
     }
 }
 


### PR DESCRIPTION
### Motivation

- Profil-Scoring ist neu zu balancieren, damit Achievements, Tode und Niederlagen weniger stark aufblähen und Objektive mehr Gewicht bekommen.
- Der Online-Positiv-Multiplikator soll reduziert werden, negative Deltas dürfen weiterhin nicht verstärkt werden.
- Doppelvergabe derselben Match-Ergebnisse (Win/Loss/Placement) innerhalb eines Match-Lifecycles muss verhindert werden; zusätzliche Podiumsboni (P2/P3) sollen separat vergaben werden.

### Description

- Angepasste Score-Konstanten in `engine/code/game/g_profile.c`: `PROFILE_SCORE_ACHIEVEMENT_TIER = 8`, `PROFILE_SCORE_DEATH = -1`, `PROFILE_SCORE_FLAG_CAPTURE = 7`, `PROFILE_SCORE_FLAG_ASSIST = 4`, `PROFILE_SCORE_DOMINATION_CAPTURE = 6`, `PROFILE_SCORE_LAP = 1`, `PROFILE_SCORE_LEAD_LAP = 1`, `PROFILE_SCORE_RACE_WIN = 12`, `PROFILE_SCORE_SUICIDE` unverändert; hinzugefügt `PROFILE_SCORE_LOSS_PENALTY_NON_RACING = -2`, `PROFILE_SCORE_RACE_PLACEMENT_PENALTY = -5`, `PROFILE_SCORE_RACE_PLACE_SECOND = 6`, `PROFILE_SCORE_RACE_PLACE_THIRD = 3`.
- Reduktion des Online-Bonus in `G_Profile_AddScore` von `1.25x` auf `1.10x` und weiterhin nur auf positive Deltas (`delta > 0`), Strafpunkte bleiben unverstärkt.
- Podiumsbehandlung in `G_Profile_RecordRacePlacement` erweitert: getrennte P2/P3-Boni implementiert und Out-of-podium-Strafe beibehalten; Placement-Score nur einmal pro Match gewährt.
- Schutz gegen doppelte Vergaben: neue Persistenzflags `profileRacePlacementRecorded` und `profileMatchOutcomeRecorded` in `clientPersistant_t` (`engine/code/game/g_local.h`), Reset bei `ClientBegin` (`engine/code/game/g_client.c`), und Guards in `G_Profile_RecordWin`, `G_Profile_RecordLoss` und `G_Profile_RecordRacePlacement` (`engine/code/game/g_profile.c`).
- Changelog-Eintrag in `changelog.txt` ergänzt, der das Balancing-Update kurz erläutert.

### Testing

- Automatisierte Code-Suche mit `rg` genutzt, um alle betroffenen Konstanten und Stellen (`G_Profile_AddScore`, `G_Profile_RecordWin/Loss/RacePlacement`, Flags) zu finden und die Änderungen zu verifizieren; die erwarteten neuen/angepassten Symbole erscheinen in den modifizierten Dateien.
- Dateiinhalte und relevante Ausschnitte per non-interaktiven Anzeige (`sed`/`nl`) geprüft, um die korrekte Einfügung der Flags und Guards sicherzustellen.
- Repository-Status geprüft und die vier betroffenen Dateien (`g_profile.c`, `g_local.h`, `g_client.c`, `changelog.txt`) nach Änderung bestätigt.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd740ce6208323a920a32bd4164304)