### PR TITLE
Fix mode bucket classification and profile visibility (add GT_KOTH, separate Derby/LCS)

### DIFF
--- a/ladder_service/php_webservice/index.php
+++ b/ladder_service/php_webservice/index.php
@@ -1286,7 +1286,8 @@ try {
       { key: 'gt_team_racing_dm', type: 'race' },
       { key: 'gt_ctf', type: 'objective' },
       { key: 'gt_ctf4', type: 'objective' },
-      { key: 'gt_domination', type: 'objective' }
+      { key: 'gt_domination', type: 'objective' },
+      { key: 'gt_koth', type: 'objective' }
     ];
 
     const LEVELSHOT_EXTENSIONS = ['webp', 'png', 'jpg', 'jpeg', 'tga'];
@@ -1632,7 +1633,8 @@ try {
         gt_team_racing_dm: 'Team Racing Deathmatch',
         gt_ctf: 'Capture the Flag',
         gt_ctf4: '4-Teams-CTF',
-        gt_domination: 'Domination'
+        gt_domination: 'Domination',
+        gt_koth: 'King of the Hill'
       },
       en: {
         gt_racing: 'Racing',
@@ -1647,7 +1649,8 @@ try {
         gt_team_racing_dm: 'Team Racing Deathmatch',
         gt_ctf: 'Capture the Flag',
         gt_ctf4: '4-Team CTF',
-        gt_domination: 'Domination'
+        gt_domination: 'Domination',
+        gt_koth: 'King of the Hill'
       }
     };
 
@@ -1655,7 +1658,7 @@ try {
     const DEATHMATCH_MODE_KEYS = new Set(['gt_deathmatch', 'gt_team']);
     const DERBY_MODE_KEYS = new Set(['gt_derby']);
     const SURVIVAL_MODE_KEYS = new Set(['gt_lcs']);
-    const OBJECTIVE_MODE_KEYS = new Set(['gt_ctf', 'gt_ctf4', 'gt_elimination', 'gt_domination']);
+    const OBJECTIVE_MODE_KEYS = new Set(['gt_ctf', 'gt_ctf4', 'gt_elimination', 'gt_domination', 'gt_koth']);
 
     const OBJECTIVE_METRIC_DEFINITIONS = {
       captures: {
@@ -1730,6 +1733,7 @@ try {
       gt_ctf4: ['captures', 'score', 'objectives', 'wins'],
       gt_elimination: ['wins', 'score', 'captures', 'objectives'],
       gt_domination: ['objectives', 'score', 'captures', 'wins'],
+      gt_koth: ['objectives', 'score', 'captures', 'wins'],
       gt_lcs: ['wins', 'score', 'captures', 'objectives']
     };
 
@@ -2263,7 +2267,17 @@ function getColumnsForMode(config) {
       { key: 'recorded', labelKey: 'leaderboard.headers.recorded' }
     ];
   }
-  if (config.type === 'deathmatch' || config.type === 'derby') {
+  if (config.type === 'deathmatch') {
+    return [
+      { key: 'rank', labelKey: 'deathmatch.headers.rank' },
+      { key: 'player', labelKey: 'deathmatch.headers.player' },
+      { key: 'kdr', labelKey: 'deathmatch.headers.kdr' },
+      { key: 'kills', labelKey: 'deathmatch.headers.kills' },
+      { key: 'deaths', labelKey: 'deathmatch.headers.deaths' },
+      { key: 'recorded', labelKey: 'deathmatch.headers.recorded' }
+    ];
+  }
+  if (config.type === 'derby') {
     return [
       { key: 'rank', labelKey: 'deathmatch.headers.rank' },
       { key: 'player', labelKey: 'deathmatch.headers.player' },
@@ -4465,25 +4479,29 @@ async function showPlayerProfile(playerId, playerName) {
     const colRight = document.createElement('div');
 
     const modeGroups = [
-      { title: 'Deathmatch',      fields: [['Wins','dmWins'],['Completed','dmCompleted'],['Kills','dmKills']] },
-      { title: 'Derby',           fields: [['Wins','derbyWins'],['Completed','derbyCompleted'],['Kills','derbyKills']] },
-      { title: 'Racing',          fields: [['Wins','racingWins'],['Podiums','racingPodiums'],['Completed','racingCompleted'],['Total Time',null,'racingTotalMs']] },
-      { title: 'Racing DM',       fields: [['Wins','racingDmWins'],['Podiums','racingDmPodiums'],['Completed','racingDmCompleted']] },
-      { title: 'Sprint',          fields: [['Wins','sprintWins'],['Completed','sprintCompleted'],['Best Time',null,'sprintBestMs']] },
-      { title: 'Elimination',     fields: [['Wins','eliminationWins'],['Completed','eliminationCompleted'],['Rounds Lasted','eliminationTotalRoundsLasted']] },
-      { title: 'LCS',             fields: [['Wins','lcsWins'],['Completed','lcsCompleted'],['Survival Time',null,'lcsTotalSurvivalMs']] },
-      { title: 'CTF',             fields: [['Wins','ctfWins'],['Completed','ctfCompleted'],['Captures','ctfCaptures']] },
-      { title: 'CTF 4-Team',      fields: [['Wins','ctf4Wins'],['Completed','ctf4Completed'],['Captures','ctf4Captures']] },
-      { title: 'Team DM',         fields: [['Wins','teamWins'],['Completed','teamCompleted'],['Kills','teamKills']] },
-      { title: 'Team Racing',     fields: [['Wins','teamRacingWins'],['Completed','teamRacingCompleted'],['Podiums','teamRacingPodiums']] },
-      { title: 'Team Racing DM',  fields: [['Wins','teamRacingDmWins'],['Completed','teamRacingDmCompleted'],['Podiums','teamRacingDmPodiums']] },
-      { title: 'Domination',      fields: [['Wins','dominationWins'],['Completed','dominationCompleted'],['Zone Hold',null,'dominationZoneHoldMs']] },
-      { title: 'King of the Hill', fields: [['Wins','kothWins'],['Completed','kothCompleted'],['Zone Hold',null,'kothZoneHoldMs']] },
+      { title: 'Deathmatch',      primaryStat: 'dmCompleted', fields: [['Wins','dmWins'],['Completed','dmCompleted'],['Kills','dmKills']] },
+      { title: 'Derby',           primaryStat: 'derbyCompleted', fields: [['Wins','derbyWins'],['Completed','derbyCompleted'],['Kills','derbyKills']] },
+      { title: 'Racing',          primaryStat: 'racingCompleted', fields: [['Wins','racingWins'],['Podiums','racingPodiums'],['Completed','racingCompleted'],['Total Time',null,'racingTotalMs']] },
+      { title: 'Racing DM',       primaryStat: 'racingDmCompleted', fields: [['Wins','racingDmWins'],['Podiums','racingDmPodiums'],['Completed','racingDmCompleted']] },
+      { title: 'Sprint',          primaryStat: 'sprintCompleted', fields: [['Wins','sprintWins'],['Completed','sprintCompleted'],['Best Time',null,'sprintBestMs']] },
+      { title: 'Elimination',     primaryStat: 'eliminationCompleted', fields: [['Wins','eliminationWins'],['Completed','eliminationCompleted'],['Rounds Lasted','eliminationTotalRoundsLasted']] },
+      { title: 'LCS',             primaryStat: 'lcsCompleted', fields: [['Wins','lcsWins'],['Completed','lcsCompleted'],['Survival Time',null,'lcsTotalSurvivalMs']] },
+      { title: 'CTF',             primaryStat: 'ctfCompleted', fields: [['Wins','ctfWins'],['Completed','ctfCompleted'],['Captures','ctfCaptures']] },
+      { title: 'CTF 4-Team',      primaryStat: 'ctf4Completed', fields: [['Wins','ctf4Wins'],['Completed','ctf4Completed'],['Captures','ctf4Captures']] },
+      { title: 'Team DM',         primaryStat: 'teamCompleted', fields: [['Wins','teamWins'],['Completed','teamCompleted'],['Kills','teamKills']] },
+      { title: 'Team Racing',     primaryStat: 'teamRacingCompleted', fields: [['Wins','teamRacingWins'],['Completed','teamRacingCompleted'],['Podiums','teamRacingPodiums']] },
+      { title: 'Team Racing DM',  primaryStat: 'teamRacingDmCompleted', fields: [['Wins','teamRacingDmWins'],['Completed','teamRacingDmCompleted'],['Podiums','teamRacingDmPodiums']] },
+      { title: 'Domination',      primaryStat: 'dominationCompleted', fields: [['Wins','dominationWins'],['Completed','dominationCompleted'],['Zone Hold',null,'dominationZoneHoldMs']] },
+      { title: 'King of the Hill', primaryStat: 'kothCompleted', fields: [['Wins','kothWins'],['Completed','kothCompleted'],['Zone Hold',null,'kothZoneHoldMs']] },
     ];
 
-    const activeModes = modeGroups.filter(g =>
-      g.fields.some(([,key,msKey]) => (key && (p[key]||0) > 0) || (msKey && (p[msKey]||0) > 0))
-    );
+    const activeModes = modeGroups.filter(g => {
+      const primaryActive = g.primaryStat ? (p[g.primaryStat] || 0) > 0 : false;
+      if (primaryActive) {
+        return true;
+      }
+      return g.fields.some(([,key,msKey]) => (key && (p[key]||0) > 0) || (msKey && (p[msKey]||0) > 0));
+    });
 
     if (activeModes.length > 0) {
       const modeH = document.createElement('h3');


### PR DESCRIPTION
### Motivation
- Ensure GT_DERBY and GT_LCS are not lumped into deathmatch logic and that objective modes include GT_KOTH so frontend filters, tabs and stats mapping are consistent. 
- Make profile Mode Stats reliably surface when a mode-specific metric exists (e.g. a racing match produces a Racing block in profile). 

### Description
- Added `gt_koth` to `MODE_CONFIG`, `MODE_TRANSLATIONS` and to the objective key set so KOTH is treated as an objective mode in the frontend and mode buckets. (file: `ladder_service/php_webservice/index.php`) 
- Extended `OBJECTIVE_MODE_KEYS` and `OBJECTIVE_MODE_PRIORITY` with `gt_koth` so objective metric selection and priority include KOTH. 
- Kept `LADDER_DEATHMATCH_MODES` unchanged and ensured `GT_DERBY` / `GT_LCS` remain in their dedicated buckets; made derby rendering explicit by splitting the previous combined `deathmatch || derby` branch into separate `deathmatch` and `derby` branches in `getColumnsForMode`. 
- Updated profile `modeGroups` to include a `primaryStat` per group (e.g. `racingCompleted`) and changed the `activeModes` predicate to check the `primaryStat` first so mode cards appear reliably when a matching recorded metric is present. 

### Testing
- Ran PHP syntax check: `php -l ladder_service/php_webservice/index.php` and it reported no syntax errors. (succeeded) 
- Executed a small static verification script that checks presence of `GT_KOTH` in `LADDER_OBJECTIVE_MODES`, `gt_koth` in `MODE_CONFIG`, `OBJECTIVE_MODE_KEYS` including `gt_koth`, and that `primaryStat: 'racingCompleted'` exists; all checks returned OK. (succeeded) 
- No browser-based UI screenshots or end-to-end UI runs were executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ddfdc4eadc8323919febdd19a03b59)