### PR TITLE
CTF4: include attacking team in flag-taken team sound events

### DIFF
--- a/engine/code/cgame/cg_event.c
+++ b/engine/code/cgame/cg_event.c
@@ -1393,9 +1393,20 @@ void CG_EntityEvent( centity_t *cent, vec3_t position ) {
                                         else if (cg.snap->ps.persistant[PERS_TEAM] == TEAM_GREEN) {
                                                 CG_AddBufferedSound( cgs.media.enemyTookYourFlagSound );
                                         } else {
-                                                // In CTF4 we can't know which team took the flag from this
-                                                // event alone, so use a neutral notification.
-                                                CG_AddBufferedSound( cgs.media.takenOpponentSound );
+                                                const int takingTeam = es->otherEntityNum;
+                                                if ( takingTeam >= TEAM_RED && takingTeam <= TEAM_YELLOW ) {
+                                                        if ( cg.snap->ps.persistant[PERS_TEAM] == takingTeam ) {
+                                                                // Play immediately (see GTS_RED_TAKEN) to avoid
+                                                                // buffering behind subsequent capture announcements.
+                                                                trap_S_StartLocalSound( cgs.media.yourTeamTookEnemyFlagSound, CHAN_ANNOUNCER );
+                                                        } else {
+                                                                CG_AddBufferedSound( cgs.media.takenOpponentSound );
+                                                        }
+                                                } else {
+                                                        // Backward-compatible fallback for demos/servers that
+                                                        // only provide eventParm without attacker payload.
+                                                        CG_AddBufferedSound( cgs.media.takenOpponentSound );
+                                                }
                                         }
                                         break;
                                 case GTS_YELLOW_TAKEN:
@@ -1405,7 +1416,18 @@ void CG_EntityEvent( centity_t *cent, vec3_t position ) {
                                         else if (cg.snap->ps.persistant[PERS_TEAM] == TEAM_YELLOW) {
                                                 CG_AddBufferedSound( cgs.media.enemyTookYourFlagSound );
                                         } else {
-                                                CG_AddBufferedSound( cgs.media.takenOpponentSound );
+                                                const int takingTeam = es->otherEntityNum;
+                                                if ( takingTeam >= TEAM_RED && takingTeam <= TEAM_YELLOW ) {
+                                                        if ( cg.snap->ps.persistant[PERS_TEAM] == takingTeam ) {
+                                                                // Play immediately (see GTS_RED_TAKEN).
+                                                                trap_S_StartLocalSound( cgs.media.yourTeamTookEnemyFlagSound, CHAN_ANNOUNCER );
+                                                        } else {
+                                                                CG_AddBufferedSound( cgs.media.takenOpponentSound );
+                                                        }
+                                                } else {
+                                                        // Backward-compatible fallback for older payloads.
+                                                        CG_AddBufferedSound( cgs.media.takenOpponentSound );
+                                                }
                                         }
                                         break;
 #ifdef MISSIONPACK

--- a/engine/code/game/g_team.c
+++ b/engine/code/game/g_team.c
@@ -1016,7 +1016,7 @@ void Team_ReturnFlagSound( gentity_t *ent, int team ) {
         te->r.svFlags |= SVF_BROADCAST;
 }
 
-void Team_TakeFlagSound( gentity_t *ent, int team ) {
+void Team_TakeFlagSound( gentity_t *ent, int team, int attackingTeam ) {
 	gentity_t	*te;
 
 	if (ent == NULL) {
@@ -1051,6 +1051,9 @@ void Team_TakeFlagSound( gentity_t *ent, int team ) {
                 te->s.eventParm = GTS_BLUE_TAKEN;
                 break;
         }
+	// In CTF4 we also send the attacking team so clients can distinguish
+	// who took green/yellow flags (eventParm alone only identifies the victim).
+	te->s.otherEntityNum = attackingTeam;
         te->r.svFlags |= SVF_BROADCAST;
 }
 
@@ -1328,7 +1331,7 @@ int Team_TouchEnemyFlag( gentity_t *ent, gentity_t *other, int team ) {
 	AddScore(other, ent->r.currentOrigin, CTF_FLAG_BONUS);
 #endif
 	cl->pers.teamState.flagsince = level.time;
-	Team_TakeFlagSound( ent, team );
+	Team_TakeFlagSound( ent, team, other->client->sess.sessionTeam );
 
 	return -1; // Do not respawn this automatically, but do delete it if it was FL_DROPPED
 }


### PR DESCRIPTION
### Motivation
- Allow CTF4 clients to know which team stole a green/yellow flag so they can play team-specific sounds instead of a neutral notification.
- Keep behavior for red/blue flags unchanged and maintain backward compatibility with older demos/servers that don't supply an attacker payload.

### Description
- Extended `Team_TakeFlagSound` signature to `Team_TakeFlagSound(gentity_t *ent, int team, int attackingTeam)` and set `te->s.otherEntityNum = attackingTeam` on the `EV_GLOBAL_TEAM_SOUND` event in `engine/code/game/g_team.c`.
- Updated the caller in `Team_TouchEnemyFlag` to pass `other->client->sess.sessionTeam` into `Team_TakeFlagSound`.
- Reworked `GTS_GREEN_TAKEN` and `GTS_YELLOW_TAKEN` handling in `engine/code/cgame/cg_event.c` to read the attacker from `es->otherEntityNum` and play `yourTeamTookEnemyFlagSound` immediately when the attacker matches the local team, otherwise fall back to the neutral `takenOpponentSound`.
- Preserved a backward-compatible fallback when `es->otherEntityNum` is not a valid team and replaced the outdated comment about not being able to know the thief from the event alone.

### Testing
- Ran repository searches (`rg`) and file inspections to verify all `Team_TakeFlagSound` call sites were updated and `GTS_GREEN_TAKEN`/`GTS_YELLOW_TAKEN` branches were modified, and these checks succeeded.
- Inspected the produced diffs to confirm the intended changes were applied to `engine/code/game/g_team.c` and `engine/code/cgame/cg_event.c` and the inspection succeeded.
- No automated build or runtime tests were run in this change set.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e1401198c083239a751d2dbeb62153)