### PR TITLE
Add ladder-pipeline correlation logs and player diagnostic script

### DIFF
--- a/engine/code/game/g_main.c
+++ b/engine/code/game/g_main.c
@@ -46,6 +46,7 @@ static const char *G_LadderModeForGametype( int gametype );
 static void G_LadderFormatIsoTime( const qtime_t *qt, char *buffer, size_t size );
 static qboolean G_LadderPopulatePlayer( ladderMatchPayload_t *payload, int clientNum );
 static void G_LadderSubmitMatchReport( const char *reason );
+static void G_LadderLogSubmitSnapshot( const ladderMatchPayload_t *payload );
 static void G_ValidateDerbyDamageCvars( void );
 static ladderMatchPayload_t s_ladderMatchPayload;
 
@@ -1374,6 +1375,8 @@ static void G_LadderSubmitMatchReport( const char *reason ) {
                 G_LadderPopulatePlayer( payload, i );
         }
 
+        G_LadderLogSubmitSnapshot( payload );
+
         if ( reason && reason[0] ) {
                 Com_Printf( "Ladder: submitting '%s' with reason '%s' (%d players)\n",
                         payload->matchId[0] ? payload->matchId : "<unknown>", reason, payload->playerCount );
@@ -1384,6 +1387,38 @@ static void G_LadderSubmitMatchReport( const char *reason ) {
 
         if ( payload->playerCount > 0 || reason ) {
                 trap_LadderSubmit( payload );
+        }
+}
+
+static void G_LadderLogSubmitSnapshot( const ladderMatchPayload_t *payload ) {
+        int i;
+
+        if ( !payload ) {
+                return;
+        }
+
+        for ( i = 0; i < payload->playerCount; ++i ) {
+                const ladderPlayerPayload_t *player = &payload->players[i];
+                int snapshotRevision = 0;
+                int snapshotEpoch = 0;
+
+                if ( !player->profileAttached ) {
+                        continue;
+                }
+
+                if ( player->profile.valid ) {
+                        snapshotRevision = player->profile.snapshotRevision;
+                        snapshotEpoch = player->profile.snapshotEpoch;
+                }
+
+                Com_Printf(
+                        "[ladder-pipeline] engine-submit matchId=%s mode=%s playerId(local)=%s snapshotRevision=%d snapshotEpoch=%d\n",
+                        payload->matchId[0] ? payload->matchId : "<unknown>",
+                        payload->mode[0] ? payload->mode : "<unknown>",
+                        player->playerId[0] ? player->playerId : "<unknown>",
+                        snapshotRevision,
+                        snapshotEpoch
+                );
         }
 }
 

--- a/engine/code/server/sv_ladder.c
+++ b/engine/code/server/sv_ladder.c
@@ -1830,6 +1830,38 @@ static qboolean SV_LadderStartRequest( ladderRequest_t *request ) {
         return qtrue;
 }
 
+static void SV_LadderLogSubmitSnapshot( const ladderMatchPayload_t *payload ) {
+        int i;
+
+        if ( !payload ) {
+                return;
+        }
+
+        for ( i = 0; i < payload->playerCount; ++i ) {
+                const ladderPlayerPayload_t *player = &payload->players[i];
+                int snapshotRevision = 0;
+                int snapshotEpoch = 0;
+
+                if ( !player->profileAttached ) {
+                        continue;
+                }
+
+                if ( player->profile.valid ) {
+                        snapshotRevision = player->profile.snapshotRevision;
+                        snapshotEpoch = player->profile.snapshotEpoch;
+                }
+
+                Com_Printf(
+                        "[ladder-pipeline] sv-submit matchId=%s mode=%s playerId(local)=%s snapshotRevision=%d snapshotEpoch=%d\n",
+                        payload->matchId[0] ? payload->matchId : "<unknown>",
+                        payload->mode[0] ? payload->mode : "<unknown>",
+                        player->playerId[0] ? player->playerId : "<unknown>",
+                        snapshotRevision,
+                        snapshotEpoch
+                );
+        }
+}
+
 static void SV_LadderHandleFailure( ladderRequest_t *request, const char *reason, long responseCode, qboolean retry ) {
         if ( retry ) {
                 int delay = SV_LadderComputeBackoff( ++request->attempt );
@@ -2495,6 +2527,8 @@ void SV_LadderSubmit( const ladderMatchPayload_t *payload ) {
                         validatedPayload.validationReason[0] ? validatedPayload.validationReason : "validation_failed" );
                 return;
         }
+
+        SV_LadderLogSubmitSnapshot( &validatedPayload );
 
         if ( sv_ladderUrl && sv_ladderUrl->string[0] ) {
                 sv_ladder.warnedNoUrl = qfalse;

--- a/ladder_service/php_webservice/diagnose_player_pipeline.php
+++ b/ladder_service/php_webservice/diagnose_player_pipeline.php
@@ -1,0 +1,118 @@
+<?php
+declare(strict_types=1);
+
+if (PHP_SAPI !== 'cli') {
+    fwrite(STDERR, "Run this script via CLI.\n");
+    exit(1);
+}
+
+$playerId = isset($argv[1]) ? trim((string)$argv[1]) : '';
+$limit = isset($argv[2]) ? max(1, (int)$argv[2]) : 10;
+
+if ($playerId === '') {
+    fwrite(STDERR, "Usage: php diagnose_player_pipeline.php <playerId> [limit]\n");
+    exit(1);
+}
+
+$baseDir = __DIR__;
+$dataDir = $baseDir . '/data';
+$profilesDir = $dataDir . '/profiles';
+$safePlayerId = preg_replace('/[^a-zA-Z0-9._-]/', '_', $playerId);
+$profilePath = $profilesDir . '/' . $safePlayerId . '.json';
+$profile = [];
+if (is_file($profilePath)) {
+    $profileRaw = file_get_contents($profilePath);
+    $decoded = is_string($profileRaw) ? json_decode($profileRaw, true) : null;
+    if (is_array($decoded)) {
+        $profile = $decoded;
+    }
+}
+
+$processed = [];
+if (isset($profile['_processedMatchIds']) && is_array($profile['_processedMatchIds'])) {
+    foreach ($profile['_processedMatchIds'] as $pid) {
+        if (is_string($pid) && $pid !== '') {
+            $processed[$pid] = true;
+        }
+    }
+}
+
+$matchRows = [];
+foreach (glob($dataDir . '/*.json') ?: [] as $matchPath) {
+    if (!is_file($matchPath)) {
+        continue;
+    }
+    $raw = file_get_contents($matchPath);
+    $match = is_string($raw) ? json_decode($raw, true) : null;
+    if (!is_array($match) || !isset($match['players']) || !is_array($match['players'])) {
+        continue;
+    }
+
+    $mode = (string)($match['mode'] ?? '');
+    $matchId = (string)($match['matchId'] ?? '');
+    $receivedAt = (string)($match['receivedAt'] ?? $match['endTime'] ?? $match['startTime'] ?? '');
+    $winnerClientNum = isset($match['winnerClientNum']) ? (int)$match['winnerClientNum'] : -9999;
+
+    foreach ($match['players'] as $p) {
+        if (!is_array($p)) {
+            continue;
+        }
+        if ((string)($p['playerId'] ?? '') !== $playerId) {
+            continue;
+        }
+
+        $clientNum = (int)($p['clientNum'] ?? -1);
+        $won = ($winnerClientNum >= 0 && $clientNum === $winnerClientNum) ? 1 : 0;
+        $snap = (isset($p['profile']) && is_array($p['profile']) && !empty($p['profile']['valid'])) ? $p['profile'] : [];
+
+        $matchRows[] = [
+            'receivedAt' => $receivedAt,
+            'matchId' => $matchId,
+            'mode' => $mode,
+            'position' => (int)($p['position'] ?? 0),
+            'won' => $won,
+            'processed' => isset($processed[$matchId]) ? 1 : 0,
+            'snapRev' => (int)($snap['snapshotRevision'] ?? 0),
+            'snapEpoch' => (int)($snap['snapshotEpoch'] ?? 0),
+            'snapWins' => (int)($snap['wins'] ?? 0),
+        ];
+    }
+}
+
+usort($matchRows, static function (array $a, array $b): int {
+    return strcmp((string)$b['receivedAt'], (string)$a['receivedAt']);
+});
+$matchRows = array_slice($matchRows, 0, $limit);
+
+echo "[ladder-pipeline] diagnose playerId={$playerId} limit={$limit}\n";
+echo "[ladder-pipeline] profile-summary wins=" . (int)($profile['wins'] ?? 0)
+    . " gamesPlayed=" . (int)($profile['gamesPlayed'] ?? 0)
+    . " lastIngestedMatchId=" . (string)($profile['lastIngestedMatchId'] ?? '')
+    . " lastServerMatchSeq=" . (string)($profile['lastServerMatchSeq'] ?? '') . "\n";
+echo "\n";
+echo str_pad('receivedAt', 22)
+    . str_pad('matchId', 28)
+    . str_pad('mode', 18)
+    . str_pad('pos', 6)
+    . str_pad('won', 6)
+    . str_pad('processed', 11)
+    . str_pad('snapRev', 9)
+    . str_pad('snapEpoch', 12)
+    . "snapWins\n";
+
+if (!$matchRows) {
+    echo "(no matches found for player)\n";
+    exit(0);
+}
+
+foreach ($matchRows as $row) {
+    echo str_pad((string)$row['receivedAt'], 22)
+        . str_pad((string)$row['matchId'], 28)
+        . str_pad((string)$row['mode'], 18)
+        . str_pad((string)$row['position'], 6)
+        . str_pad((string)$row['won'], 6)
+        . str_pad((string)$row['processed'], 11)
+        . str_pad((string)$row['snapRev'], 9)
+        . str_pad((string)$row['snapEpoch'], 12)
+        . (string)$row['snapWins'] . "\n";
+}

--- a/ladder_service/php_webservice/index.php
+++ b/ladder_service/php_webservice/index.php
@@ -151,6 +151,24 @@ function ladder_read_body(): string
     return $body;
 }
 
+function ladder_pipeline_log(string $event, array $fields = []): void
+{
+    $parts = [];
+    foreach ($fields as $key => $value) {
+        if (is_bool($value)) {
+            $value = $value ? '1' : '0';
+        } elseif ($value === null) {
+            $value = 'null';
+        } elseif (is_array($value) || is_object($value)) {
+            $value = json_encode($value, JSON_UNESCAPED_SLASHES);
+        }
+        $parts[] = sprintf('%s=%s', (string)$key, (string)$value);
+    }
+
+    $suffix = $parts ? (' ' . implode(' ', $parts)) : '';
+    error_log('[ladder-pipeline] ' . $event . $suffix);
+}
+
 $method = $_SERVER['REQUEST_METHOD'] ?? 'GET';
 
 // --- Minimal frontend for Q3Rally Ladder (HTML landing page) ---
@@ -5223,13 +5241,6 @@ function profile_upsert_from_payload(array $payload): void
         $isWinnerByTeam = $isTeamMode && $winnerTeam !== null && $playerTeam !== '' && $playerTeam === $winnerTeam;
         $isWinner = $isTeamMode ? $isWinnerByTeam : $isWinnerByClient;
 
-        error_log(sprintf(
-            '[profile_upsert_from_payload] winner-check mode=%s clientNum=%d winnerClientNum=%s',
-            (string) $mode,
-            $clientNum,
-            $hasWinnerClientNum ? (string) $winnerClientNum : 'missing'
-        ));
-
         // ── Accuracy Award ─────────────────────────────────────────────
         $accuracy      = (int)($player['accuracy'] ?? 0);
         $accuracyAward = ($accuracy >= 75) ? 1 : 0;
@@ -5273,6 +5284,24 @@ function profile_upsert_from_payload(array $payload): void
         $hasOutcome = $isTeamMode ? ($winnerTeam !== null) : ($hasWinnerClientNum && $winnerClientNum >= 0);
         $derivedWins = ($hasOutcome && $isWinner) ? 1 : 0;
         $derivedLosses = ($hasOutcome && !$isWinner) ? 1 : 0;
+        $snapshotPresent = $snap !== null;
+        $existingWins = (int)($existing['wins'] ?? 0);
+        $baseWins = $existingWins;
+        if ($snapshotPresent) {
+            $baseWins = max($baseWins, (int)($snap['wins'] ?? $baseWins));
+        }
+        $deltaWins = $countThisMatch ? $derivedWins : 0;
+        $newWins = $baseWins + $deltaWins;
+
+        ladder_pipeline_log('php-profile_upsert-player', [
+            'matchId' => $matchId,
+            'playerId' => $playerId,
+            'alreadyCounted' => $alreadyCounted,
+            'snapshotPresent' => $snapshotPresent,
+            'existingWins' => $existingWins,
+            'deltaWins' => $deltaWins,
+            'newWins' => $newWins,
+        ]);
 
         $isRaceCareerMode = in_array($mode, ['GT_RACING', 'GT_RACING_DM', 'GT_SPRINT', 'GT_TEAM_RACING', 'GT_TEAM_RACING_DM'], true);
         $racePosition = (int)($player['position'] ?? $player['rank'] ?? 0);
@@ -6025,6 +6054,34 @@ function handle_post(array $segments): void
 
     // Update leaderboard index
     index_append($payload);
+
+    if (isset($payload['players']) && is_array($payload['players'])) {
+        foreach ($payload['players'] as $player) {
+            if (!is_array($player)) {
+                continue;
+            }
+            $playerId = (string)($player['playerId'] ?? '');
+            if ($playerId === '' || !profile_is_valid_uuid($playerId)) {
+                continue;
+            }
+
+            $snapshotPresent = isset($player['profile']) && is_array($player['profile']) && !empty($player['profile']['valid']);
+            $existingProfile = profile_load($playerId) ?? [];
+            $existingWins = (int)($existingProfile['wins'] ?? 0);
+            $processedMatchIds = profile_normalize_processed_match_ids($existingProfile);
+            $alreadyCounted = $matchId !== '' && in_array($matchId, $processedMatchIds, true);
+
+            ladder_pipeline_log('php-handle_post-player', [
+                'matchId' => $matchId,
+                'playerId' => $playerId,
+                'alreadyCounted' => $alreadyCounted,
+                'snapshotPresent' => $snapshotPresent,
+                'existingWins' => $existingWins,
+                'deltaWins' => 0,
+                'newWins' => $existingWins,
+            ]);
+        }
+    }
 
     // Update player profiles
     profile_upsert_from_payload($payload);


### PR DESCRIPTION
### Motivation

- Make it easy to correlate Engine → Server → PHP profile updates for a given `matchId` + `playerId` so a "+1 match" offset can be diagnosed quickly. 

### Description

- Add engine-side submit logging by introducing `G_LadderLogSubmitSnapshot()` and calling it from `G_LadderSubmitMatchReport()` to emit `[ladder-pipeline] engine-submit` lines with `matchId`, `mode`, `playerId(local)`, `snapshotRevision`, and `snapshotEpoch` in `engine/code/game/g_main.c`.
- Add server-side upload-path logging with `SV_LadderLogSubmitSnapshot()` and call it from `SV_LadderSubmit()` to emit `[ladder-pipeline] sv-submit` lines with the same correlation fields in `engine/code/server/sv_ladder.c`.
- Add PHP helper `ladder_pipeline_log()` to `ladder_service/php_webservice/index.php` and emit per-player diagnostic logs in `handle_post()` (`php-handle_post-player`) and inside `profile_upsert_from_payload()` (`php-profile_upsert-player`) that include `matchId`, `playerId`, `alreadyCounted`, `snapshotPresent`, `existingWins`, `deltaWins`, and `newWins`.
- Add a small non-invasive CLI diagnostic script `ladder_service/php_webservice/diagnose_player_pipeline.php` that accepts a `playerId` and optional `limit` and prints the last N matches for that player together with profile indicators (processed flag, snapshot revision/epoch/wins, profile summary) to help visually compare match vs profile processing.

### Testing

- Ran PHP syntax checks with `php -l ladder_service/php_webservice/index.php` which reported no syntax errors. 
- Ran PHP syntax checks with `php -l ladder_service/php_webservice/diagnose_player_pipeline.php` which reported no syntax errors. 
- No runtime/integration tests for the C engine changes were executed in this rollout (only logging additions to submit paths).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de158572548323b472cc423d76cb77)