### PR TITLE
Harden profile match outcome deltas and team handling

### DIFF
--- a/ladder_service/php_webservice/index.php
+++ b/ladder_service/php_webservice/index.php
@@ -4941,6 +4941,8 @@ function profile_upsert_from_payload(array $payload): void
     }
 
     $mode = $payload['mode'] ?? '';
+    $teamModes = ['GT_TEAM', 'GT_TEAM_RACING', 'GT_TEAM_RACING_DM', 'GT_CTF', 'GT_CTF4', 'GT_DOMINATION', 'GT_KOTH'];
+    $isTeamMode = in_array($mode, $teamModes, true);
     $winnerClientNum = -1;
     $hasWinnerClientNum = false;
     if (array_key_exists('winnerClientNum', $payload) &&
@@ -4958,6 +4960,79 @@ function profile_upsert_from_payload(array $payload): void
         // Legacy fallback: old payloads nested the winner in settings.
         $winnerClientNum = (int) $payload['settings']['winnerClientNum'];
         $hasWinnerClientNum = true;
+    }
+
+    $humanPlayers = [];
+    foreach ($players as $candidate) {
+        if (!is_array($candidate) || !empty($candidate['isBot'])) {
+            continue;
+        }
+        $candidateClientNum = (int)($candidate['clientNum'] ?? -1);
+        $candidateTeam = isset($candidate['team']) && is_string($candidate['team']) ? strtolower(trim($candidate['team'])) : '';
+        $humanPlayers[] = [
+            'clientNum' => $candidateClientNum,
+            'team' => $candidateTeam,
+            'position' => (int)($candidate['position'] ?? 0),
+        ];
+    }
+
+    $winnerTeam = null;
+    if ($isTeamMode) {
+        if ($hasWinnerClientNum) {
+            foreach ($humanPlayers as $hp) {
+                if ($hp['clientNum'] === $winnerClientNum && $hp['team'] !== '') {
+                    $winnerTeam = $hp['team'];
+                    break;
+                }
+            }
+        }
+        if ($winnerTeam === null && isset($payload['teams']) && is_array($payload['teams'])) {
+            $topScore = null;
+            $topTeam = null;
+            $isTie = false;
+            foreach ($payload['teams'] as $teamEntry) {
+                if (!is_array($teamEntry)) {
+                    continue;
+                }
+                $teamName = isset($teamEntry['team']) && is_string($teamEntry['team']) ? strtolower(trim($teamEntry['team'])) : '';
+                if ($teamName === '') {
+                    continue;
+                }
+                $score = null;
+                foreach (['rawScore', 'score', 'points'] as $field) {
+                    if (array_key_exists($field, $teamEntry) &&
+                        (is_int($teamEntry[$field]) || is_float($teamEntry[$field]) ||
+                         (is_string($teamEntry[$field]) && is_numeric($teamEntry[$field])))) {
+                        $score = (float) $teamEntry[$field];
+                        break;
+                    }
+                }
+                if ($score === null) {
+                    continue;
+                }
+                if ($topScore === null || $score > $topScore) {
+                    $topScore = $score;
+                    $topTeam = $teamName;
+                    $isTie = false;
+                } elseif ($score === $topScore) {
+                    $isTie = true;
+                }
+            }
+            if (!$isTie && $topTeam !== null) {
+                $winnerTeam = $topTeam;
+            }
+        }
+    }
+
+    if (!$hasWinnerClientNum && !$isTeamMode) {
+        $positionOne = array_values(array_filter(
+            $humanPlayers,
+            static fn($hp) => (int)($hp['position'] ?? 0) === 1
+        ));
+        if (count($positionOne) === 1) {
+            $winnerClientNum = (int)$positionOne[0]['clientNum'];
+            $hasWinnerClientNum = $winnerClientNum >= 0;
+        }
     }
 
     foreach ($players as $player) {
@@ -4989,7 +5064,10 @@ function profile_upsert_from_payload(array $payload): void
         $clientNum  = (int)($player['clientNum'] ?? -1);
         $position   = (int)($player['position'] ?? 0);
         $isRaceMode = mode_is_race($mode);
-        $isWinner   = $hasWinnerClientNum && $winnerClientNum >= 0 && $winnerClientNum === $clientNum;
+        $playerTeam = isset($player['team']) && is_string($player['team']) ? strtolower(trim($player['team'])) : '';
+        $isWinnerByClient = $hasWinnerClientNum && $winnerClientNum >= 0 && $winnerClientNum === $clientNum;
+        $isWinnerByTeam = $isTeamMode && $winnerTeam !== null && $playerTeam !== '' && $playerTeam === $winnerTeam;
+        $isWinner = $isTeamMode ? $isWinnerByTeam : $isWinnerByClient;
 
         error_log(sprintf(
             '[profile_upsert_from_payload] winner-check mode=%s clientNum=%d winnerClientNum=%s',
@@ -5039,9 +5117,21 @@ function profile_upsert_from_payload(array $payload): void
             return $base + $delta;
         };
 
-        $derivedWins   = $isWinner ? 1 : 0;
-        // Fallback-Regel: Ohne valide Winner-Information werden weder Win noch Loss inkrementiert.
-        $derivedLosses = $hasWinnerClientNum ? ($isWinner ? 0 : 1) : 0;
+        $pickCareerWithBaselineDelta = function(string $key, int $delta = 0) use ($snap, $existing, $countThisMatch): int {
+            $base = (int)($existing[$key] ?? 0);
+            $snapValue = profile_snapshot_int($snap, $key);
+            if ($snapValue !== null) {
+                $base = max($base, $snapValue);
+            }
+            if (!$countThisMatch) {
+                return $base;
+            }
+            return $base + $delta;
+        };
+
+        $hasOutcome = $isTeamMode ? ($winnerTeam !== null) : ($hasWinnerClientNum && $winnerClientNum >= 0);
+        $derivedWins = ($hasOutcome && $isWinner) ? 1 : 0;
+        $derivedLosses = ($hasOutcome && !$isWinner) ? 1 : 0;
 
         $isDmMode = mode_is_deathmatch_like($mode);
         $racingWinDelta = 0;
@@ -5178,8 +5268,8 @@ function profile_upsert_from_payload(array $payload): void
             'gamesPlayed'     => (int)($existing['gamesPlayed'] ?? 0) + ($countThisMatch ? 1 : 0),
 
             // ── Allgemein ───────────────────────────────────────────────
-            'wins'            => $pickCareer('wins', $derivedWins),
-            'losses'          => $pickCareer('losses', $derivedLosses),
+            'wins'            => $pickCareerWithBaselineDelta('wins', $derivedWins),
+            'losses'          => $pickCareerWithBaselineDelta('losses', $derivedLosses),
             'kills'           => $pickCareer('kills', max(0, $matchKills)),
             'deaths'          => $pickCareer('deaths', max(0, $matchDeaths)),
             'flagCaptures'    => (int)($existing['flagCaptures'] ?? 0) + (int)($player['captures']    ?? 0),

--- a/ladder_service/tests/test_mode_e2e_matrix.py
+++ b/ladder_service/tests/test_mode_e2e_matrix.py
@@ -363,7 +363,7 @@ def test_php_profile_upsert_prefers_valid_snapshot(php_env: dict[str, Any]) -> N
     assert status == 201, created
 
     profile = _get_php_profile(php_env, player_id)
-    assert profile["wins"] == 11
+    assert profile["wins"] == 12
     assert profile["losses"] == 5
     assert profile["kills"] == 81
     assert profile["deaths"] == 44
@@ -463,6 +463,48 @@ def test_php_profile_missing_winner_field_is_graceful(php_env: dict[str, Any]) -
 
     profile = _get_php_profile(php_env, player_id)
     assert profile["wins"] == 0
-    assert profile["losses"] == 1
+    assert profile["losses"] == 0
     assert profile["dmWins"] == 0
     assert profile["dmCompleted"] == 1
+
+
+def test_php_profile_team_mode_applies_team_win_loss_delta(php_env: dict[str, Any]) -> None:
+    winner_id = "fdde3dae-c8c7-4c36-a60d-145b7ad95c25"
+    loser_id = "0dd4d0a4-80ef-4d7d-93bd-c4e9c4e8ab16"
+    payload = generate_golden_payload("GT_TEAM")
+    payload["matchId"] = "profile-team-delta-1"
+    payload["winnerClientNum"] = 1
+    payload["settings"]["winnerClientNum"] = 1
+    payload["players"] = [
+        {
+            "playerId": winner_id,
+            "clientNum": 1,
+            "displayName": "Winner",
+            "team": "red",
+            "kills": 3,
+            "deaths": 1,
+            "position": 1,
+            "profile": {"valid": True, "wins": 4, "losses": 2},
+        },
+        {
+            "playerId": loser_id,
+            "clientNum": 2,
+            "displayName": "Loser",
+            "team": "blue",
+            "kills": 1,
+            "deaths": 3,
+            "position": 2,
+            "profile": {"valid": True, "wins": 9, "losses": 1},
+        },
+    ]
+    payload["teams"] = [{"team": "red", "rawScore": 10}, {"team": "blue", "rawScore": 5}]
+
+    status, created = _post_php_match(php_env, payload)
+    assert status == 201, created
+
+    winner = _get_php_profile(php_env, winner_id)
+    loser = _get_php_profile(php_env, loser_id)
+    assert winner["wins"] == 5
+    assert winner["losses"] == 2
+    assert loser["wins"] == 9
+    assert loser["losses"] == 2


### PR DESCRIPTION
### Motivation
- Make `profile_upsert_from_payload()` derive wins/losses from the actual match outcome instead of blindly trusting snapshot counters so match results are applied as deltas and remain idempotent per `matchId`.
- Support team modes by resolving wins/losses at team level (winner team → all team members get a win, opponents get a loss) and fall back to `teams` scores when needed.

### Description
- Reworked `profile_upsert_from_payload()` to collect human players up-front and to detect team modes via a `teamModes` list and `isTeamMode` flag.
- Added winner resolution for team matches: first try to map a top-level `winnerClientNum` to a team, then fall back to the highest `teams` score with tie detection; for non-team modes infer winner from `position==1` when `winnerClientNum` is missing.
- Compute per-match deltas (`wins`/`losses`) and apply them as deltas on top of a baseline computed as `max(existing, snapshot)` using a new `pickCareerWithBaselineDelta` helper so snapshots are only used as a starting point and match results are always applied as deltas.
- Preserve idempotency by honouring `_processedMatchIds` and only applying deltas when the current `matchId` has not been counted for that profile; use `pickCareer`/`pickCareerWithBaselineDelta` appropriately and switch `wins`/`losses` to the baseline+delta logic.
- Tests updated/added in `ladder_service/tests/test_mode_e2e_matrix.py` to reflect snapshot+delta behaviour and to assert team-mode win/loss distribution (`test_php_profile_team_mode_applies_team_win_loss_delta`).

### Testing
- Ran PHP syntax check: `php -l ladder_service/php_webservice/index.php` — no syntax errors.
- Executed targeted Python tests: `pytest -q tests/test_mode_e2e_matrix.py -k "profile_upsert_prefers_valid_snapshot or profile_upsert_derives_without_snapshot_and_is_idempotent or profile_missing_winner_field_is_graceful or profile_team_mode_applies_team_win_loss_delta"` — all selected tests passed (`4 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ddf8d4d95083238fa0a412314bf25d)