### PR TITLE
Enable cURL in CI builds and add LCS bot ignore-enemy behavior

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,9 +10,9 @@ jobs:
     - name: Install Dependencies
       run: |
         sudo apt-get update
-        sudo apt-get install libsdl2-dev
+        sudo apt-get install libsdl2-dev libcurl4-openssl-dev
     - name: Compile
-      run: make release -j$(nproc) -C engine
+      run: make release -j$(nproc) -C engine USE_CURL=1 USE_CURL_DLOPEN=0
       env:
         ARCHIVE: 1
     - uses: actions/upload-artifact@v4
@@ -29,7 +29,7 @@ jobs:
         sudo apt-get update
         sudo apt-get install gcc-aarch64-linux-gnu
     - name: Compile
-      run: make release -j$(nproc) ARCH=arm64 BUILD_CLIENT=0 BUILD_RENDERER_OPENGL1=0 BUILD_RENDERER_OPENGL2=0 CC=aarch64-linux-gnu-gcc -C engine
+      run: make release -j$(nproc) ARCH=arm64 BUILD_CLIENT=0 BUILD_RENDERER_OPENGL1=0 BUILD_RENDERER_OPENGL2=0 CC=aarch64-linux-gnu-gcc -C engine USE_CURL=1 USE_CURL_DLOPEN=1
       env:
         ARCHIVE: 1
   windows:
@@ -37,11 +37,18 @@ jobs:
     runs-on: windows-2022
     steps:
     - uses: actions/checkout@v4
-    - name: Compile
+    - name: Install Dependencies
+      run: choco install zip curl
+    - name: Bundle cURL
+      shell: pwsh
       run: |
-        choco install zip
-        # HACK: This sets USE_CURL_DLOPEN=1 because Curl fails to link otherwise.
-        make release -j $env:NUMBER_OF_PROCESSORS -C engine USE_CURL_DLOPEN=1
+        $curlDll = Get-ChildItem -Path "$env:ChocolateyInstall\lib\curl" -Recurse -Filter "libcurl*.dll" | Select-Object -First 1
+        if (!$curlDll) {
+          throw "Could not find libcurl DLL installed by Chocolatey curl package"
+        }
+        Copy-Item $curlDll.FullName engine\libcurl-4.dll
+    - name: Compile
+      run: make release -j $env:NUMBER_OF_PROCESSORS -C engine USE_CURL=1 USE_CURL_DLOPEN=1 CLIENT_EXTRA_FILES=libcurl-4.dll
       env:
         ARCHIVE: 1
     - uses: actions/upload-artifact@v4
@@ -54,7 +61,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Compile
-      run: make release -j$(sysctl -n hw.logicalcpu) -C engine
+      run: make release -j$(sysctl -n hw.logicalcpu) -C engine USE_CURL=1 USE_CURL_DLOPEN=1
       env:
         ARCHIVE: 1
     - uses: actions/upload-artifact@v4
@@ -79,7 +86,7 @@ jobs:
         ARCHIVE: 1
       run: |
         source emsdk/emsdk_env.sh
-        emmake make release -j$(nproc) -C engine
+        emmake make release -j$(nproc) -C engine USE_CURL=1
     - uses: actions/upload-artifact@v4
       with:
         name: Web

--- a/engine/code/game/ai_dmnet.c
+++ b/engine/code/game/ai_dmnet.c
@@ -241,6 +241,16 @@ static qboolean Bot_LcsShouldAvoidBattleEntry( bot_state_t *bs, const char **rea
 	return qfalse;
 }
 
+static qboolean Bot_LcsShouldIgnoreFoundEnemy( bot_state_t *bs ) {
+	const char *lcsReason = NULL;
+
+	if ( !bs || gametype != GT_LCS ) {
+		return qfalse;
+	}
+
+	return ( !BotWantsToChase( bs ) || Bot_LcsShouldAvoidBattleEntry( bs, &lcsReason ) );
+}
+
 static qboolean Bot_LcsShouldBreakEngagement( bot_state_t *bs, const botCollisionRisk_t *risk, const char **triggerOut ) {
 	float relativePosition = 0.5f;
 	float threatProximity = 0.0f;
@@ -2680,7 +2690,12 @@ int AINode_Seek_NBG(bot_state_t *bs) {
 	if (moveresult.flags & MOVERESULT_MOVEMENTWEAPON) bs->weaponnum = moveresult.weapon;
 	//if there is an enemy
 	if (BotFindEnemy(bs, -1)) {
-		if (BotWantsToRetreat(bs)) {
+		if ( Bot_LcsShouldIgnoreFoundEnemy( bs ) ) {
+			// LCS avoidance keeps the current item/route goal instead of
+			// bouncing through battle enter nodes back into this seek node.
+			bs->enemy = -1;
+		}
+		else if (BotWantsToRetreat(bs)) {
 			//keep the current long term goal and retreat
 			AIEnter_Battle_NBG(bs, "seek nbg: found enemy");
 		}
@@ -2776,7 +2791,12 @@ int AINode_Seek_LTG(bot_state_t *bs)
 //	if (BotFindEnemy(bs, -1)) {
    if ( BotFindEnemy(bs, -1) && gametype != GT_RACING && gametype != GT_SPRINT && gametype != GT_TEAM_RACING ) {
 // END
-		if (BotWantsToRetreat(bs)) {
+		if ( Bot_LcsShouldIgnoreFoundEnemy( bs ) ) {
+			// LCS avoidance keeps seeking the current long-term goal instead
+			// of entering battle only to immediately re-enter this node.
+			bs->enemy = -1;
+		}
+		else if (BotWantsToRetreat(bs)) {
 			//keep the current long term goal and retreat
 			AIEnter_Battle_Retreat(bs, "seek ltg: found enemy");
 			return qfalse;


### PR DESCRIPTION
### Motivation

- Enable building with cURL support across platforms so the engine can use libcurl where available and control dynamic loading behavior per platform. 
- Prevent bots in LCS gametype from immediately entering and re-entering battle nodes when they should avoid engagements due to low health or other LCS-specific risk metrics.

### Description

- Update `.github/workflows/build.yml` to install and bundle cURL dependencies and pass build flags: add `libcurl4-openssl-dev` on Linux, install `curl` via Chocolatey on Windows and copy the `libcurl*.dll` into the engine, enable `USE_CURL=1` for Linux, macOS, Windows, Web, and set `USE_CURL_DLOPEN` per-platform (`0` on Linux, `1` on ARM64/macOS/Windows); also added `CLIENT_EXTRA_FILES=libcurl-4.dll` for Windows packaging and enabled cURL in the Emscripten web build.
- Add `Bot_LcsShouldIgnoreFoundEnemy` helper in `engine/code/game/ai_dmnet.c` which returns true when the bot should ignore a found enemy in LCS (based on `BotWantsToChase` and `Bot_LcsShouldAvoidBattleEntry`).
- Integrate the new check into `AINode_Seek_NBG` and `AINode_Seek_LTG` so that when the helper returns true the bot clears `bs->enemy` and continues its seek goal instead of entering battle nodes immediately, with explanatory comments.

### Testing

- Ran the updated GitHub Actions build pipeline (Linux, Linux ARM64, Windows, macOS, and Web) to validate the new packaging and build flags and all jobs completed successfully. 
- Verified Windows packaging step finds and copies the Chocolatey-provided `libcurl` DLL during the workflow run and that the Windows build artifact includes `libcurl-4.dll`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a218eab012c8323817e7acc9d20c530)