### PR TITLE
Racing sections visible when tracked; stable fallbacks and regression test

### DIFF
--- a/ladder_service/php_webservice/index.php
+++ b/ladder_service/php_webservice/index.php
@@ -4481,26 +4481,42 @@ async function showPlayerProfile(playerId, playerName) {
     const modeGroups = [
       { title: 'Deathmatch',      primaryStat: 'dmCompleted', fields: [['Wins','dmWins'],['Completed','dmCompleted'],['Kills','dmKills']] },
       { title: 'Derby',           primaryStat: 'derbyCompleted', fields: [['Wins','derbyWins'],['Completed','derbyCompleted'],['Kills','derbyKills']] },
-      { title: 'Racing',          primaryStat: 'racingCompleted', fields: [['Wins','racingWins'],['Podiums','racingPodiums'],['Completed','racingCompleted'],['Total Time',null,'racingTotalMs']] },
-      { title: 'Racing DM',       primaryStat: 'racingDmCompleted', fields: [['Wins','racingDmWins'],['Podiums','racingDmPodiums'],['Completed','racingDmCompleted']] },
-      { title: 'Sprint',          primaryStat: 'sprintCompleted', fields: [['Wins','sprintWins'],['Completed','sprintCompleted'],['Best Time',null,'sprintBestMs']] },
+      { title: 'Racing',          primaryStat: 'racingCompleted', alwaysVisibleWhenTracked: true, fields: [['Wins','racingWins'],['Podiums','racingPodiums'],['Completed','racingCompleted'],['Total Time',null,'racingTotalMs']] },
+      { title: 'Racing DM',       primaryStat: 'racingDmCompleted', alwaysVisibleWhenTracked: true, fields: [['Wins','racingDmWins'],['Podiums','racingDmPodiums'],['Completed','racingDmCompleted']] },
+      { title: 'Sprint',          primaryStat: 'sprintCompleted', alwaysVisibleWhenTracked: true, fields: [['Wins','sprintWins'],['Completed','sprintCompleted'],['Best Time',null,'sprintBestMs']] },
       { title: 'Elimination',     primaryStat: 'eliminationCompleted', fields: [['Wins','eliminationWins'],['Completed','eliminationCompleted'],['Rounds Lasted','eliminationTotalRoundsLasted']] },
       { title: 'LCS',             primaryStat: 'lcsCompleted', fields: [['Wins','lcsWins'],['Completed','lcsCompleted'],['Survival Time',null,'lcsTotalSurvivalMs']] },
       { title: 'CTF',             primaryStat: 'ctfCompleted', fields: [['Wins','ctfWins'],['Completed','ctfCompleted'],['Captures','ctfCaptures']] },
       { title: 'CTF 4-Team',      primaryStat: 'ctf4Completed', fields: [['Wins','ctf4Wins'],['Completed','ctf4Completed'],['Captures','ctf4Captures']] },
       { title: 'Team DM',         primaryStat: 'teamCompleted', fields: [['Wins','teamWins'],['Completed','teamCompleted'],['Kills','teamKills']] },
-      { title: 'Team Racing',     primaryStat: 'teamRacingCompleted', fields: [['Wins','teamRacingWins'],['Completed','teamRacingCompleted'],['Podiums','teamRacingPodiums']] },
-      { title: 'Team Racing DM',  primaryStat: 'teamRacingDmCompleted', fields: [['Wins','teamRacingDmWins'],['Completed','teamRacingDmCompleted'],['Podiums','teamRacingDmPodiums']] },
+      { title: 'Team Racing',     primaryStat: 'teamRacingCompleted', alwaysVisibleWhenTracked: true, fields: [['Wins','teamRacingWins'],['Completed','teamRacingCompleted'],['Podiums','teamRacingPodiums']] },
+      { title: 'Team Racing DM',  primaryStat: 'teamRacingDmCompleted', alwaysVisibleWhenTracked: true, fields: [['Wins','teamRacingDmWins'],['Completed','teamRacingDmCompleted'],['Podiums','teamRacingDmPodiums']] },
       { title: 'Domination',      primaryStat: 'dominationCompleted', fields: [['Wins','dominationWins'],['Completed','dominationCompleted'],['Zone Hold',null,'dominationZoneHoldMs']] },
       { title: 'King of the Hill', primaryStat: 'kothCompleted', fields: [['Wins','kothWins'],['Completed','kothCompleted'],['Zone Hold',null,'kothZoneHoldMs']] },
     ];
 
+    const hasTrackedField = (obj, field) => Object.prototype.hasOwnProperty.call(obj || {}, field);
+    const toIntStat = (obj, field) => {
+      const num = Number(obj?.[field]);
+      return Number.isFinite(num) ? num : 0;
+    };
+
     const activeModes = modeGroups.filter(g => {
-      const primaryActive = g.primaryStat ? (p[g.primaryStat] || 0) > 0 : false;
+      const primaryActive = g.primaryStat ? toIntStat(p, g.primaryStat) > 0 : false;
       if (primaryActive) {
         return true;
       }
-      return g.fields.some(([,key,msKey]) => (key && (p[key]||0) > 0) || (msKey && (p[msKey]||0) > 0));
+      const hasAnyPositiveField = g.fields.some(([,key,msKey]) => (key && toIntStat(p, key) > 0) || (msKey && toIntStat(p, msKey) > 0));
+      if (hasAnyPositiveField) {
+        return true;
+      }
+      if (g.alwaysVisibleWhenTracked) {
+        if (g.primaryStat && hasTrackedField(p, g.primaryStat)) {
+          return true;
+        }
+        return g.fields.some(([,key,msKey]) => (key && hasTrackedField(p, key)) || (msKey && hasTrackedField(p, msKey)));
+      }
+      return false;
     });
 
     if (activeModes.length > 0) {
@@ -4520,10 +4536,10 @@ async function showPlayerProfile(playerId, playerName) {
         group.fields.forEach(([label, key, msKey]) => {
           let val;
           if (msKey) {
-            const ms = p[msKey] || 0;
+            const ms = toIntStat(p, msKey);
             val = ms > 0 ? formatMs(ms) : '–';
           } else {
-            val = p[key] || 0;
+            val = String(toIntStat(p, key));
           }
           modeGrid.appendChild(statCard(label, val));
         });

--- a/ladder_service/tests/test_mode_e2e_matrix.py
+++ b/ladder_service/tests/test_mode_e2e_matrix.py
@@ -403,6 +403,46 @@ def test_php_profile_racing_p1_updates_racing_counters(php_env: dict[str, Any]) 
     _assert_profile_fields(profile, {"racingWins": 1, "racingCompleted": 1})
 
 
+def test_php_profile_single_mode_regression_keeps_racing_keys_stable(php_env: dict[str, Any]) -> None:
+    dm_only_player = "fea4bdaa-4d9d-42ca-b7f1-0e0b3fc9a2aa"
+    race_only_player = "54d0f81f-0be8-463d-bc42-164c728ad623"
+
+    dm_payload = _profile_payload("profile-ui-single-mode-dm", "GT_DEATHMATCH", dm_only_player)
+    dm_payload["players"][0].pop("profile", None)
+    dm_status, dm_created = _post_php_match(php_env, dm_payload)
+    assert dm_status == 201, dm_created
+
+    dm_profile = _get_php_profile(php_env, dm_only_player)
+    for racing_key in (
+        "racingWins",
+        "racingPodiums",
+        "racingCompleted",
+        "racingTotalMs",
+        "racingDmWins",
+        "racingDmPodiums",
+        "racingDmCompleted",
+        "teamRacingWins",
+        "teamRacingPodiums",
+        "teamRacingCompleted",
+    ):
+        assert racing_key in dm_profile, f"missing profile key: {racing_key}"
+        assert dm_profile[racing_key] == 0, f"{racing_key} should remain zero for DM-only profile"
+
+    race_payload = _profile_payload("profile-ui-single-mode-racing", "GT_RACING", race_only_player)
+    race_payload["players"][0].pop("profile", None)
+    race_payload["players"][0]["position"] = 1
+    race_payload["players"][0]["kills"] = 0
+    race_payload["players"][0]["deaths"] = 0
+    race_status, race_created = _post_php_match(php_env, race_payload)
+    assert race_status == 201, race_created
+
+    race_profile = _get_php_profile(php_env, race_only_player)
+    assert race_profile["racingCompleted"] == 1
+    assert race_profile["racingWins"] == 1
+    assert race_profile["racingPodiums"] == 1
+    assert race_profile["dmCompleted"] == 0
+
+
 def test_php_profile_combined_dm_and_racing_stats_are_separated(php_env: dict[str, Any]) -> None:
     player_id = "7f6e7277-d5fe-4a36-bfa6-e5a5b2f3cf09"
 


### PR DESCRIPTION
### Motivation
- Improve the player profile UI so racing-related groups are shown when the profile contains racing tracking fields (even if values are 0) to avoid the section disappearing after matches. 
- Provide explicit per-field fallbacks (`"0"` for counters, `"–"` for time fields) instead of hiding whole blocks. 
- Add a regression test to ensure profiles that only played a single mode (DM or Racing) render/retain the expected keys and values.

### Description
- Added `alwaysVisibleWhenTracked` flags to racing-family mode group entries in `ladder_service/php_webservice/index.php` so those groups can be shown when tracking fields exist. 
- Introduced `hasTrackedField` and `toIntStat` helpers and updated the `activeModes` filter to treat presence-of-field and numeric coercion separately. 
- Normalised displayed values: time fields use `formatMs(ms)` or `'–'`, numeric counters use `String(toIntStat(...))` so counters render as `"0"` instead of being omitted. 
- Added `test_php_profile_single_mode_regression_keeps_racing_keys_stable` in `ladder_service/tests/test_mode_e2e_matrix.py` to cover DM-only and Racing-only profile scenarios.

### Testing
- Ran `pytest -q ladder_service/tests/test_mode_e2e_matrix.py -k "profile_racing_p1_updates_racing_counters or profile_single_mode_regression_keeps_racing_keys_stable or profile_combined_dm_and_racing_stats_are_separated"` and all selected tests passed. 
- Result: `3 passed, 26 deselected, 1 warning` (test run completed successfully).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de00b96e808323b89e81a93c441f89)