### PR TITLE
Mode-aware Racing-Statistik‑Updates in profile_upsert_from_payload

### DIFF
--- a/ladder_service/php_webservice/index.php
+++ b/ladder_service/php_webservice/index.php
@@ -4950,7 +4950,7 @@ function profile_upsert_from_payload(array $payload): void
          is_float($payload['winnerClientNum']) ||
          (is_string($payload['winnerClientNum']) && is_numeric($payload['winnerClientNum'])))) {
         $winnerClientNum = (int) $payload['winnerClientNum'];
-        $hasWinnerClientNum = true;
+        $hasWinnerClientNum = $winnerClientNum >= 0;
     } elseif (isset($payload['settings']) &&
               is_array($payload['settings']) &&
               array_key_exists('winnerClientNum', $payload['settings']) &&
@@ -4959,7 +4959,7 @@ function profile_upsert_from_payload(array $payload): void
                (is_string($payload['settings']['winnerClientNum']) && is_numeric($payload['settings']['winnerClientNum'])))) {
         // Legacy fallback: old payloads nested the winner in settings.
         $winnerClientNum = (int) $payload['settings']['winnerClientNum'];
-        $hasWinnerClientNum = true;
+        $hasWinnerClientNum = $winnerClientNum >= 0;
     }
 
     $humanPlayers = [];
@@ -5063,7 +5063,6 @@ function profile_upsert_from_payload(array $payload): void
         // ── Win-Detection ──────────────────────────────────────────────
         $clientNum  = (int)($player['clientNum'] ?? -1);
         $position   = (int)($player['position'] ?? 0);
-        $isRaceMode = mode_is_race($mode);
         $playerTeam = isset($player['team']) && is_string($player['team']) ? strtolower(trim($player['team'])) : '';
         $isWinnerByClient = $hasWinnerClientNum && $winnerClientNum >= 0 && $winnerClientNum === $clientNum;
         $isWinnerByTeam = $isTeamMode && $winnerTeam !== null && $playerTeam !== '' && $playerTeam === $winnerTeam;
@@ -5133,7 +5132,11 @@ function profile_upsert_from_payload(array $payload): void
         $derivedWins = ($hasOutcome && $isWinner) ? 1 : 0;
         $derivedLosses = ($hasOutcome && !$isWinner) ? 1 : 0;
 
-        $isDmMode = mode_is_deathmatch_like($mode);
+        $isRaceCareerMode = in_array($mode, ['GT_RACING', 'GT_RACING_DM', 'GT_SPRINT', 'GT_TEAM_RACING', 'GT_TEAM_RACING_DM'], true);
+        $racePosition = (int)($player['position'] ?? $player['rank'] ?? 0);
+        $isRacePodium = $racePosition > 0 && $racePosition <= 3;
+        $raceTotalMs = $isRaceCareerMode ? max(0, $matchRaceMs) : 0;
+
         $racingWinDelta = 0;
         $racingPodiumDelta = 0;
         $racingCompletedDelta = 0;
@@ -5180,15 +5183,15 @@ function profile_upsert_from_payload(array $payload): void
         switch ($mode) {
             case 'GT_RACING':
                 $racingWinDelta = $isWinner ? 1 : 0;
-                $racingPodiumDelta = ($position > 0 && $position <= 3) ? 1 : 0;
+                $racingPodiumDelta = $isRacePodium ? 1 : 0;
                 $racingCompletedDelta = 1;
-                $racingTotalMsDelta = max(0, $matchRaceMs);
+                $racingTotalMsDelta = $raceTotalMs;
                 break;
             case 'GT_RACING_DM':
                 $racingDmWinDelta = $isWinner ? 1 : 0;
-                $racingDmPodiumDelta = ($position > 0 && $position <= 3) ? 1 : 0;
+                $racingDmPodiumDelta = $isRacePodium ? 1 : 0;
                 $racingDmCompletedDelta = 1;
-                $racingDmTotalMsDelta = max(0, $matchRaceMs);
+                $racingDmTotalMsDelta = $raceTotalMs;
                 break;
             case 'GT_SPRINT':
                 $sprintWinDelta = $isWinner ? 1 : 0;
@@ -5209,9 +5212,9 @@ function profile_upsert_from_payload(array $payload): void
                 $derbyKillsDelta = max(0, $matchKills);
                 break;
             case 'GT_DEATHMATCH':
-                $dmWinDelta = ($isDmMode && !$isRaceMode && $isWinner) ? 1 : 0;
-                $dmCompletedDelta = ($isDmMode && !$isRaceMode) ? 1 : 0;
-                $dmKillsDelta = ($isDmMode && !$isRaceMode) ? max(0, $matchKills) : 0;
+                $dmWinDelta = $isWinner ? 1 : 0;
+                $dmCompletedDelta = 1;
+                $dmKillsDelta = max(0, $matchKills);
                 break;
             case 'GT_CTF':
                 $ctfWinDelta = $isWinner ? 1 : 0;
@@ -5231,12 +5234,12 @@ function profile_upsert_from_payload(array $payload): void
             case 'GT_TEAM_RACING':
                 $teamRacingWinDelta = $isWinner ? 1 : 0;
                 $teamRacingCompletedDelta = 1;
-                $teamRacingPodiumDelta = ($position > 0 && $position <= 3) ? 1 : 0;
+                $teamRacingPodiumDelta = $isRacePodium ? 1 : 0;
                 break;
             case 'GT_TEAM_RACING_DM':
                 $teamRacingDmWinDelta = $isWinner ? 1 : 0;
                 $teamRacingDmCompletedDelta = 1;
-                $teamRacingDmPodiumDelta = ($position > 0 && $position <= 3) ? 1 : 0;
+                $teamRacingDmPodiumDelta = $isRacePodium ? 1 : 0;
                 break;
             case 'GT_DOMINATION':
                 $dominationWinDelta = $isWinner ? 1 : 0;
@@ -5274,9 +5277,12 @@ function profile_upsert_from_payload(array $payload): void
             'deaths'          => $pickCareer('deaths', max(0, $matchDeaths)),
             'flagCaptures'    => (int)($existing['flagCaptures'] ?? 0) + (int)($player['captures']    ?? 0),
             'flagAssists'     => (int)($existing['flagAssists']  ?? 0) + (int)($player['assistCount'] ?? 0),
-            'bestLapMs'       => (function() use ($player, $existing, $snap) {
-                $new = (int)($snap['bestLapMs'] ?? $player['bestLapMs'] ?? 0);
+            'bestLapMs'       => (function() use ($player, $existing, $snap, $isRaceCareerMode) {
                 $old = (int)($existing['bestLapMs'] ?? 0);
+                if (!$isRaceCareerMode) {
+                    return $old;
+                }
+                $new = (int)($snap['bestLapMs'] ?? $player['bestLapMs'] ?? 0);
                 if ($new > 0 && ($old === 0 || $new < $old)) return $new;
                 return $old ?: $new;
             })(),

--- a/ladder_service/tests/test_mode_e2e_matrix.py
+++ b/ladder_service/tests/test_mode_e2e_matrix.py
@@ -419,6 +419,46 @@ def test_php_profile_race_and_dm_wins_increment_separately(php_env: dict[str, An
     assert profile["dmWins"] == 1
 
 
+def test_php_profile_racing_dm_updates_racing_fields_not_dm_bucket(php_env: dict[str, Any]) -> None:
+    player_id = "b40f7ebf-036f-4d3f-81a5-a0f3f8195d5d"
+
+    payload = _profile_payload("profile-racing-dm-only-racing", "GT_RACING_DM", player_id)
+    payload["players"][0].pop("profile", None)
+    payload["players"][0]["position"] = 2
+    payload["players"][0]["bestLapMs"] = 65432
+
+    status, created = _post_php_match(php_env, payload)
+    assert status == 201, created
+
+    profile = _get_php_profile(php_env, player_id)
+    assert profile["racingDmWins"] == 1
+    assert profile["racingDmCompleted"] == 1
+    assert profile["racingDmPodiums"] == 1
+    assert profile["racingDmTotalMs"] == 77777
+    assert profile["dmWins"] == 0
+    assert profile["dmCompleted"] == 0
+    assert profile["dmKills"] == 0
+
+
+def test_php_profile_best_lap_updates_only_in_race_career_modes(php_env: dict[str, Any]) -> None:
+    player_id = "6164e8ce-cc2e-4cc0-b5a5-65f69f8f7f38"
+
+    race_payload = _profile_payload("profile-best-lap-race", "GT_RACING", player_id)
+    race_payload["players"][0].pop("profile", None)
+    race_payload["players"][0]["bestLapMs"] = 11111
+    race_status, race_created = _post_php_match(php_env, race_payload)
+    assert race_status == 201, race_created
+
+    dm_payload = _profile_payload("profile-best-lap-dm", "GT_DEATHMATCH", player_id)
+    dm_payload["players"][0].pop("profile", None)
+    dm_payload["players"][0]["bestLapMs"] = 999
+    dm_status, dm_created = _post_php_match(php_env, dm_payload)
+    assert dm_status == 201, dm_created
+
+    profile = _get_php_profile(php_env, player_id)
+    assert profile["bestLapMs"] == 11111
+
+
 def test_php_profile_dm_uses_top_level_winner_client_num(php_env: dict[str, Any]) -> None:
     player_id = "8ef82988-d418-443f-bb09-00143874ece1"
     payload = _profile_payload("profile-dm-top-level-winner", "GT_DEATHMATCH", player_id)


### PR DESCRIPTION
### Motivation
- Racing-spezifische Career-Felder (Wins/Podiums/Completed/TotalMs, team-varianten und bestLapMs) sollen nur in echten Renn‑Karrieremodi inkrementiert werden, damit z.B. GT_RACING_DM nicht fälschlich Deathmatch-Zähler beeinflusst.
- Podium-/Platzinformationen müssen verlässlich aus Player-Daten (position / rank) abgeleitet werden, damit Winner-Fallbacks korrekt funktionieren.
- `bestLapMs`/`totalMs` dürfen nur in Renn‑Karrieremodi aktualisiert werden.
- Negative `winnerClientNum`-Werte sollen als „fehlend“ gelten, damit Non-Team-Modi auf positionsbasiertes Winner-Fallback zurückfallen können.

### Description
- Treat `winnerClientNum < 0` as missing to allow position-based winner fallback in non-team modes by tightening winner detection logic.
- Introduced `$isRaceCareerMode` (GT_RACING, GT_RACING_DM, GT_SPRINT, GT_TEAM_RACING, GT_TEAM_RACING_DM) and derive `$racePosition` / `$isRacePodium` once per player for reuse in deltas.
- Gate race total time (`racingTotalMs` / `racingDmTotalMs`) via `$raceTotalMs` so only race career modes contribute time, and reuse `$isRacePodium` for racing and team-racing podium counters.
- Restrict `bestLapMs` profile updates to race-career modes by checking `$isRaceCareerMode` inside the existing closure.
- Make `GT_DEATHMATCH` branch explicitly update DM counters only for that mode so Racing-DM modes do not increment deathmatch buckets.
- Added two PHPUnit-style integration tests (Python test additions) to validate: GT_RACING_DM updates racing-DM fields (not DM bucket) and `bestLapMs` updates only in race career modes.

### Testing
- Linted PHP file with `php -l ladder_service/php_webservice/index.php` and received no syntax errors (passed).
- Ran targeted pytest: `pytest -q ladder_service/tests/test_mode_e2e_matrix.py -k "profile_race_and_dm_wins_increment_separately or profile_racing_dm_updates_racing_fields_not_dm_bucket or profile_best_lap_updates_only_in_race_career_modes"` and all tests passed (3 passed, 21 deselected).
- These automated checks confirm the new mode-aware deltas and `bestLapMs` gating behave as expected.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ddfb05c1048323973d8df4d74ac997)