### PR TITLE
Harden PHP team winner logic with normalized team labels and CTF tests

### DIFF
--- a/ladder_service/php_webservice/index.php
+++ b/ladder_service/php_webservice/index.php
@@ -5093,6 +5093,61 @@ function profile_hydrate_ingest_metadata(array $profile): array
     return $profile;
 }
 
+function profile_normalize_team_label($value): string
+{
+    if (is_int($value) || is_float($value) || (is_string($value) && is_numeric($value))) {
+        $teamNum = (int)$value;
+        return match ($teamNum) {
+            1 => 'red',
+            2 => 'blue',
+            3 => 'green',
+            4 => 'yellow',
+            default => '',
+        };
+    }
+
+    if (!is_string($value)) {
+        return '';
+    }
+
+    $raw = strtolower(trim($value));
+    return match ($raw) {
+        '1', 'red' => 'red',
+        '2', 'blue' => 'blue',
+        '3', 'green' => 'green',
+        '4', 'yellow' => 'yellow',
+        default => '',
+    };
+}
+
+function profile_pick_winner_team_by_scores(array $scoresByTeam): ?string
+{
+    $topScore = null;
+    $topTeam = null;
+    $isTie = false;
+    foreach ($scoresByTeam as $team => $score) {
+        if (!in_array($team, ['red', 'blue', 'green', 'yellow'], true)) {
+            continue;
+        }
+        if (!is_int($score) && !is_float($score)) {
+            continue;
+        }
+        $scoreValue = (float)$score;
+        if ($topScore === null || $scoreValue > $topScore) {
+            $topScore = $scoreValue;
+            $topTeam = $team;
+            $isTie = false;
+        } elseif ($scoreValue === $topScore) {
+            $isTie = true;
+        }
+    }
+
+    if ($topTeam === null || $isTie) {
+        return null;
+    }
+    return $topTeam;
+}
+
 function profile_upsert_from_payload(array $payload): void
 {
     $players = $payload['players'] ?? [];
@@ -5128,7 +5183,7 @@ function profile_upsert_from_payload(array $payload): void
             continue;
         }
         $candidateClientNum = (int)($candidate['clientNum'] ?? -1);
-        $candidateTeam = isset($candidate['team']) && is_string($candidate['team']) ? strtolower(trim($candidate['team'])) : '';
+        $candidateTeam = profile_normalize_team_label($candidate['team'] ?? null);
         $humanPlayers[] = [
             'clientNum' => $candidateClientNum,
             'team' => $candidateTeam,
@@ -5147,14 +5202,12 @@ function profile_upsert_from_payload(array $payload): void
             }
         }
         if ($winnerTeam === null && isset($payload['teams']) && is_array($payload['teams'])) {
-            $topScore = null;
-            $topTeam = null;
-            $isTie = false;
+            $teamScores = [];
             foreach ($payload['teams'] as $teamEntry) {
                 if (!is_array($teamEntry)) {
                     continue;
                 }
-                $teamName = isset($teamEntry['team']) && is_string($teamEntry['team']) ? strtolower(trim($teamEntry['team'])) : '';
+                $teamName = profile_normalize_team_label($teamEntry['team'] ?? null);
                 if ($teamName === '') {
                     continue;
                 }
@@ -5170,17 +5223,36 @@ function profile_upsert_from_payload(array $payload): void
                 if ($score === null) {
                     continue;
                 }
-                if ($topScore === null || $score > $topScore) {
-                    $topScore = $score;
-                    $topTeam = $teamName;
-                    $isTie = false;
-                } elseif ($score === $topScore) {
-                    $isTie = true;
+                $teamScores[$teamName] = (float)$score;
+            }
+            $winnerTeam = profile_pick_winner_team_by_scores($teamScores);
+        }
+
+        if ($winnerTeam === null) {
+            $teamScores = [];
+            if (isset($payload['teamScores']) && is_array($payload['teamScores'])) {
+                foreach ($payload['teamScores'] as $teamKey => $scoreValue) {
+                    if (!is_int($scoreValue) && !is_float($scoreValue) && !(is_string($scoreValue) && is_numeric($scoreValue))) {
+                        continue;
+                    }
+                    $teamName = profile_normalize_team_label($teamKey);
+                    if ($teamName === '') {
+                        continue;
+                    }
+                    $teamScores[$teamName] = (float)$scoreValue;
                 }
             }
-            if (!$isTie && $topTeam !== null) {
-                $winnerTeam = $topTeam;
+
+            foreach (['red', 'blue', 'green', 'yellow'] as $teamName) {
+                $field = $teamName . 'Score';
+                if (array_key_exists($field, $payload) &&
+                    (is_int($payload[$field]) || is_float($payload[$field]) ||
+                     (is_string($payload[$field]) && is_numeric($payload[$field])))) {
+                    $teamScores[$teamName] = (float)$payload[$field];
+                }
             }
+
+            $winnerTeam = profile_pick_winner_team_by_scores($teamScores);
         }
     }
 
@@ -5236,7 +5308,7 @@ function profile_upsert_from_payload(array $payload): void
         // ── Win-Detection ──────────────────────────────────────────────
         $clientNum  = (int)($player['clientNum'] ?? -1);
         $position   = (int)($player['position'] ?? 0);
-        $playerTeam = isset($player['team']) && is_string($player['team']) ? strtolower(trim($player['team'])) : '';
+        $playerTeam = profile_normalize_team_label($player['team'] ?? null);
         $isWinnerByClient = $hasWinnerClientNum && $winnerClientNum >= 0 && $winnerClientNum === $clientNum;
         $isWinnerByTeam = $isTeamMode && $winnerTeam !== null && $playerTeam !== '' && $playerTeam === $winnerTeam;
         $isWinner = $isTeamMode ? $isWinnerByTeam : $isWinnerByClient;

--- a/ladder_service/tests/test_mode_e2e_matrix.py
+++ b/ladder_service/tests/test_mode_e2e_matrix.py
@@ -698,3 +698,80 @@ def test_php_profile_team_mode_applies_team_win_loss_delta(php_env: dict[str, An
     assert winner["losses"] == 2
     assert loser["wins"] == 9
     assert loser["losses"] == 2
+
+
+@pytest.mark.parametrize("mode,win_field", [("GT_CTF", "ctfWins"), ("GT_CTF4", "ctf4Wins")])
+def test_php_profile_objective_team_int_with_teams_array(php_env: dict[str, Any], mode: str, win_field: str) -> None:
+    suffix = "1" if mode == "GT_CTF" else "4"
+    winner_id = f"11111111-1111-4111-8111-{suffix}00000000001"
+    loser_id = f"22222222-2222-4222-8222-{suffix}00000000002"
+    payload = generate_golden_payload(mode)
+    payload["matchId"] = f"profile-{mode.lower()}-int-team-with-teams"
+    payload.pop("winnerClientNum", None)
+    payload["settings"].pop("winnerClientNum", None)
+    payload["players"] = [
+        {"playerId": winner_id, "clientNum": 1, "displayName": "Winner", "team": 1, "captures": 2, "profile": {"valid": True}},
+        {"playerId": loser_id, "clientNum": 2, "displayName": "Loser", "team": 2, "captures": 0, "profile": {"valid": True}},
+    ]
+    payload["teams"] = [{"team": 1, "rawScore": 15}, {"team": 2, "rawScore": 9}]
+
+    status, created = _post_php_match(php_env, payload)
+    assert status == 201, created
+
+    winner = _get_php_profile(php_env, winner_id)
+    loser = _get_php_profile(php_env, loser_id)
+    assert winner["wins"] == 1
+    assert loser["losses"] == 1
+    assert winner[win_field] == 1
+
+
+@pytest.mark.parametrize("mode,win_field", [("GT_CTF", "ctfWins"), ("GT_CTF4", "ctf4Wins")])
+def test_php_profile_objective_team_string_without_teams_uses_team_scores(php_env: dict[str, Any], mode: str, win_field: str) -> None:
+    suffix = "1" if mode == "GT_CTF" else "4"
+    winner_id = f"33333333-3333-4333-8333-{suffix}00000000003"
+    loser_id = f"44444444-4444-4444-8444-{suffix}00000000004"
+    payload = generate_golden_payload(mode)
+    payload["matchId"] = f"profile-{mode.lower()}-string-team-no-teams"
+    payload.pop("winnerClientNum", None)
+    payload["settings"].pop("winnerClientNum", None)
+    payload["players"] = [
+        {"playerId": winner_id, "clientNum": 1, "displayName": "Winner", "team": "RED", "captures": 1, "profile": {"valid": True}},
+        {"playerId": loser_id, "clientNum": 2, "displayName": "Loser", "team": "blue", "captures": 0, "profile": {"valid": True}},
+    ]
+    payload["teams"] = None
+    payload["teamScores"] = {"RED": 8, "blue": 4}
+
+    status, created = _post_php_match(php_env, payload)
+    assert status == 201, created
+
+    winner = _get_php_profile(php_env, winner_id)
+    loser = _get_php_profile(php_env, loser_id)
+    assert winner["wins"] == 1
+    assert loser["losses"] == 1
+    assert winner[win_field] == 1
+
+
+@pytest.mark.parametrize("mode,win_field", [("GT_CTF", "ctfWins"), ("GT_CTF4", "ctf4Wins")])
+def test_php_profile_objective_winner_client_num_has_priority_over_team_scores(php_env: dict[str, Any], mode: str, win_field: str) -> None:
+    suffix = "1" if mode == "GT_CTF" else "4"
+    winner_id = f"55555555-5555-4555-8555-{suffix}00000000005"
+    loser_id = f"66666666-6666-4666-8666-{suffix}00000000006"
+    payload = generate_golden_payload(mode)
+    payload["matchId"] = f"profile-{mode.lower()}-winner-client-priority"
+    payload["winnerClientNum"] = 2
+    payload["settings"]["winnerClientNum"] = 1
+    payload["players"] = [
+        {"playerId": loser_id, "clientNum": 1, "displayName": "Loser", "team": "red", "captures": 0, "profile": {"valid": True}},
+        {"playerId": winner_id, "clientNum": 2, "displayName": "Winner", "team": 2, "captures": 3, "profile": {"valid": True}},
+    ]
+    payload["teams"] = [{"team": "red", "rawScore": 99}, {"team": "blue", "rawScore": 1}]
+    payload["teamScores"] = {"red": 99, "blue": 1}
+
+    status, created = _post_php_match(php_env, payload)
+    assert status == 201, created
+
+    winner = _get_php_profile(php_env, winner_id)
+    loser = _get_php_profile(php_env, loser_id)
+    assert winner["wins"] == 1
+    assert loser["losses"] == 1
+    assert winner[win_field] == 1


### PR DESCRIPTION
### Motivation
- Team outcome detection for objective modes relied on inconsistent team formats and loose precedence, causing incorrect winner attribution for CTF/CTF4 payload variants.
- Tests did not cover integer team identifiers, mixed string cases, missing `teams[]` arrays or interactions with `winnerClientNum` precedence.

### Description
- Add `profile_normalize_team_label()` to normalize integer or string team identifiers into canonical labels `red|blue|green|yellow` and return empty string for unknown values.
- Introduce `profile_pick_winner_team_by_scores()` to centralize top-score selection and tie handling for team-score sources.
- Apply normalization to `humanPlayers` and per-player `team` values inside `profile_upsert_from_payload()` and use it to compute `isWinnerByTeam`.
- Harden winner resolution precedence so team winner is determined in order: (1) `winnerClientNum` → that client's normalized team, (2) `payload['teams']` entries, (3) `teamScores` / `redScore|blueScore|greenScore|yellowScore` fields; ties produce no winner.
- Ensure `hasOutcome` for team modes is true only when a concrete `winnerTeam` was determined.
- Add parametrized PHP integration tests in `ladder_service/tests/test_mode_e2e_matrix.py` covering `GT_CTF` and `GT_CTF4` for int team values with `teams[]`, string team values with `teamScores`, and `winnerClientNum` precedence over score-derived winners.

### Testing
- Ran PHP lint: `php -l ladder_service/php_webservice/index.php` and received `No syntax errors detected`.
- Executed targeted pytest selection: `pytest -q ladder_service/tests/test_mode_e2e_matrix.py -k "objective_team_int_with_teams_array or objective_team_string_without_teams_uses_team_scores or objective_winner_client_num_has_priority_over_team_scores"` and observed `6 passed, 29 deselected`.
- All added tests passed in the targeted test run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de218f974483239a4d975fc61c202a)