### PR TITLE
Prevent duplicate profile stat updates on repeated match payloads

### DIFF
--- a/ladder_service/php_webservice/README.md
+++ b/ladder_service/php_webservice/README.md
@@ -39,6 +39,7 @@ Jedes Match wird als einzelne JSON-Datei unter `data/<matchId>.json` abgelegt. S
 ## Backup & Wartung
 * Regelmäßig den Ordner `data/` sichern.
 * Bei sehr vielen Matches kann die Dateibasis unübersichtlich werden; für große Installationen empfiehlt sich langfristig dennoch eine vollwertige Datenbank.
+* Bei Upgrades der Profilstruktur kann `php migrate_profiles.php` ausgeführt werden, um bestehende `data/profiles/*.json` auf das neue Match-Dedupe-Tracking (`_processedMatchIds`, `_lastProcessedMatch`) zu migrieren.
 
 ## Fehlerbehandlung
 Fehlerhafte Anfragen werden als strukturiertes JSON beantwortet:

--- a/ladder_service/php_webservice/index.php
+++ b/ladder_service/php_webservice/index.php
@@ -4951,6 +4951,34 @@ function profile_snapshot_int(?array $snapshot, string $key): ?int
     return null;
 }
 
+function profile_match_checksum(string $matchId, string $mode, array $player): string
+{
+    $material = [
+        'matchId' => $matchId,
+        'mode' => $mode,
+        'playerId' => (string)($player['playerId'] ?? ''),
+        'clientNum' => (int)($player['clientNum'] ?? -1),
+        'score' => (int)($player['score'] ?? $player['rawScore'] ?? 0),
+        'kills' => (int)($player['kills'] ?? 0),
+        'deaths' => (int)($player['deaths'] ?? 0),
+        'position' => (int)($player['position'] ?? 0),
+    ];
+    return hash('sha256', json_encode($material, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE) ?: '');
+}
+
+function profile_normalize_processed_match_ids(array $profile): array
+{
+    $ids = array_values(array_filter((array)($profile['_processedMatchIds'] ?? []), 'is_string'));
+    $ids = array_values(array_filter(array_map('normalize_match_id', $ids), static fn($v) => $v !== ''));
+    if (empty($ids) && isset($profile['_lastProcessedMatchId']) && is_string($profile['_lastProcessedMatchId'])) {
+        $legacy = normalize_match_id($profile['_lastProcessedMatchId']);
+        if ($legacy !== '') {
+            $ids[] = $legacy;
+        }
+    }
+    return array_slice(array_values(array_unique($ids)), -200);
+}
+
 function profile_upsert_from_payload(array $payload): void
 {
     $players = $payload['players'] ?? [];
@@ -5074,7 +5102,7 @@ function profile_upsert_from_payload(array $payload): void
             ? $player['profile']
             : null;
         $matchId = isset($payload['matchId']) && is_string($payload['matchId']) ? normalize_match_id($payload['matchId']) : '';
-        $processedMatchIds = array_values(array_filter((array)($existing['_processedMatchIds'] ?? []), 'is_string'));
+        $processedMatchIds = profile_normalize_processed_match_ids($existing);
         $alreadyCounted = $matchId !== '' && in_array($matchId, $processedMatchIds, true);
         $countThisMatch = !$alreadyCounted;
 
@@ -5293,8 +5321,8 @@ function profile_upsert_from_payload(array $payload): void
             'losses'          => $pickCareerWithBaselineDelta('losses', $derivedLosses),
             'kills'           => $pickCareer('kills', max(0, $matchKills)),
             'deaths'          => $pickCareer('deaths', max(0, $matchDeaths)),
-            'flagCaptures'    => (int)($existing['flagCaptures'] ?? 0) + (int)($player['captures']    ?? 0),
-            'flagAssists'     => (int)($existing['flagAssists']  ?? 0) + (int)($player['assistCount'] ?? 0),
+            'flagCaptures'    => $pickCareer('flagCaptures', (int)($player['captures'] ?? 0)),
+            'flagAssists'     => $pickCareer('flagAssists', (int)($player['assistCount'] ?? 0)),
             'bestLapMs'       => (function() use ($player, $existing, $snap, $isRaceCareerMode) {
                 $old = (int)($existing['bestLapMs'] ?? 0);
                 if (!$isRaceCareerMode) {
@@ -5304,12 +5332,12 @@ function profile_upsert_from_payload(array $payload): void
                 if ($new > 0 && ($old === 0 || $new < $old)) return $new;
                 return $old ?: $new;
             })(),
-            'accuracyAwards'  => (int)($existing['accuracyAwards']   ?? 0) + $accuracyAward,
-            'excellentAwards' => (int)($existing['excellentAwards']  ?? 0) + (int)($player['excellentCount']  ?? 0),
-            'impressiveAwards'=> (int)($existing['impressiveAwards'] ?? 0) + (int)($player['impressiveCount'] ?? 0),
-            'perfectAwards'   => (int)($existing['perfectAwards']    ?? 0) + (!empty($player['perfect']) ? 1 : 0),
-            'damageDealt'     => (int)($existing['damageDealt']      ?? 0) + (int)($player['damageDealt'] ?? 0),
-            'damageTaken'     => (int)($existing['damageTaken']      ?? 0) + (int)($player['damageTaken'] ?? 0),
+            'accuracyAwards'  => $pickCareer('accuracyAwards', $accuracyAward),
+            'excellentAwards' => $pickCareer('excellentAwards', (int)($player['excellentCount'] ?? 0)),
+            'impressiveAwards'=> $pickCareer('impressiveAwards', (int)($player['impressiveCount'] ?? 0)),
+            'perfectAwards'   => $pickCareer('perfectAwards', !empty($player['perfect']) ? 1 : 0),
+            'damageDealt'     => $pickCareer('damageDealt', (int)($player['damageDealt'] ?? 0)),
+            'damageTaken'     => $pickCareer('damageTaken', (int)($player['damageTaken'] ?? 0)),
             'distanceKm'      => $distanceKm,
             'topSpeedKph'     => $topSpeedKph,
             'fuelUsed'        => $fuelUsed,
@@ -5402,6 +5430,11 @@ function profile_upsert_from_payload(array $payload): void
                 }
                 return array_slice(array_values(array_unique($processedMatchIds)), -200);
             })(),
+            '_lastProcessedMatch' => [
+                'matchId' => $matchId,
+                'timestamp' => $payload['receivedAt'] ?? gmdate('c'),
+                'checksum' => $matchId !== '' ? profile_match_checksum($matchId, (string)$mode, $player) : '',
+            ],
         ];
 
         profile_save($playerId, $profile);

--- a/ladder_service/php_webservice/migrate_profiles.php
+++ b/ladder_service/php_webservice/migrate_profiles.php
@@ -1,0 +1,120 @@
+<?php
+/**
+ * Q3Rally Ladder – Profile Tracking Migration
+ *
+ * Normalisiert bestehende Profile auf die dedizierte Match-Dedupe-Struktur:
+ * - _processedMatchIds (max. 200)
+ * - _lastProcessedMatch { matchId, timestamp, checksum }
+ *
+ * Nutzung:
+ *   php migrate_profiles.php
+ */
+
+declare(strict_types=1);
+
+if (PHP_SAPI !== 'cli') {
+    http_response_code(403);
+    exit("Run from command line only.\n");
+}
+
+define('PROFILES_DIR', __DIR__ . '/data/profiles');
+
+if (!is_dir(PROFILES_DIR)) {
+    echo "Profiles directory does not exist: " . PROFILES_DIR . "\n";
+    exit(0);
+}
+
+$files = glob(PROFILES_DIR . '/*.json');
+if (!is_array($files)) {
+    echo "Failed to scan profiles directory.\n";
+    exit(1);
+}
+
+$updated = 0;
+$skipped = 0;
+$errors = 0;
+
+foreach ($files as $file) {
+    $raw = file_get_contents($file);
+    if ($raw === false) {
+        $errors++;
+        echo "ERROR unreadable: " . basename($file) . "\n";
+        continue;
+    }
+
+    $profile = json_decode($raw, true);
+    if (!is_array($profile)) {
+        $errors++;
+        echo "ERROR invalid JSON: " . basename($file) . "\n";
+        continue;
+    }
+
+    $ids = array_values(array_filter((array)($profile['_processedMatchIds'] ?? []), 'is_string'));
+    $ids = array_values(array_filter(array_map(
+        static function(string $value): string {
+            $value = trim($value);
+            return preg_replace('/[^A-Za-z0-9._-]/', '_', $value) ?? '';
+        },
+        $ids
+    ), static fn(string $value): bool => $value !== ''));
+
+    if (empty($ids) && isset($profile['_lastProcessedMatchId']) && is_string($profile['_lastProcessedMatchId'])) {
+        $legacy = trim($profile['_lastProcessedMatchId']);
+        $legacy = preg_replace('/[^A-Za-z0-9._-]/', '_', $legacy) ?? '';
+        if ($legacy !== '') {
+            $ids[] = $legacy;
+        }
+    }
+
+    $ids = array_slice(array_values(array_unique($ids)), -200);
+
+    $receivedAt = is_string($profile['lastSeen'] ?? null) && trim($profile['lastSeen']) !== ''
+        ? (string)$profile['lastSeen']
+        : gmdate('c');
+    $lastId = end($ids);
+    $lastId = is_string($lastId) ? $lastId : '';
+
+    $newTracking = [
+        '_processedMatchIds' => $ids,
+        '_lastProcessedMatch' => [
+            'matchId' => $lastId,
+            'timestamp' => $receivedAt,
+            'checksum' => $lastId !== '' ? hash('sha256', $lastId . '|' . ((string)($profile['playerId'] ?? ''))) : '',
+        ],
+    ];
+
+    $before = json_encode([
+        '_processedMatchIds' => $profile['_processedMatchIds'] ?? null,
+        '_lastProcessedMatch' => $profile['_lastProcessedMatch'] ?? null,
+    ], JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
+
+    $profile['_processedMatchIds'] = $newTracking['_processedMatchIds'];
+    $profile['_lastProcessedMatch'] = $newTracking['_lastProcessedMatch'];
+    unset($profile['_lastProcessedMatchId']);
+
+    $after = json_encode([
+        '_processedMatchIds' => $profile['_processedMatchIds'],
+        '_lastProcessedMatch' => $profile['_lastProcessedMatch'],
+    ], JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
+
+    if ($before === $after) {
+        $skipped++;
+        continue;
+    }
+
+    $encoded = json_encode($profile, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
+    if ($encoded === false || file_put_contents($file, $encoded, LOCK_EX) === false) {
+        $errors++;
+        echo "ERROR write failed: " . basename($file) . "\n";
+        continue;
+    }
+
+    $updated++;
+}
+
+echo "Profiles scanned : " . count($files) . "\n";
+echo "Updated         : $updated\n";
+echo "Skipped         : $skipped\n";
+echo "Errors          : $errors\n";
+
+exit($errors > 0 ? 1 : 0);


### PR DESCRIPTION
### Motivation

- Vermeiden, dass mehrfach eingehende Match-Payloads dieselben Karriere-Statistiken (Wins/Losses/Mode-Deltas, Captures, Awards, Damage usw.) doppelt hochzählen und damit Profile verfälschen.
- Beibehaltung kleiner Profile durch Begrenzung der verarbeiteten Match-ID-Historie und Bereitstellung einer kompakten Diagnostik-Checksum/Metadaten-Strategie.
- Kompatibilität zu bestehenden Profilen sicherstellen, indem ein Migrationstool Altfelder normalisiert.

### Description

- Neue Hilfsfunktionen hinzugefügt: `profile_match_checksum()` zur Erzeugung einer SHA-256-Checksum pro Spieler/Match und `profile_normalize_processed_match_ids()` zur robusten Normalisierung von `_processedMatchIds` (inkl. Legacy-Fallback `_lastProcessedMatchId`).
- Profil-Upsert-Logik in `profile_upsert_from_payload()` geändert, sodass additive Werte wie `flagCaptures`, `flagAssists`, Awards und Damage über die bestehende `pickCareer()`-Logik angewendet werden, wodurch Deduplizierung per vorhandener Match-ID-Liste funktioniert.
- Kompaktes Trackingfeld `_lastProcessedMatch` mit `matchId`, `timestamp` und `checksum` ergänzt und die verarbeitete Match-ID-Historie auf maximal 200 Einträge begrenzt.
- Neues CLI-Migrationsskript `migrate_profiles.php` hinzugefügt, das bestehende `data/profiles/*.json` auf die neue Struktur (`_processedMatchIds`, `_lastProcessedMatch`) bringt und Legacy-Felder bereinigt.
- Dokumentation in `ladder_service/php_webservice/README.md` um den Hinweis zur Migration (`php migrate_profiles.php`) erweitert.

### Testing

- Syntax-Checks ausgeführt: `php -l ladder_service/php_webservice/index.php` (erfolgreich).
- Syntax-Checks ausgeführt: `php -l ladder_service/php_webservice/migrate_profiles.php` (erfolgreich).
- Syntax-Checks ausgeführt: `php -l ladder_service/php_webservice/rebuild_index.php` (erfolgreich).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ddfeddc7e08323a1df03aa58f41004)