### PR TITLE
serverMatchSeq für deterministische Ladder-Ingest-Reihenfolge

### DIFF
--- a/engine/code/game/bg_ladder.h
+++ b/engine/code/game/bg_ladder.h
@@ -191,6 +191,7 @@ typedef struct ladderMatchPayload_s {
         int                     validationErrors;
         char            validationReason[LADDER_MAX_VALIDATION_REASON];
         char            matchId[LADDER_MAX_MATCH_ID];
+        int                     serverMatchSeq;
         char            mode[LADDER_MAX_MODE];
         int                     gametype;
         char            mapName[MAX_QPATH];

--- a/engine/code/game/g_local.h
+++ b/engine/code/game/g_local.h
@@ -1210,6 +1210,7 @@ void G_RallyUpdateAllTeamTimes( void );
 extern	vmCvar_t	g_rallyIgnoreBots;
 extern	vmCvar_t	g_aiDmnetDebugExport;
 extern	vmCvar_t	g_aiDmnetDebugExportPath;
+extern	vmCvar_t	g_ladderMatchSeq;
 extern	vmCvar_t	g_damageScale;
 extern	vmCvar_t	g_vehicleDamageScale;
 extern  vmCvar_t        g_vehicleDamageOffset;

--- a/engine/code/game/g_main.c
+++ b/engine/code/game/g_main.c
@@ -142,6 +142,7 @@ vmCvar_t	g_debugIntroCam;
 vmCvar_t	g_rallyIgnoreBots;
 vmCvar_t	g_aiDmnetDebugExport;
 vmCvar_t	g_aiDmnetDebugExportPath;
+vmCvar_t	g_ladderMatchSeq;
 
 vmCvar_t	g_damageScale;
 vmCvar_t	g_vehicleDamageScale;
@@ -299,6 +300,7 @@ static cvarTable_t		gameCvarTable[] = {
 { &g_rallyIgnoreBots, "g_rallyIgnoreBots", "0", CVAR_ARCHIVE, 0, qfalse },
 { &g_aiDmnetDebugExport, "g_aiDmnetDebugExport", "0", CVAR_ARCHIVE | CVAR_NORESTART, 0, qfalse },
 { &g_aiDmnetDebugExportPath, "g_aiDmnetDebugExportPath", "logs/ai_dmnet_debug.csv", CVAR_ARCHIVE | CVAR_NORESTART, 0, qfalse },
+{ &g_ladderMatchSeq, "sv_ladderMatchSeq", "0", CVAR_ARCHIVE | CVAR_NORESTART, 0, qfalse },
 { &g_humanplayers, "g_humanplayers", "0", CVAR_ROM | CVAR_NORESTART, 0, qfalse },
 { &g_fuelKillReward, "g_fuelKillReward", "10", CVAR_ARCHIVE, 0, qfalse },
 { &g_useFuel, "g_useFuel", "1", CVAR_ARCHIVE | CVAR_SERVERINFO, 0, qfalse },
@@ -1253,6 +1255,17 @@ static void G_LadderSubmitMatchReport( const char *reason ) {
 
         if ( level.ladderMatchId[0] ) {
                 Q_strncpyz( payload->matchId, level.ladderMatchId, sizeof( payload->matchId ) );
+        }
+        {
+                int nextServerMatchSeq = trap_Cvar_VariableIntegerValue( "sv_ladderMatchSeq" );
+                if ( nextServerMatchSeq < 0 ) {
+                        nextServerMatchSeq = 0;
+                }
+                nextServerMatchSeq++;
+                payload->serverMatchSeq = nextServerMatchSeq;
+                Com_sprintf( buffer, sizeof( buffer ), "%i", nextServerMatchSeq );
+                trap_Cvar_Set( "sv_ladderMatchSeq", buffer );
+                trap_Cvar_Update( &g_ladderMatchSeq );
         }
 
         payload->valid = qtrue;

--- a/engine/code/server/sv_ladder.c
+++ b/engine/code/server/sv_ladder.c
@@ -981,6 +981,11 @@ static char *SV_LadderSerializeMatch( const ladderMatchPayload_t *payload, size_
                 Z_Free( builder.data );
                 return NULL;
         }
+        if ( !SV_LadderJsonAppendKey( &builder, "serverMatchSeq", &first ) ||
+             !SV_LadderJsonAppendInt( &builder, payload->serverMatchSeq ) ) {
+                Z_Free( builder.data );
+                return NULL;
+        }
         if ( !SV_LadderJsonAppendKey( &builder, "validationWarnings", &first ) ||
              !SV_LadderJsonAppendInt( &builder, payload->validationWarnings ) ) {
                 Z_Free( builder.data );

--- a/ladder_service/php_webservice/index.php
+++ b/ladder_service/php_webservice/index.php
@@ -4995,6 +4995,38 @@ function profile_normalize_processed_match_ids(array $profile): array
     return array_slice(array_values(array_unique($ids)), -200);
 }
 
+function ladder_parse_server_match_seq($value): ?int
+{
+    if (is_int($value)) {
+        $seq = $value;
+    } elseif (is_float($value)) {
+        if (!is_finite($value)) {
+            return null;
+        }
+        if (floor($value) !== $value) {
+            return null;
+        }
+        $seq = (int)$value;
+    } elseif (is_string($value) && preg_match('/^\d+$/', $value)) {
+        $seq = (int)$value;
+    } else {
+        return null;
+    }
+
+    return $seq > 0 ? $seq : null;
+}
+
+function profile_last_server_match_seq(array $profile): ?int
+{
+    if (!isset($profile['_lastProcessedMatch']) || !is_array($profile['_lastProcessedMatch'])) {
+        return null;
+    }
+    if (!array_key_exists('serverMatchSeq', $profile['_lastProcessedMatch'])) {
+        return null;
+    }
+    return ladder_parse_server_match_seq($profile['_lastProcessedMatch']['serverMatchSeq']);
+}
+
 function profile_upsert_from_payload(array $payload): void
 {
     $players = $payload['players'] ?? [];
@@ -5118,9 +5150,19 @@ function profile_upsert_from_payload(array $payload): void
             ? $player['profile']
             : null;
         $matchId = isset($payload['matchId']) && is_string($payload['matchId']) ? normalize_match_id($payload['matchId']) : '';
+        $serverMatchSeq = array_key_exists('serverMatchSeq', $payload)
+            ? ladder_parse_server_match_seq($payload['serverMatchSeq'])
+            : null;
         $processedMatchIds = profile_normalize_processed_match_ids($existing);
         $alreadyCounted = $matchId !== '' && in_array($matchId, $processedMatchIds, true);
-        $countThisMatch = !$alreadyCounted;
+        $lastServerMatchSeq = profile_last_server_match_seq($existing);
+        $isOutdatedBySeq = $serverMatchSeq !== null &&
+                           $lastServerMatchSeq !== null &&
+                           $serverMatchSeq < $lastServerMatchSeq;
+        $isReplayBySeq = $serverMatchSeq !== null &&
+                         $lastServerMatchSeq !== null &&
+                         $serverMatchSeq <= $lastServerMatchSeq;
+        $countThisMatch = $isReplayBySeq ? false : !$alreadyCounted;
 
         // ── Win-Detection ──────────────────────────────────────────────
         $clientNum  = (int)($player['clientNum'] ?? -1);
@@ -5436,9 +5478,18 @@ function profile_upsert_from_payload(array $payload): void
                 return array_slice(array_values(array_unique($processedMatchIds)), -200);
             })(),
             '_lastProcessedMatch' => [
-                'matchId' => $matchId,
-                'timestamp' => $payload['receivedAt'] ?? gmdate('c'),
-                'checksum' => $matchId !== '' ? profile_match_checksum($matchId, (string)$mode, $player) : '',
+                'matchId' => ($isOutdatedBySeq && isset($existing['_lastProcessedMatch']['matchId']) && is_string($existing['_lastProcessedMatch']['matchId']))
+                    ? $existing['_lastProcessedMatch']['matchId']
+                    : $matchId,
+                'serverMatchSeq' => ($isOutdatedBySeq && isset($existing['_lastProcessedMatch']['serverMatchSeq']))
+                    ? $existing['_lastProcessedMatch']['serverMatchSeq']
+                    : $serverMatchSeq,
+                'timestamp' => ($isOutdatedBySeq && isset($existing['_lastProcessedMatch']['timestamp']) && is_string($existing['_lastProcessedMatch']['timestamp']))
+                    ? $existing['_lastProcessedMatch']['timestamp']
+                    : ($payload['receivedAt'] ?? gmdate('c')),
+                'checksum' => ($isOutdatedBySeq && isset($existing['_lastProcessedMatch']['checksum']) && is_string($existing['_lastProcessedMatch']['checksum']))
+                    ? $existing['_lastProcessedMatch']['checksum']
+                    : ($matchId !== '' ? profile_match_checksum($matchId, (string)$mode, $player) : ''),
             ],
         ];
 
@@ -5869,6 +5920,13 @@ function handle_post(array $segments): void
     $matchId = normalize_match_id($payload['matchId']);
     if ($matchId === '') {
         throw new LadderApiException(422, 'MATCH_ID_INVALID', 'matchId contains unsupported characters.');
+    }
+    if (array_key_exists('serverMatchSeq', $payload)) {
+        $serverMatchSeq = ladder_parse_server_match_seq($payload['serverMatchSeq']);
+        if ($serverMatchSeq === null) {
+            throw new LadderApiException(422, 'SERVER_MATCH_SEQ_INVALID', 'serverMatchSeq must be a positive integer.');
+        }
+        $payload['serverMatchSeq'] = $serverMatchSeq;
     }
 
     $playerCount = (int)($payload['playerCount'] ?? count((array)($payload['players'] ?? [])));


### PR DESCRIPTION
### Motivation
- Verhindern, dass durch Retries oder verspätete Zustellung Match-Updates falsche Rücksprünge / doppelte Zählungen in Spieler-Profilen verursachen. 
- Einführung einer einfachen, persistenten pro-Server Sequenz im Payload erlaubt deterministische, monoton steigende Reihenfolge-Prüfung pro Server.

### Description
- Das Payload-Typ `ladderMatchPayload_t` wurde um das Feld `serverMatchSeq` erweitert und ein persistenter Cvar `sv_ladderMatchSeq` (`g_ladderMatchSeq`) zur Archivierung hinzugefügt. 
- Beim Erzeugen des Ladder-Payloads in `G_LadderSubmitMatchReport` wird `sv_ladderMatchSeq` inkrementiert, ins Payload geschrieben und wieder in den Cvar zurückgeschrieben. 
- `SV_LadderSerializeMatch` serialisiert nun `serverMatchSeq` in das JSON, so dass der Webservice das Feld erhält. 
- Im PHP-Ingest (`handle_post()` / `profile_upsert_from_payload()` ) wird `serverMatchSeq` optional validiert (`ladder_parse_server_match_seq`), in `_lastProcessedMatch.serverMatchSeq` gespeichert und zur Erkennung von Replay / Out-of-order-Events genutzt; Events mit `serverMatchSeq <= last` werden nicht als zählende Matches gewertet und bei strikt älteren Seq-Werten werden bestehende `_lastProcessedMatch`-Metadaten beibehalten; das alte `matchId`-Dedupe-Verhalten bleibt als Fallback erhalten.

### Testing
- `php -l ladder_service/php_webservice/index.php` wurde ausgeführt und lieferte keine Syntaxfehler (erfolgreich). 
- Änderungen wurden im Arbeitsbaum geprüft (`git diff`) und danach committed; es wurden keine automatischen C-Build-Tests in dieser Änderung ausgeführt.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de12e3db5c8323aeda40e2e5929832)