### PR TITLE
Fix LCS avoid battle seek loop

### DIFF
--- a/engine/code/game/ai_dmnet.c
+++ b/engine/code/game/ai_dmnet.c
@@ -241,6 +241,16 @@ static qboolean Bot_LcsShouldAvoidBattleEntry( bot_state_t *bs, const char **rea
 	return qfalse;
 }
 
+static qboolean Bot_LcsShouldIgnoreFoundEnemy( bot_state_t *bs ) {
+	const char *lcsReason = NULL;
+
+	if ( !bs || gametype != GT_LCS ) {
+		return qfalse;
+	}
+
+	return ( !BotWantsToChase( bs ) || Bot_LcsShouldAvoidBattleEntry( bs, &lcsReason ) );
+}
+
 static qboolean Bot_LcsShouldBreakEngagement( bot_state_t *bs, const botCollisionRisk_t *risk, const char **triggerOut ) {
 	float relativePosition = 0.5f;
 	float threatProximity = 0.0f;
@@ -2680,7 +2690,12 @@ int AINode_Seek_NBG(bot_state_t *bs) {
 	if (moveresult.flags & MOVERESULT_MOVEMENTWEAPON) bs->weaponnum = moveresult.weapon;
 	//if there is an enemy
 	if (BotFindEnemy(bs, -1)) {
-		if (BotWantsToRetreat(bs)) {
+		if ( Bot_LcsShouldIgnoreFoundEnemy( bs ) ) {
+			// LCS avoidance keeps the current item/route goal instead of
+			// bouncing through battle enter nodes back into this seek node.
+			bs->enemy = -1;
+		}
+		else if (BotWantsToRetreat(bs)) {
 			//keep the current long term goal and retreat
 			AIEnter_Battle_NBG(bs, "seek nbg: found enemy");
 		}
@@ -2776,7 +2791,12 @@ int AINode_Seek_LTG(bot_state_t *bs)
 //	if (BotFindEnemy(bs, -1)) {
    if ( BotFindEnemy(bs, -1) && gametype != GT_RACING && gametype != GT_SPRINT && gametype != GT_TEAM_RACING ) {
 // END
-		if (BotWantsToRetreat(bs)) {
+		if ( Bot_LcsShouldIgnoreFoundEnemy( bs ) ) {
+			// LCS avoidance keeps seeking the current long-term goal instead
+			// of entering battle only to immediately re-enter this node.
+			bs->enemy = -1;
+		}
+		else if (BotWantsToRetreat(bs)) {
 			//keep the current long term goal and retreat
 			AIEnter_Battle_Retreat(bs, "seek ltg: found enemy");
 			return qfalse;


### PR DESCRIPTION
### Motivation
- Bots in `GT_LCS` could enter a seek→battle→seek cycle when the LCS avoidance predicate immediately prevented entering battle, causing repeated node switches and the "switched more than 50 AI nodes" fatal error. 
- The intention is to let bots continue to pursue their LTG/NBG goals when LCS avoidance says they should not enter combat, instead of flipping into battle nodes and immediately back.

### Description
- Added a helper `static qboolean Bot_LcsShouldIgnoreFoundEnemy(bot_state_t *bs)` that consolidates the check for whether a found enemy should be ignored under LCS avoidance logic. 
- Updated `AINode_Seek_NBG` to check `Bot_LcsShouldIgnoreFoundEnemy` and clear the transient enemy (`bs->enemy = -1`) when avoidance applies, keeping the current nearby-goal/route intact. 
- Updated `AINode_Seek_LTG` to perform the same check and behavior for long-term-goal seeking, preventing immediate re-entry into battle nodes. 
- Changes are in `engine/code/game/ai_dmnet.c` and were committed with message "Fix LCS avoid battle seek loop".

### Testing
- Ran `git diff --check` with no reported whitespace/patch issues. 
- Performed a targeted build: `make -C engine -j2 BUILD_CLIENT=0 BUILD_SERVER=0 BUILD_GAME_SO=1 BUILD_GAME_QVM=0 BUILD_BASEGAME=1`, which completed and produced the relevant game shared objects. 
- Attempted a full `make -C engine -j2`, which fails in this environment due to a missing system header (`SDL_version.h`) for the client build, but the game-shared-object build (the portion relevant to `ai_dmnet.c`) succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a218eab012c8323817e7acc9d20c530)